### PR TITLE
Performance: selectively reprocess styles, selectively generate styles after uploading

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -21,6 +21,7 @@ module Paperclip
     end
 
     attr_reader :name, :instance, :default_style, :convert_options, :queued_for_write, :whiny, :options
+    attr_accessor :post_processing
 
     # Creates an Attachment object. +name+ is the name of the attachment,
     # +instance+ is the ActiveRecord object instance it's attached to, and
@@ -45,6 +46,7 @@ module Paperclip
       @convert_options   = options[:convert_options]
       @processors        = options[:processors]
       @options           = options
+      @post_processing   = true
       @queued_for_delete = []
       @queued_for_write  = {}
       @errors            = {}
@@ -97,7 +99,7 @@ module Paperclip
 
       @dirty = true
 
-      post_process
+      post_process if post_processing
 
       # Reset the file size if the original file was reprocessed.
       instance_write(:file_size,   @queued_for_write[:original].size.to_i)


### PR DESCRIPTION
Image resizing time became a concern for us, with 8 different styles used on the website. We could not make this process fully asynchronous, because the users needed to see some previews by the time they were entering photo descriptions etc. So we had to generate some (but not all) size variants with each step. E.g. square thumbnails are only generated at the step where the user designated the square cropping area, and not before that.

With the proposed patch (mostly borrowed from http://groups.google.com/group/paperclip-plugin/browse_thread/thread/b097b95e2f0dfcfe), we can call:

```
image.reprocess!(:thumb_col, :thumb_feature, :thumb_gallery, :small) # the list of styles is given explicitly
image.reprocess! # without arguments it still works in the usual way - all styles
```

Another problem is the burden of the initial generation of each variant that by default happens automatically after uploading. We had to introduce some manual control here to reduce the time:

```
def create
  @photo = Photo.new
  @photo.image.post_processing = false # turn off auto post-processing
  @photo.attributes = params[:photo]
  @photo.image.post_processing = true # turn it back on
  @photo.image.send(:post_process, :medium) # and here we generate just one style that is needed immediately
  # ...
end
```

I am sure you can create a more logical API instead of this simplest hack. But it already solves a very important problem. The actual attachment uploading time is often long enough by itself to make the users additionally wait for all the styled variants to be created within the same operation.
