### PR TITLE
:filename interpolation for images with no extension

### DIFF
--- a/lib/paperclip/interpolations.rb
+++ b/lib/paperclip/interpolations.rb
@@ -35,7 +35,7 @@ module Paperclip
 
     # Returns the filename, the same way as ":basename.:extension" would.
     def filename attachment, style_name
-      "#{basename(attachment, style_name)}.#{extension(attachment, style_name)}"
+      (ext = extension(attachment, style_name)).blank? ? basename(attachment, style_name) : "#{basename(attachment, style_name)}.#{ext}"
     end
 
     # Returns the interpolated URL. Will raise an error if the url itself

--- a/test/interpolations_test.rb
+++ b/test/interpolations_test.rb
@@ -110,6 +110,13 @@ class InterpolationsTest < Test::Unit::TestCase
     assert_equal "one.png", Paperclip::Interpolations.filename(attachment, :style)
   end
 
+  should "return the filename as basename when extension is blank" do
+    attachment = mock
+    attachment.stubs(:styles).returns({})
+    attachment.stubs(:original_filename).returns("one")
+    assert_equal "one", Paperclip::Interpolations.filename(attachment, :style)
+  end
+
   should "return the timestamp" do
     now = Time.now
     attachment = mock


### PR DESCRIPTION
Test and fix for http://github.com/thoughtbot/paperclip/issues/issue/299/ ":filename interpolation produces invalid url for images with no extension"

:filename no longer appends a '.' if no extension is present. I can't think of a case where this change would break existing uses of :filename unless someone is actually relying on this behavior.
