### PR TITLE
Make Paperclip::Upfile#fingerprint idempotent by calling IO#rewind after IO#read

### DIFF
--- a/lib/paperclip/upfile.rb
+++ b/lib/paperclip/upfile.rb
@@ -35,7 +35,9 @@ module Paperclip
 
     # Returns the hash of the file.
     def fingerprint
-      Digest::MD5.hexdigest(self.read)
+      fingerprint = Digest::MD5.hexdigest(self.read)
+      self.rewind
+      return fingerprint
     end
   end
 end

--- a/test/upfile_test.rb
+++ b/test/upfile_test.rb
@@ -33,4 +33,12 @@ class UpfileTest < Test::Unit::TestCase
     end
     assert_equal 'text/plain', file.content_type
   end
+  
+  should "return an idempotent fingerprint on a file" do
+    file = File.new(File.join(File.dirname(__FILE__), "..", "LICENSE"))
+    class << file
+      include Paperclip::Upfile
+    end
+    assert_equal file.fingerprint, file.fingerprint
+  end
 end


### PR DESCRIPTION
Upfile#fingerprint looks like a safe (idempotent) method, however, it is not. The method calls IO#read, without calling IO#rewind. Thus, any Paperclip::Storage backend must make sure to call call IO#rewind before reading the contents of the file. See http://github.com/qoobaa/s3/blob/master/extra/s3_paperclip.rb#L114 for an example of where things might go wrong.

This also fixes issue thoughtbot/paperclip#315.
