### PR TITLE
Bug fixes

### DIFF
--- a/lib/paperclip/command_line.rb
+++ b/lib/paperclip/command_line.rb
@@ -45,7 +45,7 @@ module Paperclip
 
     def interpolate(pattern, vars)
       # interpolates :variables and :{variables}
-      pattern.gsub(%r#:(?:\w+|\{\w+\})#) do |match|
+      pattern.gsub(%r#:(?:\{\w+\})#) do |match|
         key = match[1..-1]
         key = key[1..-2] if key[0,1] == '{'
         if invalid_variables.include?(key)

--- a/lib/paperclip/geometry.rb
+++ b/lib/paperclip/geometry.rb
@@ -16,7 +16,7 @@ module Paperclip
     def self.from_file file
       file = file.path if file.respond_to? "path"
       geometry = begin
-                   Paperclip.run("identify", "-format %wx%h :file", :file => "#{file}[0]")
+                   Paperclip.run("identify", "-format %wx%h :{file}", :file => "#{file}[0]")
                  rescue PaperclipCommandLineError
                    ""
                  end

--- a/lib/paperclip/iostream.rb
+++ b/lib/paperclip/iostream.rb
@@ -5,7 +5,7 @@ module IOStream
   # Returns a Tempfile containing the contents of the readable object.
   def to_tempfile
     name = respond_to?(:original_filename) ? original_filename : (respond_to?(:path) ? path : "stream")
-    tempfile = Paperclip::Tempfile.new("stream" + File.extname(name))
+    tempfile = Tempfile.new("stream" + File.extname(name))
     tempfile.binmode
     self.stream_to(tempfile)
   end

--- a/lib/paperclip/processor.rb
+++ b/lib/paperclip/processor.rb
@@ -33,17 +33,4 @@ module Paperclip
       new(file, options, attachment).make
     end
   end
-
-  # Due to how ImageMagick handles its image format conversion and how Tempfile
-  # handles its naming scheme, it is necessary to override how Tempfile makes
-  # its names so as to allow for file extensions. Idea taken from the comments
-  # on this blog post:
-  # http://marsorange.com/archives/of-mogrify-ruby-tempfile-dynamic-class-definitions
-  class Tempfile < ::Tempfile
-    # Replaces Tempfile's +make_tmpname+ with one that honors file extensions.
-    def make_tmpname(basename, n)
-      extension = File.extname(basename)
-      sprintf("%s,%d,%d%s", File.basename(basename, extension), $$, n.to_i, extension)
-    end
-  end
 end

--- a/lib/paperclip/upfile.rb
+++ b/lib/paperclip/upfile.rb
@@ -17,7 +17,7 @@ module Paperclip
       when "csv", "xml", "css"       then "text/#{type}"
       else
         # On BSDs, `file` doesn't give a result code of 1 if the file doesn't exist.
-        content_type = (Paperclip.run("file", "-b --mime-type :file", :file => self.path).split(':').last.strip rescue "application/x-#{type}")
+        content_type = (Paperclip.run("file", "-b --mime-type :{file}", :file => self.path).split(':').last.strip rescue "application/x-#{type}")
         content_type = "application/x-#{type}" if content_type.match(/\(.*?\)/)
         content_type
       end

--- a/test/attachment_test.rb
+++ b/test/attachment_test.rb
@@ -607,7 +607,7 @@ class AttachmentTest < Test::Unit::TestCase
                 io = @attachment.to_file(style)
                 # p "in commit to disk test, io is #{io.inspect} and @instance.id is #{@instance.id}"
                 assert File.exists?(io)
-                assert ! io.is_a?(::Tempfile)
+                assert ! io.is_a?(Tempfile)
                 io.close
               end
             end

--- a/test/iostream_test.rb
+++ b/test/iostream_test.rb
@@ -58,8 +58,8 @@ class IOStreamTest < Test::Unit::TestCase
         assert @tempfile = @file.to_tempfile
       end
 
-      should "convert it to a Paperclip Tempfile" do
-        assert @tempfile.is_a?(Paperclip::Tempfile)
+      should "convert it to a Tempfile" do
+        assert @tempfile.is_a?(Tempfile)
       end
 
       should "have the name be based on the original_filename" do

--- a/test/paperclip_test.rb
+++ b/test/paperclip_test.rb
@@ -13,18 +13,18 @@ class PaperclipTest < Test::Unit::TestCase
       Paperclip.expects(:log).with(includes('[DEPRECATION]'))
       Paperclip.expects(:log).with(regexp_matches(%r{/usr/bin/convert ['"]one.jpg['"] ['"]two.jpg['"]}))
       Paperclip::CommandLine.expects(:"`").with(regexp_matches(%r{/usr/bin/convert ['"]one.jpg['"] ['"]two.jpg['"]}))
-      Paperclip.run("convert", ":one :two", :one => "one.jpg", :two => "two.jpg")
+      Paperclip.run("convert", ":{one} :{two}", :one => "one.jpg", :two => "two.jpg")
     end
 
     should "execute the right command with :command_path" do
       Paperclip.options[:command_path] = "/usr/bin"
       Paperclip::CommandLine.expects(:"`").with(regexp_matches(%r{/usr/bin/convert ['"]one.jpg['"] ['"]two.jpg['"]}))
-      Paperclip.run("convert", ":one :two", :one => "one.jpg", :two => "two.jpg")
+      Paperclip.run("convert", ":{one} :{two}", :one => "one.jpg", :two => "two.jpg")
     end
 
     should "execute the right command with no path" do
       Paperclip::CommandLine.expects(:"`").with(regexp_matches(%r{convert ['"]one.jpg['"] ['"]two.jpg['"]}))
-      Paperclip.run("convert", ":one :two", :one => "one.jpg", :two => "two.jpg")
+      Paperclip.run("convert", ":{one} :{two}", :one => "one.jpg", :two => "two.jpg")
     end
 
     should "tell you the command isn't there if the shell returns 127" do

--- a/test/thumbnail_test.rb
+++ b/test/thumbnail_test.rb
@@ -2,34 +2,6 @@ require 'test/helper'
 
 class ThumbnailTest < Test::Unit::TestCase
 
-  context "A Paperclip Tempfile" do
-    setup do
-      @tempfile = Paperclip::Tempfile.new("file.jpg")
-    end
-
-    should "have its path contain a real extension" do
-      assert_equal ".jpg", File.extname(@tempfile.path)
-    end
-
-    should "be a real Tempfile" do
-      assert @tempfile.is_a?(::Tempfile)
-    end
-  end
-
-  context "Another Paperclip Tempfile" do
-    setup do
-      @tempfile = Paperclip::Tempfile.new("file")
-    end
-
-    should "not have an extension if not given one" do
-      assert_equal "", File.extname(@tempfile.path)
-    end
-
-    should "still be a real Tempfile" do
-      assert @tempfile.is_a?(::Tempfile)
-    end
-  end
-
   context "An image" do
     setup do
       @file = File.new(File.join(File.dirname(__FILE__), "fixtures", "5k.png"), 'rb')
@@ -68,7 +40,18 @@ class ThumbnailTest < Test::Unit::TestCase
       end
     end
 
-    context "being thumbnailed at 100x50 with cropping" do
+    context "being thumbnailed with a format specified" do
+      setup do
+        @thumb = Paperclip::Thumbnail.new(@file, :geometry => "100x50#", :format => 'jpg')
+      end
+
+      should "report it's correct format" do
+        assert_equal 'jpg', @thumb.format
+      end
+    end
+    
+
+    context "being thumbnailed at 100x50 with cropping and no format specified" do
       setup do
         @thumb = Paperclip::Thumbnail.new(@file, :geometry => "100x50#")
       end
@@ -78,8 +61,8 @@ class ThumbnailTest < Test::Unit::TestCase
         assert_equal "434x66", @thumb.current_geometry.to_s
       end
 
-      should "report its correct format" do
-        assert_nil @thumb.format
+      should "determine it's format from the file" do
+        assert_equal 'png', @thumb.format
       end
 
       should "have whiny turned on by default" do


### PR DESCRIPTION
I've fixed a few bugs with Paperclip:
- I was having problems when Paperclip would try to move the temp file to the destination location running Ruby 1.9.2 (See issue [270](http://github.com/thoughtbot/paperclip/issues/#issue/270)). I fixed this by removing the Tempfile monkey patch.  It appeared that it's only real purpose was to allow temp files to have file extensions, which you can accomplish by passing an Array into Ruby's `Tempfile#new` method.
- Paperclip would not allow colons in convert options due to the variable format (e.g. :one, :two).  I fixed this by disallowing the colon-only format.  Now we can do things like `:convert_options => {:negative => "-resize 175x220> -size 175x220 xc:black +swap -gravity center -composite"}`

I have added/modified tests for all of my changes.
