### PR TITLE
Passing a Blank Filename to identify Causes Paperclip to Block

### DIFF
--- a/lib/paperclip/geometry.rb
+++ b/lib/paperclip/geometry.rb
@@ -15,9 +15,13 @@ module Paperclip
     # File or path.
     def self.from_file file
       file = file.path if file.respond_to? "path"
-      geometry = begin
-                   Paperclip.run("identify", "-format %wx%h :file", :file => "#{file}[0]")
-                 rescue PaperclipCommandLineError
+      geometry = if file && !file.empty?
+                   begin
+                     Paperclip.run("identify", "-format %wx%h :file", :file => "#{file}[0]")
+                   rescue PaperclipCommandLineError
+                     ""
+                   end
+                 else
                    ""
                  end
       parse(geometry) ||

--- a/test/geometry_test.rb
+++ b/test/geometry_test.rb
@@ -120,6 +120,22 @@ class GeometryTest < Test::Unit::TestCase
       assert_raise(Paperclip::NotIdentifiedByImageMagickError){ @geo = Paperclip::Geometry.from_file(file) }
     end
 
+    should "not generate from a blank filename" do
+      file = ""
+      assert_raise(Paperclip::NotIdentifiedByImageMagickError){ @geo = Paperclip::Geometry.from_file(file) }
+    end
+
+    should "not generate from a nil file" do
+      file = nil
+      assert_raise(Paperclip::NotIdentifiedByImageMagickError){ @geo = Paperclip::Geometry.from_file(file) }
+    end
+
+    should "not generate from a file with no path" do
+      file = mock("file", :path => "")
+      file.stubs(:respond_to?).with("path").returns(true)
+      assert_raise(Paperclip::NotIdentifiedByImageMagickError){ @geo = Paperclip::Geometry.from_file(file) }
+    end
+
     [['vertical',   900,  1440, true,  false, false, 1440, 900, 0.625],
      ['horizontal', 1024, 768,  false, true,  false, 1024, 768, 1.3333],
      ['square',     100,  100,  false, false, true,  100,  100, 1]].each do |args|


### PR DESCRIPTION
Please find attached a commit to prevent Paperclip from telling ImageMagick to identify a file with a blank filename. This can happen if one's database is out of sync with the actual assets on disk and so Paperclip will execute the following command: `identify -format %wx%h [0]` which will hang indefinitely as it is waiting for input on STDIN.

I've also included the appropriate tests (note that running the tests on the code without this fix will hang indefinitely rather than failing).
