### PR TITLE
Style#initialize - dup definition before deleting options 

### DIFF
--- a/lib/paperclip/style.rb
+++ b/lib/paperclip/style.rb
@@ -15,6 +15,7 @@ module Paperclip
       @name = name
       @attachment = attachment
       if definition.is_a? Hash
+        definition = definition.dup
         @geometry = definition.delete(:geometry)
         @format = definition.delete(:format)
         @processors = definition.delete(:processors)


### PR DESCRIPTION
This fixes an error where a processor expects options[:geometry] to be available but is nil after the first image has
been processed (at least, when using passenger)
