### PR TITLE
Change plugin initialization to rails3 style

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,1 +1,4 @@
 require File.join(File.dirname(__FILE__), "lib", "paperclip")
+require 'paperclip/railtie'
+
+Paperclip::Railtie.insert

--- a/rails/init.rb
+++ b/rails/init.rb
@@ -1,2 +1,0 @@
-require 'paperclip/railtie'
-Paperclip::Railtie.insert


### PR DESCRIPTION
Move plugin initialization from rails/init.rb to init.rb for remove deprecated init style.
