### PR TITLE
Fix for undefined method `fingerprint' for ActionDispatch::Http::UploadedFile in Rails 3.0.3

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -93,7 +93,11 @@ module Paperclip
       instance_write(:file_name,       uploaded_file.original_filename.strip)
       instance_write(:content_type,    uploaded_file.content_type.to_s.strip)
       instance_write(:file_size,       uploaded_file.size.to_i)
-      instance_write(:fingerprint,     uploaded_file.tempfile.fingerprint)
+      if uploaded_file.is_a?(ActionDispatch::Http::UploadedFile)
+        instance_write(:fingerprint,   uploaded_file.tempfile.fingerprint)
+      else
+        instance_write(:fingerprint,   uploaded_file.fingerprint)
+      end
       instance_write(:updated_at,      Time.now)
 
       @dirty = true


### PR DESCRIPTION
The recent-ish commit to Rails (http://github.com/rails/rails/commit/12173396163616e077f761e190c13beb43d536bd) that was caused the problem in thoughtbot/paperclip#327 also results in this error:

```
A NoMethodError occurred in places#submit:

 undefined method `fingerprint' for #<ActionDispatch::Http::UploadedFile:0xad382f4>
 paperclip (2.3.5) lib/paperclip/attachment.rb:96:in `assign'
```

According to the commit message, "hard work" should retrieve the delegate tempfile itself, rather than rely on UploadedFile to forward the message. This pull request includes the small change to call `fingerprint` through the delegate.
