### PR TITLE
Ssl expiring urls (Issue 207)

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -95,7 +95,7 @@ module Paperclip
       end
 
       def expiring_url(time = 3600)
-        AWS::S3::S3Object.url_for(path, bucket_name, :expires_in => time )
+        AWS::S3::S3Object.url_for(path, bucket_name, :expires_in => time, :use_ssl => (s3_protocol == 'https'))
       end
 
       def bucket_name


### PR DESCRIPTION
For S3 attachments using ssl, the protocol is not reflected in the expiring_url method, unlike the url method.
