### PR TITLE
s3_host_alias now supports a Proc

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -103,7 +103,7 @@ module Paperclip
       end
 
       def s3_host_alias
-        @s3_host_alias
+        @s3_host_alias.is_a?(Proc) ? @s3_host_alias.call(self) : @s3_host_alias
       end
 
       def parse_credentials creds

--- a/lib/paperclip/version.rb
+++ b/lib/paperclip/version.rb
@@ -1,3 +1,3 @@
 module Paperclip
-  VERSION = "2.3.8" unless defined? Paperclip::VERSION
+  VERSION = "2.3.9" unless defined? Paperclip::VERSION
 end

--- a/test/storage_test.rb
+++ b/test/storage_test.rb
@@ -360,4 +360,24 @@ class StorageTest < Test::Unit::TestCase
       end
     end
   end
+
+  context 'Using a proc to determine s3_host_alias' do
+    setup do
+     ENV['S3_KEY']    = 'pathname_key'
+     ENV['S3_BUCKET'] = 'pathname_bucket'
+     ENV['S3_SECRET'] = 'pathname_secret'
+    end
+
+    should 'be able to execute a proc' do
+      at = attachment(:storage => :s3, :s3_host_alias => Proc.new {'foo'}, :s3_credentials => File.new(File.join(File.dirname(__FILE__), "fixtures/s3.yml")))
+
+      assert_equal 'foo', at.s3_host_alias
+    end
+
+    should 'return a static string' do
+      at = attachment(:storage => :s3, :s3_host_alias => 'bar', :s3_credentials => File.new(File.join(File.dirname(__FILE__), "fixtures/s3.yml")))
+
+      assert_equal 'bar', at.s3_host_alias
+    end
+  end
 end


### PR DESCRIPTION
I made this change so that the host alias can be distributed to multiple CDNs or servers. I've written tests as well - hopefully you will add it to the master repo :) 

Do leave feedback either way - the diff is minuscule. Thanks

Ravi.
