### PR TITLE
Return original Tempfile#size results if @tmpfile instance variable not present

### DIFF
--- a/lib/paperclip/iostream.rb
+++ b/lib/paperclip/iostream.rb
@@ -32,13 +32,14 @@ end
 # Corrects a bug in Windows when asking for Tempfile size.
 if defined? Tempfile
   class Tempfile
+    alias orig_size size
     def size
       if @tmpfile
         @tmpfile.fsync
         @tmpfile.flush
         @tmpfile.stat.size
       else
-        0
+        orig_size
       end
     end
   end


### PR DESCRIPTION
Otherwise this monkey patch damages JRuby implementation of Tempfile#size which have different implementation than MRI.
