### PR TITLE
S3 expiring url should default to secure

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -94,8 +94,8 @@ module Paperclip
         end
       end
 
-      def expiring_url(time = 3600)
-        AWS::S3::S3Object.url_for(path, bucket_name, :expires_in => time )
+      def expiring_url(time = 3600, ssl = true)
+        AWS::S3::S3Object.url_for(path, bucket_name, :expires_in => time, :use_ssl => ssl )
       end
 
       def bucket_name

--- a/test/storage_test.rb
+++ b/test/storage_test.rb
@@ -131,7 +131,7 @@ class StorageTest < Test::Unit::TestCase
       @dummy = Dummy.new
       @dummy.avatar = StringIO.new(".")
 
-      AWS::S3::S3Object.expects(:url_for).with("avatars/stringio.txt", "prod_bucket", { :expires_in => 3600 })
+      AWS::S3::S3Object.expects(:url_for).with("avatars/stringio.txt", "prod_bucket", { :expires_in => 3600, :use_ssl => true })
 
       @dummy.avatar.expiring_url
     end


### PR DESCRIPTION
Self explanatory... and it makes sense considering the reason you would even be hiding assets in the first place would be for security... Added an arg to change it if need be.
