### PR TITLE
deep_merge within Attachment.rb

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -30,7 +30,7 @@ module Paperclip
       @name              = name
       @instance          = instance
 
-      options = self.class.default_options.merge(options)
+      options = self.class.default_options.deep_merge(options)
 
       @url               = options[:url]
       @url               = @url.call(self) if @url.is_a?(Proc)


### PR DESCRIPTION
using deep_merge within Attachment. This way we can specify e.g. :styles => { :thumb => "80x80#" } in the initializers/paperclip_defaults.rb and have thumbnails generated by default for all images
