### PR TITLE
Fixed bug with colon in comand line parameters. 

### DIFF
--- a/lib/paperclip/command_line.rb
+++ b/lib/paperclip/command_line.rb
@@ -45,7 +45,7 @@ module Paperclip
 
     def interpolate(pattern, vars)
       # interpolates :variables and :{variables}
-      pattern.gsub(%r#:(?:\w+|\{\w+\})#) do |match|
+      pattern.gsub(%r#:(?:\{\w+\})#) do |match|
         key = match[1..-1]
         key = key[1..-2] if key[0,1] == '{'
         if invalid_variables.include?(key)

--- a/lib/paperclip/geometry.rb
+++ b/lib/paperclip/geometry.rb
@@ -16,7 +16,7 @@ module Paperclip
     def self.from_file file
       file = file.path if file.respond_to? "path"
       geometry = begin
-                   Paperclip.run("identify", "-format %wx%h :file", :file => "#{file}[0]")
+                   Paperclip.run("identify", "-format %wx%h :{file}", :file => "#{file}[0]")
                  rescue PaperclipCommandLineError
                    ""
                  end

--- a/lib/paperclip/thumbnail.rb
+++ b/lib/paperclip/thumbnail.rb
@@ -51,10 +51,10 @@ module Paperclip
       begin
         parameters = []
         parameters << source_file_options
-        parameters << ":source"
+        parameters << ":{source}"
         parameters << transformation_command
         parameters << convert_options
-        parameters << ":dest"
+        parameters << ":{dest}"
 
         parameters = parameters.flatten.compact.join(" ").strip.squeeze(" ")
 

--- a/lib/paperclip/upfile.rb
+++ b/lib/paperclip/upfile.rb
@@ -17,7 +17,7 @@ module Paperclip
       when "csv", "xml", "css"       then "text/#{type}"
       else
         # On BSDs, `file` doesn't give a result code of 1 if the file doesn't exist.
-        content_type = (Paperclip.run("file", "-b --mime-type :file", :file => self.path).split(':').last.strip rescue "application/x-#{type}")
+        content_type = (Paperclip.run("file", "-b --mime-type :{file}", :file => self.path).split(':').last.strip rescue "application/x-#{type}")
         content_type = "application/x-#{type}" if content_type.match(/\(.*?\)/)
         content_type
       end

--- a/test/command_line_test.rb
+++ b/test/command_line_test.rb
@@ -6,6 +6,11 @@ class CommandLineTest < Test::Unit::TestCase
     File.stubs(:exist?).with("/dev/null").returns(true)
   end
 
+ should "allow colons in parameters" do
+    cmd = Paperclip::CommandLine.new("convert", "'a.jpg' -resize 175x220> -size 175x220 xc:black +swap -gravity center -composite 'b.jpg'", :swallow_stderr => false)
+    assert_equal "convert 'a.jpg' -resize 175x220> -size 175x220 xc:black +swap -gravity center -composite 'b.jpg'", cmd.command 
+  end
+
   should "take a command and parameters and produce a shell command for bash" do
     cmd = Paperclip::CommandLine.new("convert", "a.jpg b.png", :swallow_stderr => false)
     assert_equal "convert a.jpg b.png", cmd.command
@@ -19,7 +24,7 @@ class CommandLineTest < Test::Unit::TestCase
 
   should "be able to interpolate quoted variables into the parameters" do
     cmd = Paperclip::CommandLine.new("convert",
-                                     ":one :{two}",
+                                     ":{one} :{two}",
                                      :one => "a.jpg",
                                      :two => "b.png",
                                      :swallow_stderr => false)
@@ -29,7 +34,7 @@ class CommandLineTest < Test::Unit::TestCase
   should "quote command line options differently if we're on windows" do
     File.stubs(:exist?).with("/dev/null").returns(false)
     cmd = Paperclip::CommandLine.new("convert",
-                                     ":one :{two}",
+                                     ":{one} :{two}",
                                      :one => "a.jpg",
                                      :two => "b.png",
                                      :swallow_stderr => false)
@@ -38,7 +43,7 @@ class CommandLineTest < Test::Unit::TestCase
 
   should "be able to quote and interpolate dangerous variables" do
     cmd = Paperclip::CommandLine.new("convert",
-                                     ":one :two",
+                                     ":{one} :{two}",
                                      :one => "`rm -rf`.jpg",
                                      :two => "ha'ha.png",
                                      :swallow_stderr => false)
@@ -48,7 +53,7 @@ class CommandLineTest < Test::Unit::TestCase
   should "be able to quote and interpolate dangerous variables even on windows" do
     File.stubs(:exist?).with("/dev/null").returns(false)
     cmd = Paperclip::CommandLine.new("convert",
-                                     ":one :two",
+                                     ":{one} :{two}",
                                      :one => "`rm -rf`.jpg",
                                      :two => "ha'ha.png",
                                      :swallow_stderr => false)
@@ -75,7 +80,7 @@ class CommandLineTest < Test::Unit::TestCase
 
   should "raise if trying to interpolate :swallow_stderr or :expected_outcodes" do
     cmd = Paperclip::CommandLine.new("convert",
-                                     ":swallow_stderr :expected_outcodes",
+                                     ":{swallow_stderr} :{expected_outcodes}",
                                      :swallow_stderr => false,
                                      :expected_outcodes => [0, 1])
     assert_raise(Paperclip::PaperclipCommandLineError) do

--- a/test/paperclip_test.rb
+++ b/test/paperclip_test.rb
@@ -13,18 +13,18 @@ class PaperclipTest < Test::Unit::TestCase
       Paperclip.expects(:log).with(includes('[DEPRECATION]'))
       Paperclip.expects(:log).with(regexp_matches(%r{/usr/bin/convert ['"]one.jpg['"] ['"]two.jpg['"]}))
       Paperclip::CommandLine.expects(:"`").with(regexp_matches(%r{/usr/bin/convert ['"]one.jpg['"] ['"]two.jpg['"]}))
-      Paperclip.run("convert", ":one :two", :one => "one.jpg", :two => "two.jpg")
+      Paperclip.run("convert", ":{one} :{two}", :one => "one.jpg", :two => "two.jpg")
     end
 
     should "execute the right command with :command_path" do
       Paperclip.options[:command_path] = "/usr/bin"
       Paperclip::CommandLine.expects(:"`").with(regexp_matches(%r{/usr/bin/convert ['"]one.jpg['"] ['"]two.jpg['"]}))
-      Paperclip.run("convert", ":one :two", :one => "one.jpg", :two => "two.jpg")
+      Paperclip.run("convert", ":{one} :{two}", :one => "one.jpg", :two => "two.jpg")
     end
 
     should "execute the right command with no path" do
       Paperclip::CommandLine.expects(:"`").with(regexp_matches(%r{convert ['"]one.jpg['"] ['"]two.jpg['"]}))
-      Paperclip.run("convert", ":one :two", :one => "one.jpg", :two => "two.jpg")
+      Paperclip.run("convert", ":{one} :{two}", :one => "one.jpg", :two => "two.jpg")
     end
 
     should "tell you the command isn't there if the shell returns 127" do


### PR DESCRIPTION
This solution based on hoverlover/paperclip@a4c1a1b571e879d005889d91043689e201b4bd43, but without tempfile fixes.
