### PR TITLE
Improve performance of s3 attachments

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -85,13 +85,13 @@ module Paperclip
         end
         Paperclip.interpolates(:s3_alias_url) do |attachment, style|
           "#{attachment.s3_protocol}://#{attachment.s3_host_alias}/#{attachment.path(style).gsub(%r{^/}, "")}"
-        end
+        end unless Paperclip::Interpolations.respond_to? :s3_alias_url
         Paperclip.interpolates(:s3_path_url) do |attachment, style|
           "#{attachment.s3_protocol}://s3.amazonaws.com/#{attachment.bucket_name}/#{attachment.path(style).gsub(%r{^/}, "")}"
-        end
+        end unless Paperclip::Interpolations.respond_to? :s3_path_url
         Paperclip.interpolates(:s3_domain_url) do |attachment, style|
           "#{attachment.s3_protocol}://#{attachment.bucket_name}.s3.amazonaws.com/#{attachment.path(style).gsub(%r{^/}, "")}"
-        end
+        end unless Paperclip::Interpolations.respond_to? :s3_domain_url
       end
 
       def expiring_url(time = 3600)


### PR DESCRIPTION
These patches significantly improve the performance of s3 attachments, making attachment_for calls roughly twice as fast (more on 1.9).

Performance graphs and further discussion is on the mailing list:
https://groups.google.com/d/topic/paperclip-plugin/-2bVTf3GFac/discussion
