### PR TITLE
Performance: selectively reprocess styles, selectively generate styles after uploading

### DIFF
--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -98,6 +98,49 @@ class IntegrationTest < Test::Unit::TestCase
     end
   end
 
+  context "Attachment with no generated thumbnails" do
+    setup do
+      @thumb_small_path = "./test/../public/system/avatars/1/thumb_small/5k.png"
+      @thumb_large_path = "./test/../public/system/avatars/1/thumb_large/5k.png"
+      File.delete(@thumb_small_path) if File.exists?(@thumb_small_path)
+      File.delete(@thumb_large_path) if File.exists?(@thumb_large_path)
+      rebuild_model :styles => { :thumb_small => "50x50#", :thumb_large => "60x60#" }
+      @dummy = Dummy.new
+      @file = File.new(File.join(File.dirname(__FILE__),
+                                 "fixtures",
+                                 "5k.png"), 'rb')
+
+      @dummy.avatar.post_processing = false
+      @dummy.avatar = @file
+      assert @dummy.save
+      @dummy.avatar.post_processing = true
+    end
+
+    teardown { @file.close }
+
+    should "allow us to create all thumbnails in one go" do
+      assert !File.exists?(@thumb_small_path)
+      assert !File.exists?(@thumb_large_path)
+
+      @dummy.avatar.reprocess!
+
+      assert File.exists?(@thumb_small_path)
+      assert File.exists?(@thumb_large_path)
+    end
+
+    should "allow us to selectively create each thumbnail" do
+      assert !File.exists?(@thumb_small_path)
+      assert !File.exists?(@thumb_large_path)
+
+      @dummy.avatar.reprocess! :thumb_small
+      assert File.exists?(@thumb_small_path)
+      assert !File.exists?(@thumb_large_path)
+
+      @dummy.avatar.reprocess! :thumb_large
+      assert File.exists?(@thumb_large_path)
+    end
+  end
+
   context "A model that modifies its original" do
     setup do
       rebuild_model :styles => { :original => "2x2#" }


### PR DESCRIPTION
This is a resubmission of https://github.com/thoughtbot/paperclip/pull/282, now with tests.

Image resizing time became a concern for us, with 8 different styles used on the website. We could not make this process fully asynchronous, because the users already needed to see some previews at the time they were entering photo descriptions etc. So we had to generate some (but not all) size variants for each step. E.g. square thumbnails were only generated at the step where the user designated the square cropping area, and not before that.

With the proposed patch (mostly borrowed from http://groups.google.com/group/paperclip-plugin/browse_thread/thread/b097b95e2f0dfcfe), we can call:

```
image.reprocess!(:thumb_col, :thumb_feature, :thumb_gallery, :small) # the list of styles is given explicitly
image.reprocess! # without arguments it still works in the usual way - all styles
```

Another problem is the burden of the initial generation of each variant that by default happens automatically after uploading. We had to introduce some manual control here to reduce this time:

```
def create
  @photo = Photo.new
  @photo.image.post_processing = false # turn off auto post-processing before assignment
  @photo.attributes = params[:photo]
  @photo.image.post_processing = true # turn it back on
  @photo.image.reprocess :medium # and here we generate just one style that is needed immediately
  # ...
end
```

I am sure you can create a more logical API instead of this simplest hack. But it already solves a very important problem. The actual attachment uploading time is often long enough by itself to make the users additionally wait for all the styled variants to be created within the same operation.
