### PR TITLE
Allow :s3_host_alias to be a proc for dynamic cdn generation

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -74,6 +74,7 @@ module Paperclip
           @s3_protocol    = @options[:s3_protocol]    || (@s3_permissions == :public_read ? 'http' : 'https')
           @s3_headers     = @options[:s3_headers]     || {}
           @s3_host_alias  = @options[:s3_host_alias]
+          @s3_host_alias  = @s3_host_alias.call(self) if @s3_host_alias.is_a?(Proc)
           unless @url.to_s.match(/^:s3.*url$/)
             @path          = @path.gsub(/:url/, @url)
             @url           = ":s3_path_url"

--- a/test/storage_test.rb
+++ b/test/storage_test.rb
@@ -7,7 +7,7 @@ class StorageTest < Test::Unit::TestCase
       Object.const_set(:Rails, stub('Rails', :env => env))
     end
   end
-  
+
   context "filesystem" do
     setup do
       rebuild_model :styles => { :thumbnail => "25x25#" }
@@ -15,16 +15,16 @@ class StorageTest < Test::Unit::TestCase
 
       @dummy.avatar = File.open(File.join(File.dirname(__FILE__), "fixtures", "5k.png"))
     end
-    
+
     should "allow file assignment" do
       assert @dummy.save
     end
-    
+
     should "store the original" do
       @dummy.save
       assert File.exists?(@dummy.avatar.path)
     end
-    
+
     should "store the thumbnail" do
       @dummy.save
       assert File.exists?(@dummy.avatar.path(:thumbnail))
@@ -112,6 +112,27 @@ class StorageTest < Test::Unit::TestCase
     should "return a url based on the host_alias" do
       assert_match %r{^http://something.something.com/avatars/stringio.txt}, @dummy.avatar.url
     end
+  end
+  context "generating a url with a proc as the host alias" do
+    setup do
+      AWS::S3::Base.stubs(:establish_connection!)
+      rebuild_model :storage => :s3,
+                    :s3_credentials => { :bucket => "prod_bucket" },
+                    :s3_host_alias => Proc.new { |image| "cdn#{image.size.to_i % 4}.example.com" },
+                    :path => ":attachment/:basename.:extension",
+                    :url => ":s3_alias_url"
+      @dummy = Dummy.new
+      @dummy.avatar = StringIO.new(".")
+    end
+
+    should "return a url based on the host_alias" do
+      assert_match %r{^http://cdn0.example.com/avatars/stringio.txt}, @dummy.avatar.url
+    end
+
+    should "still return the bucket name" do
+      assert_equal "prod_bucket", @dummy.avatar.bucket_name
+    end
+
   end
 
   context "Generating a url with an expiration" do


### PR DESCRIPTION
Hi there,

This simple test and patch allows the s3_host_alias to be a proc and allow you to calculate the CDN for each file.

Mikel
