### PR TITLE
Add uploaded_file instance variable in case of fresh uploads

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -89,6 +89,8 @@ module Paperclip
       if uploaded_file.is_a?(Paperclip::Attachment)
         uploaded_file = uploaded_file.to_file(:original)
         close_uploaded_file = uploaded_file.respond_to?(:close)
+      else
+        instance_write(:uploaded_file, uploaded_file)
       end
 
       return nil unless valid_assignment?(uploaded_file)
@@ -175,12 +177,17 @@ module Paperclip
       save
     end
 
+    # Returns the uploaded file if present.
+    def uploaded_file
+      instance_read(:uploaded_file)
+    end
+
     # Returns the name of the file as originally assigned, and lives in the
     # <attachment>_file_name attribute of the model.
     def original_filename
       instance_read(:file_name)
     end
-
+    
     # Returns the size of the file as originally assigned, and lives in the
     # <attachment>_file_size attribute of the model.
     def size


### PR DESCRIPTION
This is a useful feature if the use case requires an automatic unlinking of the original attachment.
