### PR TITLE
Animated GIF support

### DIFF
--- a/lib/paperclip/thumbnail.rb
+++ b/lib/paperclip/thumbnail.rb
@@ -58,7 +58,7 @@ module Paperclip
 
         parameters = parameters.flatten.compact.join(" ").strip.squeeze(" ")
 
-        success = Paperclip.run("convert", parameters, :source => "#{File.expand_path(src.path)}[0]", :dest => File.expand_path(dst.path))
+        success = Paperclip.run("convert", parameters, :source => File.extname(src.path) == ".gif" ? "#{File.expand_path(src.path)}" : "#{File.expand_path(src.path)}[0]", :dest => File.expand_path(dst.path))
       rescue PaperclipCommandLineError => e
         raise PaperclipError, "There was an error processing the thumbnail for #{@basename}" if @whiny
       end


### PR DESCRIPTION
I added support for animated gif resizing while maintaining status-quo for all other file types (notably PDF) – it just checks if the file is a gif or not before appending the [0] to the file source.
