### PR TITLE
Renamed Attachment#hash to #secret_hash

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -214,7 +214,7 @@ module Paperclip
 
     # Returns a unique hash suitable for obfuscating the URL of an otherwise
     # publicly viewable attachment.
-    def hash(style_name = default_style)
+    def secret_hash(style_name = default_style)
       raise ArgumentError, "Unable to generate hash without :hash_secret" unless @hash_secret
       require 'openssl' unless defined?(OpenSSL)
       data = interpolate(@hash_data, style_name)

--- a/lib/paperclip/interpolations.rb
+++ b/lib/paperclip/interpolations.rb
@@ -107,7 +107,7 @@ module Paperclip
     # Returns a the attachment hash.  See Paperclip::Attachment#hash for
     # more details.
     def hash attachment, style_name
-      attachment.hash(style_name)
+      attachment.secret_hash(style_name)
     end
 
     # Returns the id of the instance in a split path form. e.g. returns

--- a/test/attachment_test.rb
+++ b/test/attachment_test.rb
@@ -156,7 +156,7 @@ class AttachmentTest < Test::Unit::TestCase
 
       should "interpolate the hash data" do
         @attachment.expects(:interpolate).with(@attachment.options[:hash_data],anything).returns("interpolated_stuff")
-        @attachment.hash
+        @attachment.secret_hash
       end
 
       should "result in the correct interpolation" do

--- a/test/interpolations_test.rb
+++ b/test/interpolations_test.rb
@@ -129,7 +129,7 @@ class InterpolationsTest < Test::Unit::TestCase
   should "return hash" do
     attachment = mock
     fake_hash = "a_wicked_secure_hash"
-    attachment.expects(:hash).returns(fake_hash)
+    attachment.expects(:secret_hash).returns(fake_hash)
     assert_equal fake_hash, Paperclip::Interpolations.hash(attachment, :style)
   end
 


### PR DESCRIPTION
The name of the interpolation remains `:hash`
This is because of issue 450:
https://github.com/thoughtbot/paperclip/issues/450
