### PR TITLE
quote the full path for Windows

### DIFF
--- a/lib/paperclip/command_line.rb
+++ b/lib/paperclip/command_line.rb
@@ -40,7 +40,7 @@ module Paperclip
     private
 
     def full_path(binary)
-      [self.class.path, binary].compact.join("/")
+      '"' + [self.class.path, binary].compact.join("/") + '"'
     end
 
     def interpolate(pattern, vars)


### PR DESCRIPTION
Pretty straightforward. Windows paths may contain spaces, and so this quotes them before they are run.
