### PR TITLE
Fixing permission denied error using FileUtils.mv

### DIFF
--- a/lib/paperclip/storage/filesystem.rb
+++ b/lib/paperclip/storage/filesystem.rb
@@ -38,7 +38,12 @@ module Paperclip
           file.close
           FileUtils.mkdir_p(File.dirname(path(style_name)))
           log("saving #{path(style_name)}")
-          FileUtils.mv(file.path, path(style_name))
+          begin
+            FileUtils.mv(file.path, path(style_name))
+          rescue SystemCallError
+            FileUtils.cp(file.path, path(style_name))
+            FileUtils.rm(file.path)
+          end
           FileUtils.chmod(0644, path(style_name))
         end
         @queued_for_write = {}


### PR DESCRIPTION
When you are mounting files over sshfs the FileUtils.mv calls chown which will not work.  The file will get written and make it to its destination and remove the source but then throw a Permission Denied error.  Work around is to copy the file and then remove it.  This way chown doesn't get called.
