### PR TITLE
Use ActiveSupport::Inflector#constantize instead of a custom implementation

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -114,7 +114,7 @@ module Paperclip
     end
 
     def each_instance_with_attachment(klass, name)
-      class_for(klass).all.each do |instance|
+      klass.constantize.all.each do |instance|
         yield(instance) if instance.send(:"#{name}?")
       end
     end
@@ -131,12 +131,6 @@ module Paperclip
 
     def logging? #:nodoc:
       options[:log]
-    end
-    
-    def class_for(class_name)
-      class_name.split('::').inject(Object) do |klass, partial_class_name|
-        klass.const_get(partial_class_name)
-      end
     end
   end
 

--- a/lib/tasks/paperclip.rake
+++ b/lib/tasks/paperclip.rake
@@ -5,7 +5,7 @@ def obtain_class
 end
 
 def obtain_attachments(klass)
-  klass = Paperclip.class_for(klass.to_s)
+  klass = klass.to_s.constantize
   name = ENV['ATTACHMENT'] || ENV['attachment']
   raise "Class #{klass.name} has no attachments specified" unless klass.respond_to?(:attachment_definitions)
   if !name.blank? && klass.attachment_definitions.keys.include?(name)

--- a/test/paperclip_test.rb
+++ b/test/paperclip_test.rb
@@ -72,11 +72,6 @@ class PaperclipTest < Test::Unit::TestCase
     assert_equal ::Paperclip::Thumbnail, Paperclip.processor(:thumbnail)
   end
 
-  should "get a class from a namespaced class name" do
-    class ::One; class Two; end; end
-    assert_equal ::One::Two, Paperclip.class_for("One::Two")
-  end
-
   context "An ActiveRecord model with an 'avatar' attachment" do
     setup do
       rebuild_model :path => "tmp/:class/omg/:style.:extension"


### PR DESCRIPTION
Use ActiveSupport::Inflector#constantize already looks up namespaced classes by name, so no need to have a custom Paperclip.class_for method.
