### PR TITLE
Fog patches

### DIFF
--- a/test/fog_test.rb
+++ b/test/fog_test.rb
@@ -16,6 +16,9 @@ class FogTest < Test::Unit::TestCase
       }
 
       @connection = Fog::Storage.new(@credentials)
+      @connection.directories.create(
+        :key => @fog_directory
+      )
 
       @options = {
         :fog_directory    => @fog_directory,
@@ -49,16 +52,17 @@ class FogTest < Test::Unit::TestCase
       end
 
       context "without a bucket" do
-        should "succeed" do
+        setup do
+          @connection.directories.get(@fog_directory).destroy
+        end
+
+        should "create the bucket" do
           assert @dummy.save
+          assert @connection.directories.get(@fog_directory)
         end
       end
 
       context "with a bucket" do
-        setup do
-          @connection.directories.create(:key => @fog_directory)
-        end
-
         should "succeed" do
           assert @dummy.save
         end


### PR DESCRIPTION
The first patch adds a :fog_file Hash that works like :s3_headers and allows setting Cache-Control and Expires.

The second patch prevents Fog from loading both a bucket and all of its files into memory anytime the Attachment needs to operate (e.g. when generating urls). The Directories#get method was easily adding 60s of processing time to every page load for my production-size bucket. So the refactored code uses Directories#new, with no over-the-wire transmission, but still manages to auto-create directories as needed by catching Excon 404 errors and saving the new directory.
