### PR TITLE
avoid reading uploads into memory by using system commands (md5 / md5sum)

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -225,9 +225,8 @@ module Paperclip
     end
 
     def generate_fingerprint(source)
-      data = source.read
-      source.rewind if source.respond_to?(:rewind)
-      Digest::MD5.hexdigest(data)
+      return if source.path.blank?
+      Digest::MD5.file(source.path).to_s
     end
 
     # Paths and URLs can have a number of variables interpolated into them


### PR DESCRIPTION
The current generate_fingerprint method reads files into memory to calculate a hexdigest. For large files, this is problematic. The attached commit solves it by using system commands (md5 for bsd, md5sum for unix) to calculate fingerprints.

see issue #469
