### PR TITLE
s3_host_alias configurable via yml file

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -73,7 +73,7 @@ module Paperclip
           @s3_permissions = @options[:s3_permissions] || :public_read
           @s3_protocol    = @options[:s3_protocol]    || (@s3_permissions == :public_read ? 'http' : 'https')
           @s3_headers     = @options[:s3_headers]     || {}
-          @s3_host_alias  = @options[:s3_host_alias]
+          @s3_host_alias  = @options[:s3_host_alias]  || @s3_credentials[:s3_host_alias]
           unless @url.to_s.match(/^:s3.*url$/)
             @path          = @path.gsub(/:url/, @url)
             @url           = ":s3_path_url"


### PR DESCRIPTION
s3_host_alias is basically the same as bucket in that it is dependent on Rails.env just as often.
