### PR TITLE
URI Escaping

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -124,7 +124,8 @@ module Paperclip
     # if you want to stop the attachment update time appended to the url
     def url(style_name = default_style, use_timestamp = @use_timestamp)
       url = original_filename.nil? ? interpolate(@default_url, style_name) : interpolate(@url, style_name)
-      use_timestamp && updated_at ? [url, updated_at].compact.join(url.include?("?") ? "&" : "?") : url
+      escaped = URI.escape url
+      use_timestamp && updated_at ? [escaped, updated_at].compact.join(escaped.include?("?") ? "&" : "?") : escaped
     end
 
     # Returns the path of the attachment as defined by the :path option. If the

--- a/test/attachment_test.rb
+++ b/test/attachment_test.rb
@@ -14,6 +14,14 @@ class AttachmentTest < Test::Unit::TestCase
     assert_equal "#{Rails.root}/public/fake_models/1234/fake", @attachment.path
   end
 
+  should "escape the url" do
+    @attachment = attachment :url => '/:class/:id/:basename'
+    @model = @attachment.instance
+    @model.id = 1234
+    @model.avatar_file_name = "fake #1.jpg"
+    assert_equal '/fake_models/1234/fake%20%231', @attachment.url
+  end
+
   context "Attachment default_options" do
     setup do
       rebuild_model


### PR DESCRIPTION
Added URI for the attachment url.  Things like # in the file name confuse browsers because they are looking for anchors.
