### PR TITLE
Fixes GH-504. Add rails/init.rb back into repo.

### DIFF
--- a/rails/init.rb
+++ b/rails/init.rb
@@ -1,0 +1,2 @@
+require 'paperclip/railtie'
+Paperclip::Railtie.insert


### PR DESCRIPTION
Addresses `undefined method has_attached_file` issue with Rails 2.3.12 and Paperclip 2.3.12.
