### PR TITLE
When generating thumbnails for animated images, pass the -coalesce option to convert.

### DIFF
--- a/lib/paperclip/thumbnail.rb
+++ b/lib/paperclip/thumbnail.rb
@@ -76,6 +76,7 @@ module Paperclip
     def transformation_command
       scale, crop = @current_geometry.transformation_to(@target_geometry, crop?)
       trans = []
+      trans << "-coalesce" if animated?
       trans << "-resize" << %["#{scale}"] unless scale.nil? || scale.empty?
       trans << "-crop" << %["#{crop}"] << "+repage" if crop
       trans

--- a/test/thumbnail_test.rb
+++ b/test/thumbnail_test.rb
@@ -289,6 +289,10 @@ class ThumbnailTest < Test::Unit::TestCase
         cmd = %Q[identify -format "%wx%h" "#{dst.path}"]
         assert_equal "50x50"*12, `#{cmd}`.chomp
       end
+
+      should "use the -coalesce option" do
+	assert_equal @thumb.transformation_command.first, "-coalesce"
+      end
     end
 
     context "with omitted output format" do
@@ -300,6 +304,10 @@ class ThumbnailTest < Test::Unit::TestCase
         dst = @thumb.make
         cmd = %Q[identify -format "%wx%h" "#{dst.path}"]
         assert_equal "50x50"*12, `#{cmd}`.chomp
+      end
+
+      should "use the -coalesce option" do
+	assert_equal @thumb.transformation_command.first, "-coalesce"
       end
     end
   end


### PR DESCRIPTION
From the convert manpage:
         -coalesce            merge a sequence of images

Most gifs seem to be thumbnailed correctly without this option, however sometimes the frames seem to be layered on top of each other if this option is not passed:

original: http://s3.amazonaws.com/forttree/original/guy.gif?1310176466
thumbnail: http://s3.amazonaws.com/forttree/thumb/guy.gif?1310176466

original: http://s3.amazonaws.com/forttree/original/poptart1red1.gif?1310176519
thumbnail: http://s3.amazonaws.com/forttree/thumb/poptart1red1.gif?1310176519
