### PR TITLE
S3 also available in the Tokyo region

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -66,6 +66,7 @@ module Paperclip
     #   to interpolate. Keys should be unique, like filenames, and despite the fact that
     #   S3 (strictly speaking) does not support directories, you can still use a / to
     #   separate parts of your file name.
+    # * +region+: If you are using your bucket in Tokyo region, "tokyo" write.
     module S3
       def self.extended base
         begin


### PR DESCRIPTION
Hello.

I'm using S3 in the Tokyo region.
Normally, Host is "s3.amazonaws.com", but , Tokyo region is hosted by "s3-ap-northeast-1.amazonaws.com".

I add option "resion". If needed, can use this. 
