### PR TITLE
S3 available in the Tokyo region 

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -66,7 +66,7 @@ module Paperclip
     #   to interpolate. Keys should be unique, like filenames, and despite the fact that
     #   S3 (strictly speaking) does not support directories, you can still use a / to
     #   separate parts of your file name.
-    # * +region+: If you are using your bucket in Tokyo region, "tokyo" write.
+    # * +s3_host_name+: If you are using your bucket in Tokyo region etc, write host_name.
     module S3
       def self.extended base
         begin
@@ -78,7 +78,7 @@ module Paperclip
 
         base.instance_eval do
           @s3_credentials = parse_credentials(@options[:s3_credentials])
-          @region         = @options[:region]         || @s3_credentials[:region]
+          @s3_host_name   = @options[:s3_host_name] || @s3_credentials[:s3_host_name]
           @bucket         = @options[:bucket]         || @s3_credentials[:bucket]
           @bucket         = @bucket.call(self) if @bucket.is_a?(Proc)
           @s3_options     = @options[:s3_options]     || {}
@@ -123,12 +123,7 @@ module Paperclip
       end
 
       def s3_host_name 
-        case @region 
-        when "tokyo"
-          "s3-ap-northeast-1.amazonaws.com"
-        else 
-          "s3.amazonaws.com" 
-        end
+        @s3_host_name || "s3.amazonaws.com" 
       end
 
       def set_permissions permissions

--- a/test/storage_test.rb
+++ b/test/storage_test.rb
@@ -79,19 +79,19 @@ class StorageTest < Test::Unit::TestCase
     end
   end
 
-  context "S3 Tokyo Region" do
+  context "s3_host_name" do
     setup do
       AWS::S3::Base.stubs(:establish_connection!)
       rebuild_model :storage => :s3,
                     :s3_credentials => {},
                     :bucket => "bucket",
                     :path => ":attachment/:basename.:extension",
-                    :region => "tokyo"
+                    :s3_host_name => "s3-ap-northeast-1.amazonaws.com"
       @dummy = Dummy.new
       @dummy.avatar = StringIO.new(".")
     end
 
-    should "return a url based on an S3@tokyo path" do
+    should "return a url based on an :s3_host_name path" do
       assert_match %r{^http://s3-ap-northeast-1.amazonaws.com/bucket/avatars/stringio.txt}, @dummy.avatar.url
     end
   end
@@ -277,25 +277,30 @@ class StorageTest < Test::Unit::TestCase
     end
   end
 
-  context "Parsing S3 credentials with a region in them" do
+  context "Parsing S3 credentials with a s3_host_name in them" do
     setup do
       AWS::S3::Base.stubs(:establish_connection!)
       rebuild_model :storage => :s3,
                     :s3_credentials => {
-                      :production   => { :region => "us" },
-                      :development  => { :region => "tokyo" }
+                      :production   => {:s3_host_name => "s3-world-end.amazonaws.com"},
+                      :development  => { :s3_host_name => "s3-ap-northeast-1.amazonaws.com" }
                     }
       @dummy = Dummy.new
     end
 
     should "get the right s3_host_name in production" do
       rails_env("production")
-      assert_match %r{^s3.amazonaws.com}, @dummy.avatar.s3_host_name
+      assert_match %r{^s3-world-end.amazonaws.com}, @dummy.avatar.s3_host_name
     end
 
     should "get the right s3_host_name in development" do
       rails_env("development")
       assert_match %r{^s3-ap-northeast-1.amazonaws.com}, @dummy.avatar.s3_host_name
+    end
+
+    should "get the right s3_host_name if the key does not exist" do
+      rails_env("test")
+      assert_match %r{^s3.amazonaws.com}, @dummy.avatar.s3_host_name
     end
   end
 


### PR DESCRIPTION
Hello.

I'm using S3 in the Tokyo region.
Normally, Host is "s3.amazonaws.com", but , Tokyo region is hosted by "s3-ap-northeast-1.amazonaws.com".

I add option "resion". If needed, can use this.
