### PR TITLE
Log commands if Paperclip.options[:log_command] = true

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -62,7 +62,7 @@ module Paperclip
         :image_magick_path => nil,
         :command_path      => nil,
         :log               => true,
-        :log_command       => true,
+        :log_command       => false,
         :swallow_stderr    => true
       }
     end
@@ -95,6 +95,7 @@ module Paperclip
       if options[:image_magick_path]
         Paperclip.log("[DEPRECATION] :image_magick_path is deprecated and will be removed. Use :command_path instead")
       end
+      Paperclip.log("#{cmd} #{params}") if options[:log_command]
       Cocaine::CommandLine.path = options[:command_path] || options[:image_magick_path]
       Cocaine::CommandLine.new(cmd, *params).run
     end

--- a/test/paperclip_test.rb
+++ b/test/paperclip_test.rb
@@ -6,6 +6,12 @@ class PaperclipTest < Test::Unit::TestCase
       Cocaine::CommandLine.expects(:new).with("convert", "stuff").returns(stub(:run))
       Paperclip.run("convert", "stuff")
     end
+
+    should "log the command when [:log_command] is set" do
+      Paperclip.options[:log_command] = true
+      Paperclip.expects(:log).with("echo 1 2 3")
+      Paperclip.run("echo", "1 2 3")
+    end
   end
 
   context "Paperclip.each_instance_with_attachment" do


### PR DESCRIPTION
It looks like there used to be code for this option, but it disappeared.
