### PR TITLE
Update to the official Amazon supplied aws-sdk gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem "mocha"
 gem "rake"
 # gem "ruby-debug", :platform => :ruby_18
 # gem "ruby-debug19", :platform => :ruby_19
-gem "aws-s3", :require => "aws/s3"
+gem "aws-sdk", :require => "aws/s3"
 gem "sqlite3-ruby", "~>1.3.0"
 gem "appraisal"
 gem "fog"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,14 +9,16 @@ GEM
       childprocess (>= 0.1.9)
       cucumber (>= 0.10.5)
       rspec (>= 2.6.0)
-    aws-s3 (0.6.2)
-      builder
-      mime-types
-      xml-simple
+    aws-sdk (1.0.1)
+      httparty (~> 0.7)
+      json (~> 1.4)
+      nokogiri (~> 1.4.4)
+      uuidtools (~> 2.1)
     builder (3.0.0)
     childprocess (0.1.9)
       ffi (~> 1.0.6)
     cocaine (0.1.0)
+    crack (0.1.8)
     cucumber (0.10.5)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.2)
@@ -38,6 +40,8 @@ GEM
     formatador (0.1.4)
     gherkin (2.4.0)
       json (>= 1.4.6)
+    httparty (0.7.8)
+      crack (= 0.1.8)
     json (1.5.1)
     mime-types (1.16)
     mocha (0.9.12)
@@ -59,14 +63,14 @@ GEM
     sqlite3-ruby (1.3.3)
       sqlite3 (>= 1.3.3)
     term-ansicolor (1.0.5)
-    xml-simple (1.0.16)
+    uuidtools (2.1.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   appraisal
-  aws-s3
+  aws-sdk
   bundler
   cocaine
   fog

--- a/gemfiles/rails2.gemfile
+++ b/gemfiles/rails2.gemfile
@@ -2,16 +2,16 @@
 
 source "http://rubygems.org"
 
-gem "rails", "~>2.3.0"
-gem "rake"
-gem "sqlite3-ruby", "~>1.3.0"
-gem "cocaine"
 gem "shoulda"
-gem "mime-types"
 gem "mocha"
-gem "bundler"
-gem "fog"
-gem "aws-s3", :require=>"aws/s3"
+gem "rake"
+gem "aws-sdk", :require=>"aws/s3"
+gem "sqlite3-ruby", "~>1.3.0"
 gem "appraisal"
+gem "fog"
+gem "bundler"
+gem "cocaine"
+gem "mime-types"
 gem "rdoc", :require=>false
+gem "rails", "~>2.3.0"
 

--- a/gemfiles/rails2.gemfile.lock
+++ b/gemfiles/rails2.gemfile.lock
@@ -11,15 +11,18 @@ GEM
     activeresource (2.3.10)
       activesupport (= 2.3.10)
     activesupport (2.3.10)
+    ansi (1.3.0)
     appraisal (0.1)
       bundler
       rake
-    aws-s3 (0.6.2)
-      builder
-      mime-types
-      xml-simple
+    aws-sdk (1.0.1)
+      httparty (~> 0.7)
+      json (~> 1.4)
+      nokogiri (~> 1.4.4)
+      uuidtools (~> 2.1)
     builder (3.0.0)
     cocaine (0.0.2)
+    crack (0.1.8)
     excon (0.5.7)
     fog (0.7.1)
       builder
@@ -31,6 +34,8 @@ GEM
       nokogiri (>= 1.4.4)
       ruby-hmac
     formatador (0.1.2)
+    httparty (0.7.8)
+      crack (= 0.1.8)
     json (1.5.1)
     mime-types (1.16)
     mocha (0.9.9)
@@ -50,14 +55,16 @@ GEM
     ruby-hmac (0.4.0)
     shoulda (2.11.3)
     sqlite3-ruby (1.3.2)
-    xml-simple (1.0.12)
+    turn (0.8.2)
+      ansi (>= 1.2.2)
+    uuidtools (2.1.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   appraisal
-  aws-s3
+  aws-sdk
   bundler
   cocaine
   fog
@@ -68,3 +75,4 @@ DEPENDENCIES
   rdoc
   shoulda
   sqlite3-ruby (~> 1.3.0)
+  turn

--- a/gemfiles/rails3.gemfile
+++ b/gemfiles/rails3.gemfile
@@ -2,16 +2,16 @@
 
 source "http://rubygems.org"
 
-gem "rails", "~>3.0.0"
-gem "rake"
-gem "sqlite3-ruby", "~>1.3.0"
-gem "cocaine"
 gem "shoulda"
-gem "mime-types"
 gem "mocha"
-gem "bundler"
-gem "fog"
-gem "aws-s3", :require=>"aws/s3"
+gem "rake"
+gem "aws-sdk", :require=>"aws/s3"
+gem "sqlite3-ruby", "~>1.3.0"
 gem "appraisal"
+gem "fog"
+gem "bundler"
+gem "cocaine"
+gem "mime-types"
 gem "rdoc", :require=>false
+gem "rails", "~>3.0.0"
 

--- a/gemfiles/rails3.gemfile.lock
+++ b/gemfiles/rails3.gemfile.lock
@@ -28,16 +28,19 @@ GEM
       activemodel (= 3.0.3)
       activesupport (= 3.0.3)
     activesupport (3.0.3)
+    ansi (1.3.0)
     appraisal (0.1)
       bundler
       rake
     arel (2.0.4)
-    aws-s3 (0.6.2)
-      builder
-      mime-types
-      xml-simple
+    aws-sdk (1.0.1)
+      httparty (~> 0.7)
+      json (~> 1.4)
+      nokogiri (~> 1.4.4)
+      uuidtools (~> 2.1)
     builder (2.1.2)
     cocaine (0.0.2)
+    crack (0.1.8)
     erubis (2.6.6)
       abstract (>= 1.0.0)
     excon (0.5.7)
@@ -51,6 +54,8 @@ GEM
       nokogiri (>= 1.4.4)
       ruby-hmac
     formatador (0.1.2)
+    httparty (0.7.8)
+      crack (= 0.1.8)
     i18n (0.4.2)
     json (1.5.1)
     mail (2.2.10)
@@ -90,15 +95,17 @@ GEM
     thor (0.14.6)
     treetop (1.4.9)
       polyglot (>= 0.3.1)
+    turn (0.8.2)
+      ansi (>= 1.2.2)
     tzinfo (0.3.23)
-    xml-simple (1.0.12)
+    uuidtools (2.1.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   appraisal
-  aws-s3
+  aws-sdk
   bundler
   cocaine
   fog
@@ -109,3 +116,4 @@ DEPENDENCIES
   rdoc
   shoulda
   sqlite3-ruby (~> 1.3.0)
+  turn

--- a/gemfiles/rails3_1.gemfile
+++ b/gemfiles/rails3_1.gemfile
@@ -2,16 +2,16 @@
 
 source "http://rubygems.org"
 
-gem "rails", "~>3.1.0.rc1"
-gem "rake"
-gem "sqlite3-ruby", "~>1.3.0"
-gem "cocaine"
 gem "shoulda"
-gem "mime-types"
 gem "mocha"
-gem "bundler"
-gem "fog"
-gem "aws-s3", :require=>"aws/s3"
+gem "rake"
+gem "aws-sdk", :require=>"aws/s3"
+gem "sqlite3-ruby", "~>1.3.0"
 gem "appraisal"
+gem "fog"
+gem "bundler"
+gem "cocaine"
+gem "mime-types"
 gem "rdoc", :require=>false
+gem "rails", "~>3.1.0.rc1"
 

--- a/gemfiles/rails3_1.gemfile.lock
+++ b/gemfiles/rails3_1.gemfile.lock
@@ -31,17 +31,20 @@ GEM
       activesupport (= 3.1.0.rc1)
     activesupport (3.1.0.rc1)
       multi_json (~> 1.0)
+    ansi (1.3.0)
     appraisal (0.2.0)
       bundler
       rake
     arel (2.1.1)
-    aws-s3 (0.6.2)
-      builder
-      mime-types
-      xml-simple
+    aws-sdk (1.0.1)
+      httparty (~> 0.7)
+      json (~> 1.4)
+      nokogiri (~> 1.4.4)
+      uuidtools (~> 2.1)
     bcrypt-ruby (2.1.4)
     builder (3.0.0)
     cocaine (0.0.2)
+    crack (0.1.8)
     erubis (2.7.0)
     excon (0.6.3)
     fog (0.8.1)
@@ -55,6 +58,8 @@ GEM
       ruby-hmac
     formatador (0.1.4)
     hike (1.0.0)
+    httparty (0.7.8)
+      crack (= 0.1.8)
     i18n (0.6.0)
     json (1.5.1)
     mail (2.3.0)
@@ -105,15 +110,17 @@ GEM
     tilt (1.3.1)
     treetop (1.4.9)
       polyglot (>= 0.3.1)
+    turn (0.8.2)
+      ansi (>= 1.2.2)
     tzinfo (0.3.27)
-    xml-simple (1.0.15)
+    uuidtools (2.1.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   appraisal
-  aws-s3
+  aws-sdk
   bundler
   cocaine
   fog
@@ -124,3 +131,4 @@ DEPENDENCIES
   rdoc
   shoulda
   sqlite3-ruby (~> 1.3.0)
+  turn


### PR DESCRIPTION
This is regarding issue #530.

My patch updated paperclip to use the official Amazon supplied AWS gem (aws-sdk).
Given that this is the official gem, I think it makes sense to standardize on it. I know I plan to move all my projects to using it. 

This means that there won't be a need to included multiple gems with duplicate functionality.

It's a fairly straightforward patch. The biggest pain was in update the tests, since the new gem uses methods on objects rather than static calls to classes, which means having to mock/stub down a couple levels.
