### PR TITLE
Use camelize instead of capitalize for custom storage modules

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -323,7 +323,7 @@ module Paperclip
     end
 
     def initialize_storage #:nodoc:
-      storage_class_name = @storage.to_s.camelize
+      storage_class_name = @storage.to_s.downcase.camelize
       begin
         @storage_module = Paperclip::Storage.const_get(storage_class_name)
       rescue NameError

--- a/test/attachment_test.rb
+++ b/test/attachment_test.rb
@@ -496,6 +496,19 @@ class AttachmentTest < Test::Unit::TestCase
     rebuild_model :storage => :FileSystem
     @dummy = Dummy.new
     assert @dummy.avatar.is_a?(Paperclip::Storage::Filesystem)
+    
+    rebuild_model :storage => :Filesystem
+    @dummy = Dummy.new
+    assert @dummy.avatar.is_a?(Paperclip::Storage::Filesystem)
+  end
+  
+  should "convert underscored storage name to camelcase" do
+    rebuild_model :storage => :not_here
+    @dummy = Dummy.new
+    exception = assert_raises(Paperclip::StorageMethodNotFound) do |e|
+      @dummy.avatar
+    end
+    assert exception.message.include?("NotHere")
   end
 
   should "raise an error if you try to include a storage module that doesn't exist" do


### PR DESCRIPTION
This is to replace @526

I've made a new branch with just the changes I originally wanted to commit. The test which @mike-burns previously referred to now passes and I've added two other tests.

Full disclosure: I'm getting some other tests failing in thoughtbot's head because my imagemagick got mashed in the upgrade to Lion, so I'm generally struggling with them anyway atm - but I'm 99% sure this isn't causing any fails.

Sorry for the confusion.

iHiD
