### PR TITLE
Default fog_public option to true (as stated in documentation).

### DIFF
--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -44,7 +44,7 @@ module Paperclip
           @fog_directory    = @options[:fog_directory]
           @fog_credentials  = @options[:fog_credentials]
           @fog_host         = @options[:fog_host]
-          @fog_public       = @options[:fog_public]
+          @fog_public       = @options[:fog_public] || true
           @fog_file         = @options[:fog_file] || {}
 
           @url = ':fog_public_url'

--- a/test/fog_test.rb
+++ b/test/fog_test.rb
@@ -24,7 +24,6 @@ class FogTest < Test::Unit::TestCase
         :fog_directory    => @fog_directory,
         :fog_credentials  => @credentials,
         :fog_host         => nil,
-        :fog_public       => true,
         :fog_file         => {:cache_control => 1234},
         :path             => ":attachment/:basename.:extension",
         :storage          => :fog
@@ -100,7 +99,6 @@ class FogTest < Test::Unit::TestCase
             :fog_directory    => @fog_directory,
             :fog_credentials  => @credentials,
             :fog_host         => 'http://img%d.example.com',
-            :fog_public       => true,
             :path             => ":attachment/:basename.:extension",
             :storage          => :fog
           )


### PR DESCRIPTION
The documentation around Fog Storage says that :fog_public defaults to true. This is not the case is the current codebase so I have patched it and adjusted the tests. I also patched from v2.3.15 tag but it should apply cleanly to master.
