### PR TITLE
A few .travis.yml tweaks 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 rvm:
   - 1.8.7
   - 1.9.2
-  - jruby
+  - 1.9.3
+  - rbx
+  - rbx-2.0
 script: "bundle exec rake clean test"
 gemfile:
   - gemfiles/rails2.gemfile


### PR DESCRIPTION
- We have some known problems with JRuby on travis-ci.org. We suggest people to disable testing against JRuby for now. We'll let you know once they are resolved.
- We provide 1.9.3[-preview1] as 1.9.3 on travis
- Today is #rbxday so lets try testing against both Rubinius branches? 
