### PR TITLE
Fix bug with the :fog_public option

### DIFF
--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -44,7 +44,7 @@ module Paperclip
           @fog_directory    = @options[:fog_directory]
           @fog_credentials  = @options[:fog_credentials]
           @fog_host         = @options[:fog_host]
-          @fog_public       = @options[:fog_public] || true
+          @fog_public       = @options.key?(:fog_public) ? @options[:fog_public] : true
           @fog_file         = @options[:fog_file] || {}
 
           @url = ':fog_public_url'

--- a/test/fog_test.rb
+++ b/test/fog_test.rb
@@ -111,6 +111,19 @@ class FogTest < Test::Unit::TestCase
           assert @dummy.avatar.url =~ /^http:\/\/img[0123]\.example\.com\/avatars\/stringio\.txt\?\d*$/
         end
       end
+      
+      context "with fog_public set to false" do
+        setup do
+          rebuild_model(@options.merge(:fog_public => false))
+          @dummy = Dummy.new
+          @dummy.avatar = StringIO.new('.')
+          @dummy.save
+        end
+        
+        should 'set the @fog_public instance variable to false' do
+          assert_equal false, @dummy.avatar.instance_variable_get('@fog_public')
+        end
+      end
 
     end
 


### PR DESCRIPTION
You can't currently set "false" to the :fog_public option when using the fog storage module.  I threw together a simple fix and a test, although I'm not sure if the test could have been done more succinctly and idiomatically.  Let me know!
