### PR TITLE
Provide content-type of file to fog storage provider.

### DIFF
--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -68,9 +68,10 @@ module Paperclip
           retried = false
           begin
             directory.files.create(@fog_file.merge(
-              :body   => file,
-              :key    => path(style),
-              :public => @fog_public
+              :body         => file,
+              :key          => path(style),
+              :public       => @fog_public,
+              :content_type => file.content_type.to_s.strip
             ))
           rescue Excon::Errors::NotFound
             raise if retried


### PR DESCRIPTION
When uploading attachment thumbnails to Rackspace CloudFiles, I've had a problem with the content-type of the thumbnails being set to "application/json".  By sending a content_type argument to fog's #create method, this behavior seems to be corrected.

Unfortunately, I'm having a tough time figuring out how to write a test for this, since the content_type of all files returned by mocked Fog file objects seems to be nil.  Any assistance here would be welcome.  I've included my prospective tests to be included in fog_test.rb here:

```
context "image with thumbnail" do
  setup do
    rebuild_model(
      :path   => ":attachment/:basename_:style.:extension",
      :styles => { :thumb => '50x50>' }
    )
    @file = File.new(File.join(File.dirname(__FILE__), 'fixtures', '5k.png'), 'rb')
    @dummy = Dummy.new
    @dummy.avatar = @file
    @dummy.save
    @files = @connection.directories.get(@fog_directory).files
  end

  teardown do
    @file.close
    directory = @connection.directories.new(:key => @fog_directory)
    directory.files.each {|file| file.destroy}
    directory.destroy
  end

  should "save file and its thumbnail" do
    assert_equal 2, @files.size
  end

  should "set the correct mime type for all versions of file" do
    @files.each do |file|
      assert_equal @dummy.avatar.content_type, file.content_type
    end
  end
end
```

Thanks...
