### PR TITLE
Images with "special" chars on the file name are generating incorrect URL

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -128,7 +128,7 @@ module Paperclip
     # if you want to stop the attachment update time appended to the url
     def url(style_name = default_style, use_timestamp = @use_timestamp)
       default_url = @default_url.is_a?(Proc) ? @default_url.call(self) : @default_url
-      url = CGI.escape(original_filename.nil? ? interpolate(default_url, style_name) : interpolate(@url, style_name))
+      url = original_filename.nil? ? interpolate(default_url, style_name) : interpolate(@url, style_name)
       use_timestamp && updated_at ? [url, updated_at].compact.join(url.include?("?") ? "&" : "?") : url
     end
 

--- a/lib/paperclip/interpolations.rb
+++ b/lib/paperclip/interpolations.rb
@@ -83,7 +83,7 @@ module Paperclip
 
     # Returns the basename of the file. e.g. "file" for "file.jpg"
     def basename attachment, style_name
-      attachment.original_filename.gsub(/#{File.extname(attachment.original_filename)}$/, "")
+      CGI.escape(attachment.original_filename.gsub(/#{File.extname(attachment.original_filename)}$/, ""))
     end
 
     # Returns the extension of the file. e.g. "jpg" for "file.jpg"


### PR DESCRIPTION
Special chars allowed on filenames are not handled correctly when the URL is generated. Simplest example would be a file named %20.jpg: its URL should end with %2520.jpg.

Not sure if I'm escaping the characters on the right place or collateral effects I might be unaware of (the build seems to be OK, though).
