### PR TITLE
Use https for travis-ci build status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Paperclip [![Build Status](http://travis-ci.org/thoughtbot/paperclip.png)](http://travis-ci.org/thoughtbot/paperclip)
+# Paperclip [![Build Status](https://secure.travis-ci.org/thoughtbot/paperclip.png)](http://travis-ci.org/thoughtbot/paperclip)
 
 Paperclip is intended as an easy file attachment library for ActiveRecord. The
 intent behind it was to keep setup as easy as possible and to treat files as


### PR DESCRIPTION
Will prevent Github from caching the travis-ci build image.
