### PR TITLE
Passing :source_file_options when dealing with .pdf

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -14,6 +14,7 @@ module Paperclip
         :only_process          => [],
         :processors            => [:thumbnail],
         :convert_options       => {},
+        :source_file_options   => {},
         :default_url           => "/:attachment/:style/missing.png",
         :default_style         => :original,
         :storage               => :filesystem,
@@ -26,7 +27,7 @@ module Paperclip
       }
     end
 
-    attr_reader :name, :instance, :default_style, :convert_options, :queued_for_write, :whiny, :options
+    attr_reader :name, :instance, :default_style, :convert_options, :queued_for_write, :whiny, :options, :source_file_options
     attr_accessor :post_processing
 
     # Creates an Attachment object. +name+ is the name of the attachment,
@@ -55,6 +56,7 @@ module Paperclip
       @hash_data             = options[:hash_data]
       @hash_secret           = options[:hash_secret]
       @convert_options       = options[:convert_options]
+      @source_file_options   = options[:source_file_options]
       @processors            = options[:processors]
       @preserve_files        = options[:preserve_files]
       @options               = options
@@ -336,6 +338,15 @@ module Paperclip
       all_options   = convert_options[:all]
       all_options   = all_options.call(instance)   if all_options.respond_to?(:call)
       style_options = convert_options[style]
+      style_options = style_options.call(instance) if style_options.respond_to?(:call)
+
+      [ style_options, all_options ].compact.join(" ")
+    end
+
+    def extra_source_file_options_for(style) #:nodoc:
+      all_options   = source_file_options[:all]
+      all_options   = all_options.call(instance)   if all_options.respond_to?(:call)
+      style_options = source_file_options[style]
       style_options = style_options.call(instance) if style_options.respond_to?(:call)
 
       [ style_options, all_options ].compact.join(" ")

--- a/lib/paperclip/style.rb
+++ b/lib/paperclip/style.rb
@@ -49,6 +49,10 @@ module Paperclip
       attachment.send(:extra_options_for, name)
     end
 
+    def source_file_options
+      attachment.send(:extra_source_file_options_for, name)
+    end
+
     # returns the geometry string for this style
     # if a proc has been supplied, we call it here
     def geometry
@@ -63,7 +67,7 @@ module Paperclip
       @other_args.each do |k,v|
         args[k] = v.respond_to?(:call) ? v.call(attachment) : v
       end
-      [:processors, :geometry, :format, :whiny, :convert_options].each do |k|
+      [:processors, :geometry, :format, :whiny, :convert_options, :source_file_options].each do |k|
         (arg = send(k)) && args[k] = arg
       end
       args
@@ -72,7 +76,7 @@ module Paperclip
     # Supports getting and setting style properties with hash notation to ensure backwards-compatibility
     # eg. @attachment.styles[:large][:geometry]@ will still work
     def [](key)
-      if [:name, :convert_options, :whiny, :processors, :geometry, :format, :animated].include?(key)
+      if [:name, :convert_options, :whiny, :processors, :geometry, :format, :animated, :source_file_options].include?(key)
         send(key)
       elsif defined? @other_args[key]
         @other_args[key]
@@ -80,7 +84,7 @@ module Paperclip
     end
 
     def []=(key, value)
-      if [:name, :convert_options, :whiny, :processors, :geometry, :format, :animated].include?(key)
+      if [:name, :convert_options, :whiny, :processors, :geometry, :format, :animated, :source_file_options].include?(key)
         send("#{key}=".intern, value)
       else
         @other_args[key] = value

--- a/test/attachment_test.rb
+++ b/test/attachment_test.rb
@@ -263,6 +263,29 @@ class AttachmentTest < Test::Unit::TestCase
     end
   end
 
+  context "An attachment with :source_file_options" do
+    setup do
+      rebuild_model :styles => {
+                      :thumb => "100x100",
+                      :large => "400x400"
+                    },
+                    :source_file_options => {
+                      :all => "-density 400",
+                      :thumb => "-depth 8"
+                    }
+      @dummy = Dummy.new
+      @dummy.avatar
+    end
+
+    should "report the correct options when sent #extra_source_file_options_for(:thumb)" do
+      assert_equal "-depth 8 -density 400", @dummy.avatar.send(:extra_source_file_options_for, :thumb), @dummy.avatar.source_file_options.inspect
+    end
+
+    should "report the correct options when sent #extra_source_file_options_for(:large)" do
+      assert_equal "-density 400", @dummy.avatar.send(:extra_source_file_options_for, :large)
+    end
+  end
+
   context "An attachment with :only_process" do
     setup do
       rebuild_model :styles => {
@@ -476,7 +499,12 @@ class AttachmentTest < Test::Unit::TestCase
       end
 
       before_should "call #make with the right parameters passed as second argument" do
-        expected_params = @style_params[:once].merge({:processors => [:thumbnail, :test], :whiny => true, :convert_options => ""})
+        expected_params = @style_params[:once].merge({
+          :processors => [:thumbnail, :test],
+          :whiny => true,
+          :convert_options => "",
+          :source_file_options => ""
+        })
         Paperclip::Thumbnail.expects(:make).with(anything, expected_params, anything).returns(@file)
       end
 

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -283,6 +283,38 @@ class IntegrationTest < Test::Unit::TestCase
     end
   end
 
+  context "A model with no source_file_options setting" do
+    setup do
+      rebuild_model :styles => { :large => "300x300>",
+                                 :medium => "100x100",
+                                 :thumb => ["32x32#", :gif] },
+                    :default_style => :medium,
+                    :url => "/:attachment/:class/:style/:id/:basename.:extension",
+                    :path => ":rails_root/tmp/:attachment/:class/:style/:id/:basename.:extension"
+      @dummy     = Dummy.new
+    end
+
+    should "have its definition return nil when asked about source_file_options" do
+      assert ! Dummy.attachment_definitions[:avatar][:source_file_options]
+    end
+
+    context "redefined to have source_file_options setting" do
+      setup do
+        rebuild_model :styles => { :large => "300x300>",
+                                   :medium => "100x100",
+                                   :thumb => ["32x32#", :gif] },
+                      :source_file_options => "-density 400",
+                      :default_style => :medium,
+                      :url => "/:attachment/:class/:style/:id/:basename.:extension",
+                      :path => ":rails_root/tmp/:attachment/:class/:style/:id/:basename.:extension"
+      end
+
+      should "have its definition return source_file_options value when asked about source_file_options" do
+        assert_equal "-density 400", Dummy.attachment_definitions[:avatar][:source_file_options]
+      end
+    end
+  end
+
   context "A model with a filesystem attachment" do
     setup do
       rebuild_model :styles => { :large => "300x300>",

--- a/test/style_test.rb
+++ b/test/style_test.rb
@@ -117,6 +117,26 @@ class StyleTest < Test::Unit::TestCase
     end
   end
 
+  context "An attachment with :source_file_options" do
+    setup do
+      @attachment = attachment :path => ":basename.:extension",
+                               :styles => {:thumb => "100x100", :large => "400x400"},
+                               :source_file_options => {:all => "-density 400", :thumb => "-depth 8"}
+      @style = @attachment.styles[:thumb]
+      @file = StringIO.new("...")
+      @file.stubs(:original_filename).returns("file.jpg")
+    end
+
+    before_should "not have called extra_source_file_options_for(:thumb/:large) on initialization" do
+      @attachment.expects(:extra_source_file_options_for).never
+    end
+
+    should "call extra_options_for(:thumb/:large) when convert options are requested" do
+      @attachment.expects(:extra_source_file_options_for).with(:thumb)
+      @attachment.styles[:thumb].source_file_options
+    end
+  end
+
   context "A style rule with its own :processors" do
     setup do
       @attachment = attachment :path => ":basename.:extension",

--- a/test/thumbnail_test.rb
+++ b/test/thumbnail_test.rb
@@ -102,6 +102,10 @@ class ThumbnailTest < Test::Unit::TestCase
         assert_equal nil, @thumb.convert_options
       end
 
+      should "have source_file_options set to nil by default" do
+        assert_equal nil, @thumb.source_file_options
+      end
+
       should "send the right command to convert when sent #make" do
         Paperclip.expects(:run).with do |*arg|
           arg[0] == 'convert' &&


### PR DESCRIPTION
I need to pass -density to 'convert' for better pdf to image conversion quality. This can't go with :convert_options (it's too late in arguments list for 'convert'), so I made this little patch.

Hope you will find this useful:)

``` ruby
  has_attached_file :pdf,
    :styles => { :as_image => {:geometry => '1200x1200', :format => :png} },
    :source_file_options => {:as_image => '-density 300'} # for better PDF screenshot quality
```
