### PR TITLE
Allow Fog credentials to be set from an external YAML file.

### DIFF
--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -42,7 +42,7 @@ module Paperclip
 
         base.instance_eval do
           @fog_directory    = @options[:fog_directory]
-          @fog_credentials  = @options[:fog_credentials]
+          @fog_credentials  = parse_credentials(@options[:fog_credentials])
           @fog_host         = @options[:fog_host]
           @fog_public       = @options.key?(:fog_public) ? @options[:fog_public] : true
           @fog_file         = @options[:fog_file] || {}
@@ -119,9 +119,28 @@ module Paperclip
           directory.files.new(:key => path(style)).public_url
         end
       end
+      
+      def parse_credentials creds
+        creds = find_credentials(creds).stringify_keys
+        env = Object.const_defined?(:Rails) ? Rails.env : nil
+        (creds[env] || creds).symbolize_keys
+      end
 
       private
-
+      
+      def find_credentials creds
+        case creds
+        when File
+          YAML::load(ERB.new(File.read(creds.path)).result)
+        when String, Pathname
+          YAML::load(ERB.new(File.read(creds)).result)
+        when Hash
+          creds
+        else
+          raise ArgumentError, "Credentials are not a path, file, or hash."
+        end
+      end
+      
       def connection
         @connection ||= ::Fog::Storage.new(@fog_credentials)
       end
@@ -129,8 +148,6 @@ module Paperclip
       def directory
         @directory ||= connection.directories.new(:key => @fog_directory)
       end
-
     end
-
   end
 end

--- a/test/fixtures/fog.yml
+++ b/test/fixtures/fog.yml
@@ -1,0 +1,8 @@
+development:
+    provider: AWS
+    aws_access_key_id: AWS_ID
+    aws_secret_access_key: AWS_SECRET
+test:
+    provider: AWS
+    aws_access_key_id: AWS_ID
+    aws_secret_access_key: AWS_SECRET

--- a/test/fog_test.rb
+++ b/test/fog_test.rb
@@ -5,6 +5,40 @@ Fog.mock!
 
 class FogTest < Test::Unit::TestCase
   context "" do
+    
+    context "with credentials provided in a path string" do
+      setup do
+        rebuild_model :styles => { :medium => "300x300>", :thumb => "100x100>" },
+                      :storage => :fog,
+                      :url => '/:attachment/:filename',
+                      :fog_directory => "paperclip",
+                      :fog_credentials => File.join(File.dirname(__FILE__), 'fixtures', 'fog.yml')
+        @dummy = Dummy.new
+        @dummy.avatar = File.new(File.join(File.dirname(__FILE__), 'fixtures', '5k.png'), 'rb')
+      end
+
+      should "have the proper information loading credentials from a file" do
+        assert_equal @dummy.avatar.instance_variable_get("@fog_credentials")[:provider], 'AWS'
+      end
+    end
+    
+    context "with credentials provided in a File object" do
+      setup do
+        rebuild_model :styles => { :medium => "300x300>", :thumb => "100x100>" },
+                      :storage => :fog,
+                      :url => '/:attachment/:filename',
+                      :fog_directory => "paperclip",
+                      :fog_credentials => File.open(File.join(File.dirname(__FILE__), 'fixtures', 'fog.yml'))
+        @dummy = Dummy.new
+        @dummy.avatar = File.new(File.join(File.dirname(__FILE__), 'fixtures', '5k.png'), 'rb')
+      end
+
+      should "have the proper information loading credentials from a file" do
+        assert_equal @dummy.avatar.instance_variable_get("@fog_credentials")[:provider], 'AWS'
+      end
+    end
+    
+    
     context "with default values for path and url" do
       setup do
         rebuild_model :styles => { :medium => "300x300>", :thumb => "100x100>" },
@@ -25,7 +59,7 @@ class FogTest < Test::Unit::TestCase
                      @dummy.avatar.path
       end
     end
-
+          
     setup do
       @fog_directory = 'papercliptests'
 


### PR DESCRIPTION
This patch allows you to create an external YAML file for storing credentials when using the Fog storage engine.  It's based heavily on the AWS one, and will be a big help for people who don't want to check their credentials into version control (or roll their own credential storage outside the model).
