### PR TITLE
When testing if post_processing is set, the method should be used.

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -135,7 +135,7 @@ module Paperclip
 
       @dirty = true
 
-      post_process(*@only_process) if @post_processing
+      post_process(*@only_process) if post_processing
 
       # Reset the file size if the original file was reprocessed.
       instance_write(:file_size,   @queued_for_write[:original].size.to_i)


### PR DESCRIPTION
When testing if post_processing is set, the method should be used. This allows plugins to overwrite the post_processing decision. This is useful for plugins that want to do the post_processing in a background processor.
