### PR TITLE
Interpolating id_partition bug for new records

### DIFF
--- a/lib/paperclip/interpolations.rb
+++ b/lib/paperclip/interpolations.rb
@@ -143,10 +143,10 @@ module Paperclip
     # Returns the id of the instance in a split path form. e.g. returns
     # 000/001/234 for an id of 1234.
     def id_partition attachment, style_name
-      if (id = attachment.instance.id).is_a?(Integer)
-        ("%09d" % id).scan(/\d{3}/).join("/")
-      else
+      if (id = attachment.instance.id).is_a?(String)
         id.scan(/.{3}/).first(3).join("/")
+      else
+        ("%09d" % id).scan(/\d{3}/).join("/")
       end
     end
 

--- a/test/interpolations_test.rb
+++ b/test/interpolations_test.rb
@@ -102,6 +102,14 @@ class InterpolationsTest < Test::Unit::TestCase
     assert_equal "32f/nj2/3oi", Paperclip::Interpolations.id_partition(attachment, :style)
   end
 
+  should "return the fake partitioned id of the attachment when the id is nil for new record" do
+    attachment = mock
+    attachment.expects(:id).returns(nil)
+    attachment.expects(:instance).returns(attachment)
+    assert_equal "000/000/000", Paperclip::Interpolations.id_partition(attachment, :style)
+  end
+
+
   should "return the name of the attachment" do
     attachment = mock
     attachment.expects(:name).returns("file")


### PR DESCRIPTION
Whenever you assign file for new record, you get hairy `NoMethodError: private method 'scan' called for nil:NilClass` exception, because new objects don't have ID.

``` ruby
user = User.new
user.avatar = File.read(...)
```
