### PR TITLE
file: unrecognized option `--mime-type'

### DIFF
--- a/lib/paperclip/upfile.rb
+++ b/lib/paperclip/upfile.rb
@@ -25,7 +25,7 @@ module Paperclip
     def type_from_file_command
     #  On BSDs, `file` doesn't give a result code of 1 if the file doesn't exist.
       type = (self.original_filename.match(/\.(\w+)$/)[1] rescue "octet-stream").downcase
-      mime_type = (Paperclip.run("file", "-b --mime :file", :file => self.path).split(':').last.strip rescue "application/x-#{type}")
+      mime_type = (Paperclip.run("file", "-b --mime :file", :file => self.path).split(':').last.split(';').first.strip rescue "application/x-#{type}")
       mime_type = "application/x-#{type}" if mime_type.match(/\(.*?\)/)
       mime_type
     end


### PR DESCRIPTION
On Centos 5.6 we were trying to deploy paperclip, however the file command doesn't support this option. It does have --mime (along with standard file implementations). --mime will output the mime-type and mime-encoding, however it is available on more systems than --mime-type. This patch fixes that issue.

I don't have a test for this, but it's a weird case and I'm not sure where I'd start to write one to test this functionality. Any advice/tips would be helpful!
