### PR TITLE
fixes #588 . Attempt to log warning message when 2 models use same attach

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -184,6 +184,19 @@ module Paperclip
         raise e
       end
     end
+
+    def check_for_url_clash(name,url,klass)
+      @names_url ||= {}
+      default_url = url || Attachment.default_options[:url]
+      if @names_url[name] && @names_url[name][:url] == default_url && @names_url[name][:class] != klass
+        log("Duplicate URL for #{name} with #{default_url}. This will clash with attachment defined in #{@names_url[name][:class]} class")
+      end
+      @names_url[name] = {:url => default_url, :class => klass}
+    end
+
+    def reset_duplicate_clash_check!
+      @names_url = nil
+    end
   end
 
   class PaperclipError < StandardError #:nodoc:
@@ -290,6 +303,7 @@ module Paperclip
 
       attachment_definitions[name] = {:validations => []}.merge(options)
       Paperclip.classes_with_attachments << self
+      Paperclip.check_for_url_clash(name,attachment_definitions[name][:url],self.name)
 
       after_save :save_attached_files
       before_destroy :prepare_for_destroy

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -84,6 +84,7 @@ def rebuild_class options = {}
   ActiveRecord::Base.send(:include, Paperclip::Glue)
   Object.send(:remove_const, "Dummy") rescue nil
   Object.const_set("Dummy", Class.new(ActiveRecord::Base))
+  Paperclip.reset_duplicate_clash_check!
   Dummy.class_eval do
     include Paperclip::Glue
     has_attached_file :avatar, options

--- a/test/paperclip_test.rb
+++ b/test/paperclip_test.rb
@@ -46,6 +46,24 @@ class PaperclipTest < Test::Unit::TestCase
     end
   end
 
+  context "Attachments with clashing URLs should raise error" do
+    setup do
+      class Dummy2 < ActiveRecord::Base
+        include Paperclip::Glue
+      end
+    end
+
+    should "generate warning if attachment is redefined with the same url string" do
+      Paperclip.expects(:log).with("Duplicate URL for blah with /system/:attachment/:id/:style/:filename. This will clash with attachment defined in Dummy class")
+      Dummy.class_eval do
+        has_attached_file :blah
+      end
+      Dummy2.class_eval do
+        has_attached_file :blah
+      end
+    end
+  end
+
   context "An ActiveRecord model with an 'avatar' attachment" do
     setup do
       rebuild_model :path => "tmp/:class/omg/:style.:extension"


### PR DESCRIPTION
fixes #588 . Attempt to log warning message when 2 models use same attachment name with default url interpolation

@sikachu I am able to make the tests pass by checking that log method is invoked with the expected text.

Feel free to review/comment.
