### PR TITLE
Support for specifying HTTP Proxy

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -95,6 +95,12 @@ module Paperclip
             @url          = ":s3_path_url"
           end
           @url            = ":asset_host" if @options[:url].to_s == ":asset_host"
+          
+          @http_proxy = @options[:http_proxy] || nil
+          if @http_proxy
+            @s3_options.merge!({:proxy => @http_proxy})
+          end
+          
           AWS::S3::Base.establish_connection!( @s3_options.merge(
             :access_key_id => @s3_credentials[:access_key_id],
             :secret_access_key => @s3_credentials[:secret_access_key]
@@ -121,6 +127,27 @@ module Paperclip
       def bucket_name
         @bucket
       end
+      
+      def using_http_proxy?
+        !!@http_proxy
+      end
+      
+      def http_proxy_host
+        using_http_proxy? ? @http_proxy[:host] : nil
+      end
+
+      def http_proxy_port
+        using_http_proxy? ? @http_proxy[:port] : nil
+      end
+      
+      def http_proxy_user
+        using_http_proxy? ? @http_proxy[:user] : nil
+      end
+
+      def http_proxy_password
+        using_http_proxy? ? @http_proxy[:password] : nil
+      end
+      
 
       def s3_host_name
         @s3_host_name || "s3.amazonaws.com"

--- a/test/storage_test.rb
+++ b/test/storage_test.rb
@@ -41,9 +41,11 @@ class StorageTest < Test::Unit::TestCase
 
   context "Parsing S3 credentials" do
     setup do
+      @proxy_settings = {:host => "127.0.0.1", :port => 8888, :user => "foo", :password => "bar"}
       AWS::S3::Base.stubs(:establish_connection!)
       rebuild_model :storage => :s3,
                     :bucket => "testing",
+                    :http_proxy => @proxy_settings,
                     :s3_credentials => {:not => :important}
 
       @dummy = Dummy.new
@@ -68,6 +70,16 @@ class StorageTest < Test::Unit::TestCase
       rails_env("not really an env")
       assert_equal({:test => "12345"}, @avatar.parse_credentials(:test => "12345"))
     end
+    
+    should "support HTTP proxy settings" do
+      rails_env("development")
+      assert_equal(true, @avatar.using_http_proxy?)
+      assert_equal(@proxy_settings[:host], @avatar.http_proxy_host)
+      assert_equal(@proxy_settings[:port], @avatar.http_proxy_port)
+      assert_equal(@proxy_settings[:user], @avatar.http_proxy_user)
+      assert_equal(@proxy_settings[:password], @avatar.http_proxy_password)
+    end
+    
   end
 
   context "" do


### PR DESCRIPTION
The underlying AWS/S3 gem supports the specification of an HTTP Proxy so its small order to specify the Proxy settings in the Paperclip settings, which get pushed down AWS::S3.

Being able to specify an HTTP Proxy is crucial in some intranet environments, not to mention its helpful.
