### PR TITLE
Fix 293, 601: STI subclassing overwrites options

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -314,6 +314,8 @@ module Paperclip
         else
           write_inheritable_attribute(:attachment_definitions, {})
         end
+      else
+        self.attachment_definitions = self.attachment_definitions.dup
       end
 
       attachment_definitions[name] = {:validations => []}.merge(options)


### PR DESCRIPTION
Problem: When using STI, and when 'config.cache_classes = true', then
the STI subclass that gets loaded last will overwrite the options for
the others. This is due to using Rails class_attribute with a mutable
hash.

Solution: dup the hash.

Related issues: #293, #601
