### PR TITLE
Reassigning 'file' variable was causing Tempfile race condition for common design pattern

### DIFF
--- a/lib/paperclip/geometry.rb
+++ b/lib/paperclip/geometry.rb
@@ -13,18 +13,20 @@ module Paperclip
 
     # Uses ImageMagick to determing the dimensions of a file, passed in as either a
     # File or path.
+    # NOTE: (race cond) Do not reassign the 'file' variable inside this method as it is likely to be
+    # a Tempfile object, which would be eligible for file deletion when no longer referenced.
     def self.from_file file
-      file = file.path if file.respond_to? "path"
-      raise(Paperclip::NotIdentifiedByImageMagickError.new("Cannot find the geometry of a file with a blank name")) if file.blank?
+      file_path = file.respond_to?(:path) ? file.path : file
+      raise(Paperclip::NotIdentifiedByImageMagickError.new("Cannot find the geometry of a file with a blank name")) if file_path.blank?
       geometry = begin
-                   Paperclip.run("identify", "-format %wx%h :file", :file => "#{file}[0]")
+                   Paperclip.run("identify", "-format %wx%h :file", :file => "#{file_path}[0]")
                  rescue Cocaine::ExitStatusError
                    ""
                  rescue Cocaine::CommandNotFoundError => e
                    raise Paperclip::CommandNotFoundError.new("Could not run the `identify` command. Please install ImageMagick.")
                  end
       parse(geometry) ||
-        raise(NotIdentifiedByImageMagickError.new("#{file} is not recognized by the 'identify' command."))
+        raise(NotIdentifiedByImageMagickError.new("#{file_path} is not recognized by the 'identify' command."))
     end
 
     # Parses a "WxH" formatted string, where W is the width and H is the height.


### PR DESCRIPTION
``` ruby
Paperclip::Geometry.from_file(image.to_file(:original))
```

The code above results in a race condition where an image file could be deleted before it can be read by the 'identify' command.

It is an unlikely result, but it's happened to me enough times to want a fix.
