### PR TITLE
Fixed an issue with interpolations.basename

### DIFF
--- a/lib/paperclip/interpolations.rb
+++ b/lib/paperclip/interpolations.rb
@@ -86,7 +86,7 @@ module Paperclip
 
     # Returns the basename of the file. e.g. "file" for "file.jpg"
     def basename attachment, style_name
-      attachment.original_filename.gsub(/#{File.extname(attachment.original_filename)}$/, "")
+      attachment.original_filename.gsub(/#{Regexp.escape(File.extname(attachment.original_filename))}$/, "")
     end
 
     # Returns the extension of the file. e.g. "jpg" for "file.jpg"

--- a/test/interpolations_test.rb
+++ b/test/interpolations_test.rb
@@ -154,6 +154,13 @@ class InterpolationsTest < Test::Unit::TestCase
     attachment.stubs(:original_filename).returns("one")
     assert_equal "one", Paperclip::Interpolations.filename(attachment, :style)
   end
+  
+  should "return the basename when the extension contains regexp special characters" do
+    attachment = mock
+    attachment.stubs(:styles).returns({})
+    attachment.stubs(:original_filename).returns("one.ab)")
+    assert_equal "one", Paperclip::Interpolations.basename(attachment, :style)
+  end
 
   should "return the timestamp" do
     now = Time.now


### PR DESCRIPTION
Previously, if the filename extension contained characters that are considered "special" in a regexp, interpolations.basename would fail. I've used Regexp.escape to resolve this and added a suitable test
