### PR TITLE
Fix NaN crop error when 'identify' identifies XML as SVG with 0 geometry

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -217,6 +217,9 @@ module Paperclip
   class InfiniteInterpolationError < PaperclipError #:nodoc:
   end
 
+  class InvalidCropGeometryError < PaperclipError #:nodoc:
+  end
+
   module Glue
     def self.included base #:nodoc:
       base.extend ClassMethods

--- a/lib/paperclip/geometry.rb
+++ b/lib/paperclip/geometry.rb
@@ -89,6 +89,8 @@ module Paperclip
     # is weighted at the center of the Geometry.
     def transformation_to dst, crop = false
       if crop
+        raise InvalidCropGeometryError if self.width < dst.width or self.height < dst.height
+
         ratio = Geometry.new( dst.width / self.width, dst.height / self.height )
         scale_geometry, scale = scaling(dst, ratio)
         crop_geometry         = cropping(dst, ratio, scale)

--- a/test/geometry_test.rb
+++ b/test/geometry_test.rb
@@ -136,6 +136,12 @@ class GeometryTest < Test::Unit::TestCase
       assert_raise(Paperclip::NotIdentifiedByImageMagickError){ @geo = Paperclip::Geometry.from_file(file) }
     end
 
+    should "raise an InvalidCropGeometryError when cropping from an initial geometry that is smaller than the target geometry" do
+      assert @src = Paperclip::Geometry.parse("10x10")
+      assert @dst = Paperclip::Geometry.parse("123x456>")
+      assert_raise(Paperclip::InvalidCropGeometryError) { @src.transformation_to(@dst, true) }
+    end
+
     should "let us know when a command isn't found versus a processing error" do
       old_path = ENV['PATH']
       begin


### PR DESCRIPTION
Identify incorrectly identifies some file types, namely some XML, as SVG with 0x0 geometry. Cropping to a larger size from a smaller size causes a FP NaN error.

Cropping by definition should be larger dimensions => smaller dimensions.

This fix raises an InvalidCropGeometryError, which is handled gracefully, instead of an unexpected NaN when cropping from an initial geometry that is smaller than the target geometry.
