### PR TITLE
Allow :fog_public to be set to false and read as false from #fog_public a

### DIFF
--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -68,7 +68,8 @@ module Paperclip
       end
 
       def fog_public
-        @fog_public ||= @options.fog_public || true
+        return @fog_public if defined?(@fog_public)
+        @fog_public = defined?(@options.fog_public) ? @options.fog_public : true
       end
 
       def flush_writes

--- a/test/fog_test.rb
+++ b/test/fog_test.rb
@@ -182,6 +182,7 @@ class FogTest < Test::Unit::TestCase
 
         should 'set the @fog_public instance variable to false' do
           assert_equal false, @dummy.avatar.options.fog_public
+          assert_equal false, @dummy.avatar.fog_public
         end
       end
 


### PR DESCRIPTION
This issue was supposedly fixed in ticket #547, but it did not test the real world usage, the #fog_public accessor. I fixed the test to do that and then the code to pass.
