### PR TITLE
Access the uploaded file beyond the paperclip lifecycle

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -95,7 +95,7 @@ module Paperclip
         uploaded_file = uploaded_file.to_file(:original)
         close_uploaded_file = uploaded_file.respond_to?(:close)
       else
-        instance_write(:uploaded_file, uploaded_file)
+        instance_write(:uploaded_file, uploaded_file) if uploaded_file
       end
 
       return nil unless valid_assignment?(uploaded_file)
@@ -208,7 +208,7 @@ module Paperclip
     def original_filename
       instance_read(:file_name)
     end
-    
+
     # Returns the size of the file as originally assigned, and lives in the
     # <attachment>_file_size attribute of the model.
     def size

--- a/test/attachment_test.rb
+++ b/test/attachment_test.rb
@@ -825,6 +825,10 @@ class AttachmentTest < Test::Unit::TestCase
             assert @attachment.dirty?
           end
 
+          should "set uploaded_file for access beyond the paperclip lifecycle" do
+            assert_equal @file, @attachment.uploaded_file
+          end
+
           context "and saved" do
             setup do
               @attachment.save

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,6 @@
 require 'rubygems'
 require 'tempfile'
+require 'pathname'
 require 'test/unit'
 
 require 'shoulda'


### PR DESCRIPTION
Hy,

I'm reopening #445 with this slightly improved pull request.

@yawn introduced Attachment#uploaded_file in order to access the file that was used to set the attachment via assignment. I've just updated the fork to the latest version of Paperclip and I've added a test that ensures the assignment takes place.

The whole idea is to access the uploaded file conveniently from within the model. This allows for cleaning up files that should not stay within the tmp.

So we can address very specific cleanup issues like this one:

An asynchronous background job bursts a PDF into a file each page. For each file we create a Page record with the pdf as a Paperclip attachment.
Now we have the problem, that all the bursted PDF files stay within the tmp directory until the OS cleans them up. This is especially a problem in environments where we don't have access to those clean up configurations. In our case the tmp directory would quickly fill up, and the server was configured to clean on reboot.

With this small addition we can conveniently clean up those files at the right time.

``` ruby
class Page < ActiveRecord::Base

  belongs_to :booklet
  has_attached_file :pdf
  after_save :cleanup_tmpfile

  protected

  def cleanup_tmpfile
    if pdf.uploaded_file && pdf.uploaded_file.path.starts_with?(Dir.tmpdir)
      File.unlink(pdf.uploaded_file.path)
    end
  end
```

``` ruby
class Booklet < ActiveRecord::Base
  has_many :pages

  def create_pages
    Dir.glob(File.join(burst_directory, '*.pdf') do |path|
      pages.create :pdf => File.open(path)
    end
  end
end
```

Cheers,

Lukas on behalf of Kreuzwerker
