### PR TITLE
Updated S3 configuration tests to create an explicit connection

### DIFF
--- a/test/storage/s3_test.rb
+++ b/test/storage/s3_test.rb
@@ -480,6 +480,7 @@ class S3Test < Test::Unit::TestCase
     end
 
     should "parse the credentials" do
+      assert_kind_of AWS::S3::Connection, @dummy.avatar.send(:establish_connection!)
       assert_equal 'pathname_bucket', @dummy.avatar.bucket_name
       assert_equal 'pathname_key', AWS::S3::Base.connection.options[:access_key_id]
       assert_equal 'pathname_secret', AWS::S3::Base.connection.options[:secret_access_key]
@@ -504,6 +505,7 @@ class S3Test < Test::Unit::TestCase
     end
 
     should "run the file through ERB" do
+      assert_kind_of AWS::S3::Connection, @dummy.avatar.send(:establish_connection!)
       assert_equal 'env_bucket', @dummy.avatar.bucket_name
       assert_equal 'env_key', AWS::S3::Base.connection.options[:access_key_id]
       assert_equal 'env_secret', AWS::S3::Base.connection.options[:secret_access_key]


### PR DESCRIPTION
S3 connections are now created on demand so the S3 credentials had to be manually parsed for this test to succeed.

Finished in 47.156795 seconds.
501 tests, 889 assertions, 0 failures, 0 errors, 0 skips
