### PR TITLE
Allowing access to the raw options hash passed into has_attached_file via Paperclip::Options

### DIFF
--- a/lib/paperclip/options.rb
+++ b/lib/paperclip/options.rb
@@ -51,6 +51,9 @@ module Paperclip
       @fog_host              = hash[:fog_host]
       @fog_public            = hash[:fog_public]
       @fog_file              = hash[:fog_file]
+
+      #access to the raw options hash passed in
+      @raw_options           = hash
     end
 
     def method_missing(method, *args, &blk)


### PR DESCRIPTION
Not having access to the raw hash passed into has_attached_file limits the ability to make clean add-ons to Paperclip.

For instance, consider an add-on like the one that follows that allows for on-demand thumbnail creation (rather than creating all thumbnails at time of attachment):

``` ruby
Paperclip::Attachment.class_eval do
  def thumbnail(style_name)
    # We'll need to be able to access additional options passed into has_attached_file here, maybe like:
    @options.raw_options[:on_demand_styles][:"#{style_name}"]
    # etc...
  end
end
```

And in your model using Paperclip:

``` ruby
has_attached_file   :attachment,
                      :styles => { :large => '1000x1000>'},
                      :on_demand_styles => { :small => "600x600>" }
```

If you need to see more of the code of the add-on to be convinced I can provide that soon. Still putting on the finishing touches but so far it's much smaller than how attachment-on-the-fly has done and it by reusing much more of the internal Paperclip code (such as the built-in thumbnail processor.) It just seems much cleaner to be able to make add-ons this way.
