### PR TITLE
A bottleneck in attachment URL generation

### DIFF
--- a/lib/paperclip/style.rb
+++ b/lib/paperclip/style.rb
@@ -19,6 +19,10 @@ module Paperclip
         @format = definition.delete(:format)
         @processors = definition.delete(:processors)
         @other_args = definition
+      elsif definition.is_a? String
+        @geometry = definition
+        @format = nil
+        @other_args = {}
       else
         @geometry, @format = [definition, nil].flatten[0..1]
         @other_args = {}


### PR DESCRIPTION
The actual diff might seem strange and unrelated to the topic, but in fact it was the root of evil.

I used a profiler ([perftools.rb](https://github.com/tmm1/perftools.rb)) against `Model.all.each { |m| m.file.url }` and here is the result (before this patch):

```
  51 87.9%  87.9% 51 87.9% NilClass#raise_nil_warning_for
   4  6.9%  94.8%  4  6.9% garbage_collector
   2  3.4%  98.3%  2  3.4% IO#read
   1  1.7% 100.0% 52 89.7% NilClass#method_missing
   0  0.0% 100.0% 52 89.7% Array#flatten
```

In plain English it means that 87.9% of time was took by weird calls of `NilClass#raise_nil_warning_for`.
Tough it is quite plausible, calling a missing method is inefficient.

Well, long story short, this issue has been fixed by a small edition in `Paperclip::Style#initialize`.
This is what benchmark look like now:

```
   5 55.6%  55.6% 5 55.6% Enumerable#inject
   2 22.2%  77.8% 2 22.2% garbage_collector
   1 11.1%  88.9% 1 11.1% IO#read
   1 11.1% 100.0% 1 11.1% IO#write
```
