### PR TITLE
Ruby 1.8.7 compatibility for Paperclip::Options property setters

### DIFF
--- a/lib/paperclip/options.rb
+++ b/lib/paperclip/options.rb
@@ -58,7 +58,7 @@ module Paperclip
 
     def method_missing(method, *args, &blk)
       if method.to_s[-1,1] == "="
-        instance_variable_set("@#{method[0..-2]}", args[0])
+        instance_variable_set("@#{method.to_s[0..-2]}", args[0])
       else
         instance_variable_get("@#{method}")
       end


### PR DESCRIPTION
Symbols don't have the `[]` method in 1.8.7.

So you can't do this: `User.avatar.options.processors = [:special_processor_only_for_this_model]`

Patch resolves issue by transforming symbol to string before attempting string slice in `Paperclip::Options#method_missing`.
