### PR TITLE
Fix for rake paperclip:refresh

### DIFF
--- a/lib/tasks/paperclip.rake
+++ b/lib/tasks/paperclip.rake
@@ -47,7 +47,7 @@ namespace :paperclip do
         Paperclip.each_instance_with_attachment(klass, name) do |instance|
           if file = instance.send(name).to_file(:original)
             instance.send("#{name}_file_name=", instance.send("#{name}_file_name").strip)
-            instance.send("#{name}_content_type=", file.content_type.strip)
+            instance.send("#{name}_content_type=", file.content_type.to_s.strip)
             instance.send("#{name}_file_size=", file.size) if instance.respond_to?("#{name}_file_size")
             if Rails.version >= "3.0.0"
               instance.save(:validate => false)


### PR DESCRIPTION
When running rake paperclip:refresh, I receive the error message below.  I noticed that the rest of the paperclip code performed a to_s on the content type before strip was called.

rake aborted!
undefined method `strip' for image/bmp:MIME::Type
/app/.bundle/gems/ruby/1.9.1/gems/paperclip-2.4.5/lib/tasks/paperclip.rake:50:in`block (5 levels) in <top (required)>'
/app/.bundle/gems/ruby/1.9.1/gems/paperclip-2.4.5/lib/paperclip.rb:144:in `block in each_instance_with_attachment'
/app/.bundle/gems/ruby/1.9.1/gems/paperclip-2.4.5/lib/paperclip.rb:143:in`each'
/app/.bundle/gems/ruby/1.9.1/gems/paperclip-2.4.5/lib/paperclip.rb:143:in `each_instance_with_attachment'
/app/.bundle/gems/ruby/1.9.1/gems/paperclip-2.4.5/lib/tasks/paperclip.rake:47:in`block (4 levels) in <top (required)>'
/app/.bundle/gems/ruby/1.9.1/gems/paperclip-2.4.5/lib/tasks/paperclip.rake:46:in `each'
/app/.bundle/gems/ruby/1.9.1/gems/paperclip-2.4.5/lib/tasks/paperclip.rake:46:in`block (3 levels) in <top (required)>'
/app/.bundle/gems/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/task.rb:205:in `call'
/app/.bundle/gems/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/task.rb:205:in`block in execute'
/app/.bundle/gems/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/task.rb:200:in `each'
/app/.bundle/gems/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/task.rb:200:in`execute'
/app/.bundle/gems/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/task.rb:158:in `block in invoke_with_call_chain'
/usr/ruby1.9.2/lib/ruby/1.9.1/monitor.rb:201:in`mon_synchronize'
/app/.bundle/gems/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/task.rb:151:in `invoke_with_call_chain'
/app/.bundle/gems/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/task.rb:176:in`block in invoke_prerequisites'
/app/.bundle/gems/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/task.rb:174:in `each'
/app/.bundle/gems/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/task.rb:174:in`invoke_prerequisites'
/app/.bundle/gems/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/task.rb:157:in `block in invoke_with_call_chain'
/usr/ruby1.9.2/lib/ruby/1.9.1/monitor.rb:201:in`mon_synchronize'
/app/.bundle/gems/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/task.rb:151:in `invoke_with_call_chain'
/app/.bundle/gems/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/task.rb:144:in`invoke'
/app/.bundle/gems/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/application.rb:116:in `invoke_task'
/app/.bundle/gems/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/application.rb:94:in`block (2 levels) in top_level'
/app/.bundle/gems/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/application.rb:94:in `each'
/app/.bundle/gems/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/application.rb:94:in`block in top_level'
/app/.bundle/gems/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/application.rb:133:in `standard_exception_handling'
/app/.bundle/gems/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/application.rb:88:in`top_level'
/app/.bundle/gems/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/application.rb:66:in `block in run'
/app/.bundle/gems/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/application.rb:133:in`standard_exception_handling'
/app/.bundle/gems/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/application.rb:63:in `run'
/app/.bundle/gems/ruby/1.9.1/gems/rake-0.9.2.2/bin/rake:33:in`<top (required)>'
/app/.bundle/gems/ruby/1.9.1/bin/rake:19:in `load'
/app/.bundle/gems/ruby/1.9.1/bin/rake:19:in`<main>'
Tasks: TOP => paperclip:refresh => paperclip:refresh:metadata
