### PR TITLE
Teach missing_attachment_styles.rb how to handle a new attachment in an existing model

### DIFF
--- a/lib/paperclip/missing_attachment_styles.rb
+++ b/lib/paperclip/missing_attachment_styles.rb
@@ -70,7 +70,7 @@ module Paperclip
     Hash.new.tap do |missing_styles|
       current_styles.each do |klass, attachment_definitions|
         attachment_definitions.each do |attachment_name, styles|
-          registered = registered_styles[klass][attachment_name] rescue []
+          registered = registered_styles[klass][attachment_name] || [] rescue []
           missed = styles - registered 
           if missed.present?
             klass_sym = klass.to_s.to_sym

--- a/test/paperclip_missing_attachment_styles_test.rb
+++ b/test/paperclip_missing_attachment_styles_test.rb
@@ -68,6 +68,22 @@ class PaperclipMissingAttachmentStylesTest < Test::Unit::TestCase
       Paperclip.save_current_attachments_styles!
       assert_equal Hash.new, Paperclip.missing_attachments_styles
     end
+    
+    should "be able to calculate differences when a new attachment is added to a model" do
+      rebuild_model :styles => {:croppable => '600x600>', :big => '1000x1000>'}
+      Paperclip.save_current_attachments_styles!
+      
+      class ::Dummy
+        has_attached_file :photo, :styles => {:small => 'x100', :large => '1000x1000>'}
+      end
+      
+      expected_hash = {
+        :Dummy => {:photo => [:large, :small]}
+      }
+      assert_equal expected_hash, Paperclip.missing_attachments_styles
+      Paperclip.save_current_attachments_styles!
+      assert_equal Hash.new, Paperclip.missing_attachments_styles
+    end
 
     # It's impossible to build styles hash without loading from database whole bunch of records
     should "skip lambda-styles" do


### PR DESCRIPTION
This is a one-line fix to handle the case where a model with an existing attachment gains a second attachment, not just new styles on the first attachment. Prior to this fix, running "rake paperclip:refresh:missing_styles" generated a crash (TypeError: can't convert nil into Array).

The pull request includes a couple of other commits from a discussion last November that was resolved on Paperclip's master branch in a cleaner way. The merge commit (HEAD^) resolves this difference, so this pull really only deals with the newest commit for the missing styles issue.
