### PR TITLE
AWS IAM STS compatibility

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -175,7 +175,7 @@ module Paperclip
             config[:proxy_uri] = URI::HTTP.build(proxy_opts)
           end
 
-          [:access_key_id, :secret_access_key].each do |opt|
+          [:access_key_id, :secret_access_key, :session_token].each do |opt|
             config[opt] = s3_credentials[opt] if s3_credentials[opt]
           end
 


### PR DESCRIPTION
Lots of acronyms, but a tiny change. Passes :session_token to AWS::S3.new if it's provided in the s3_credentials hash. Allows for federated STS users.
