### PR TITLE
Don't calculate fingerprint when fingerprint can not be stored.

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -106,12 +106,12 @@ module Paperclip
       return nil if uploaded_file.nil?
 
       uploaded_filename ||= uploaded_file.original_filename
-      stores_fingerprint = @instance.respond_to?("#{name}_fingerprint".to_sym)
+      stores_fingerprint             = @instance.respond_to?("#{name}_fingerprint".to_sym)
       @queued_for_write[:original]   = to_tempfile(uploaded_file)
       instance_write(:file_name,       uploaded_filename.strip)
       instance_write(:content_type,    uploaded_file.content_type.to_s.strip)
       instance_write(:file_size,       uploaded_file.size.to_i)
-      instance_write(:fingerprint,     stores_fingerprint ? generate_fingerprint(uploaded_file) : false)
+      instance_write(:fingerprint,     generate_fingerprint(uploaded_file)) if stores_fingerprint
       instance_write(:updated_at,      Time.now)
 
       @dirty = true
@@ -254,7 +254,13 @@ module Paperclip
     # Returns the hash of the file as originally assigned, and lives in the
     # <attachment>_fingerprint attribute of the model.
     def fingerprint
-      instance_read(:fingerprint) || (@queued_for_write[:original] && generate_fingerprint(@queued_for_write[:original]))
+      if instance_read(:fingerprint)
+        instance_read(:fingerprint)
+      elsif @instance.respond_to?("#{name}_fingerprint".to_sym)
+        @queued_for_write[:original] && generate_fingerprint(@queued_for_write[:original])
+      else
+        nil
+      end
     end
 
     # Returns the content_type of the file as originally assigned, and lives

--- a/test/attachment_test.rb
+++ b/test/attachment_test.rb
@@ -998,10 +998,14 @@ class AttachmentTest < Test::Unit::TestCase
       end
     end
     
-    should "not calculate fingerprint without fingerprint column" do
-      assert_equal false, @dummy.respond_to?(:avatar_fingerprint)
+    should "not calculate fingerprint after save" do
       @dummy.avatar = @file
       @dummy.save
+      assert_nil @dummy.avatar.fingerprint
+    end
+    
+    should "not calculate fingerprint before saving" do
+      @dummy.avatar = @file
       assert_nil @dummy.avatar.fingerprint
     end
     


### PR DESCRIPTION
Only calculate an attachment fingerprint when the instance can store the result. Per #357 : Don't fingerprint when there is no fingerprint column.
