### PR TITLE
save content type of the file in s3 metadata with fog storage engine

### DIFF
--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -80,9 +80,10 @@ module Paperclip
           retried = false
           begin
             directory.files.create(fog_file.merge(
-              :body   => file,
-              :key    => path(style),
-              :public => fog_public
+              :body         => file,
+              :key          => path(style),
+              :public       => fog_public,
+              :content_type => file.content_type.to_s.strip
             ))
           rescue Excon::Errors::NotFound
             raise if retried

--- a/test/storage/fog_test.rb
+++ b/test/storage/fog_test.rb
@@ -110,6 +110,13 @@ class FogTest < Test::Unit::TestCase
         directory.destroy
       end
 
+      should "pass the content type to the Fog::Storage::AWS::Files instance" do
+        Fog::Storage::AWS::Files.any_instance.expects(:create).with do |hash|
+          hash[:content_type]
+        end
+        @dummy.save
+      end
+
       context "without a bucket" do
         setup do
           @connection.directories.get(@fog_directory).destroy


### PR DESCRIPTION
This is actually a duplicate of pull request #551, with an added test.
