### PR TITLE
Add i18n support for attachment size validator

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -41,6 +41,7 @@ require 'paperclip/storage'
 require 'paperclip/callback_compatibility'
 require 'paperclip/missing_attachment_styles'
 require 'paperclip/railtie'
+require 'paperclip/validations'
 require 'logger'
 require 'cocaine'
 
@@ -232,6 +233,8 @@ module Paperclip
   end
 
   module ClassMethods
+    include Validations::HelperMethods
+
     # +has_attached_file+ gives the class it is called on an attribute that maps to a file. This
     # is typically a file stored somewhere on the filesystem and has been uploaded by a user.
     # The attribute returns a Paperclip::Attachment object which handles the management of
@@ -352,31 +355,6 @@ module Paperclip
         attachment = record.attachment_for(name)
         attachment.send(:flush_errors)
       end
-    end
-
-    # Places ActiveRecord-style validations on the size of the file assigned. The
-    # possible options are:
-    # * +in+: a Range of bytes (i.e. +1..1.megabyte+),
-    # * +less_than+: equivalent to :in => 0..options[:less_than]
-    # * +greater_than+: equivalent to :in => options[:greater_than]..Infinity
-    # * +message+: error message to display, use :min and :max as replacements
-    # * +if+: A lambda or name of an instance method. Validation will only
-    #   be run if this lambda or method returns true.
-    # * +unless+: Same as +if+ but validates if lambda or method returns false.
-    def validates_attachment_size name, options = {}
-      min     = options[:greater_than] || (options[:in] && options[:in].first) || 0
-      max     = options[:less_than]    || (options[:in] && options[:in].last)  || (1.0/0)
-      range   = (min..max)
-      message = options[:message] || "file size must be between :min and :max bytes"
-      message = message.call if message.respond_to?(:call)
-      message = message.gsub(/:min/, min.to_s).gsub(/:max/, max.to_s)
-
-      validates_inclusion_of :"#{name}_file_size",
-                             :in        => range,
-                             :message   => message,
-                             :if        => options[:if],
-                             :unless    => options[:unless],
-                             :allow_nil => true
     end
 
     # Adds errors if thumbnail creation fails. The same as specifying :whiny_thumbnails => true.

--- a/lib/paperclip/validations.rb
+++ b/lib/paperclip/validations.rb
@@ -1,0 +1,8 @@
+require "paperclip/validations/attachment_size_validator"
+
+module Paperclip
+  module Validations
+    module HelperMethods
+    end
+  end
+end

--- a/lib/paperclip/validations/attachment_size_validator.rb
+++ b/lib/paperclip/validations/attachment_size_validator.rb
@@ -1,0 +1,88 @@
+module Paperclip
+  module Validations
+    class AttachmentSizeValidator < ActiveModel::EachValidator
+      CHECKS = {:greater_than => :>=, :less_than => :<=}.freeze
+      RESERVED_OPTIONS = [:greater_than, :less_than, :in, :within].freeze
+
+      def initialize(options)
+        if range = options.delete(:in) || options.delete(:within)
+          unless range.is_a?(Range)
+            raise ArgumentError, ":in and :within must be a Range"
+          end
+
+          options[:greater_than], options[:less_than] = range.min, range.max
+        end
+
+        options[:greater_than] ||= 0
+        options[:less_than]    ||= 1024**3 # 1 GB
+
+        super
+      end
+
+      private
+
+      def validate_each(record, attribute, value)
+        return if value.nil?
+
+        CHECKS.each do |key, validity_check|
+          next unless check_value = options[key]
+          next if value.send(validity_check, check_value)
+
+          error_options = options.except(*RESERVED_OPTIONS)
+          record.errors.add(attribute, error_message, error_options)
+
+          break
+        end
+      end
+
+      def check_validity!
+        keys = CHECKS.keys & options.keys
+
+        if keys.empty?
+          raise ArgumentError, "Range unspecified. Specify the :in, :within, :greated_than or :less_than option."
+        end
+
+        keys.each do |key|
+          value = options[key]
+
+          unless value.is_a?(Integer) && value >= 0
+            raise ArgumentError, ":#{key} must be a nonnegative Integer"
+          end
+        end
+      end
+
+      def error_message
+        min, max = options[:greater_than], options[:less_than]
+
+        message = options[:message]
+        message = message.call if message.respond_to?(:call)
+        message ||= I18n.translate(:size,
+          :scope => [:paperclip, :errors],
+          :min => min,
+          :max => max,
+          :default => "file size must be between #{min} and #{max} bytes"
+        )
+        message.gsub(/:min/, min.to_s).gsub(/:max/, max.to_s)
+      end
+    end
+
+    module HelperMethods
+      # Places ActiveRecord-style validations on the size of the file assigned. The
+      # possible options are:
+      # * +in+: a Range of bytes (i.e. +1..1.megabyte+),
+      # * +less_than+: equivalent to :in => 0..options[:less_than]
+      # * +greater_than+: equivalent to :in => options[:greater_than]..Infinity
+      # * +message+: error message to display, use :min and :max as replacements
+      # * +if+: A lambda or name of an instance method. Validation will only
+      #   be run if this lambda or method returns true.
+      # * +unless+: Same as +if+ but validates if lambda or method returns false.
+      def validates_attachment_size(*attr_names)
+        options = attr_names.extract_options!
+        attr_names = attr_names.map {|name| "#{name}_file_size"}
+        options = options.merge(:attributes => attr_names)
+
+        validates_with AttachmentSizeValidator, options
+      end
+    end
+  end
+end

--- a/test/attachment_size_validator_test.rb
+++ b/test/attachment_size_validator_test.rb
@@ -1,0 +1,153 @@
+require './test/helper'
+
+class AttachmentSizeValidatorTest < Test::Unit::TestCase
+  context "Model with size validation" do
+    setup do
+      rebuild_model
+      Dummy.has_attached_file :avatar
+    end
+
+    context "without a file" do
+      setup do
+        Dummy.validates_attachment_size :avatar, :less_than => 10240
+      end
+
+      should "be valid" do
+        assert Dummy.new.valid?
+      end
+    end
+
+    context "for files below 10240 bytes" do
+      setup do
+        Dummy.validates_attachment_size :avatar, :less_than => 10240
+      end
+
+      should "be valid when size is below 10240 bytes" do
+        assert Dummy.new(:avatar_file_size => 512).valid?
+      end
+
+      should "be invalid when too large file" do
+        assert !Dummy.new(:avatar_file_size => 12345).valid?
+      end
+    end
+
+    context "for files above 100 bytes" do
+      setup do
+        Dummy.validates_attachment_size :avatar, :greater_than => 100
+      end
+
+      should "be valid when size is above 100 bytes" do
+        assert Dummy.new(:avatar_file_size => 512).valid?
+      end
+
+      should "be invalid when too small file" do
+        assert !Dummy.new(:avatar_file_size => 32).valid?
+      end
+    end
+
+    context "for files between 100 and 200 bytes" do
+      setup do
+        Dummy.validates_attachment_size :avatar, :in => 100..200
+      end
+
+      should "be valid when size is 150 bytes" do
+        assert Dummy.new(:avatar_file_size => 150).valid?
+      end
+
+      should "be invalid when too small file" do
+        assert !Dummy.new(:avatar_file_size => 50).valid?
+      end
+
+      should "be invalid when too large file" do
+        assert !Dummy.new(:avatar_file_size => 300).valid?
+      end
+    end
+
+    context "when conditional" do
+      context "using if clause" do
+        setup do
+          Dummy.send :attr_accessor, :should_validate
+          Dummy.validates_attachment_size :avatar,
+            :in => 100..200, :if => :should_validate
+          @dummy = Dummy.new(:avatar_file_size => 1)
+        end
+
+        should "not validate when false" do
+          @dummy.should_validate = false
+          assert @dummy.valid?
+        end
+
+        should "validate when true" do
+          @dummy.should_validate = true
+          assert !@dummy.valid?
+        end
+      end
+
+      context "using unless clause" do
+        setup do
+          Dummy.send :attr_accessor, :should_not_validate
+          Dummy.validates_attachment_size :avatar,
+            :in => 100..200, :unless => :should_not_validate
+          @dummy = Dummy.new(:avatar_file_size => 1)
+        end
+
+        should "not validate when true" do
+          @dummy.should_not_validate = true
+          assert @dummy.valid?
+        end
+
+        should "validate when false" do
+          @dummy.should_not_validate = false
+          assert !@dummy.valid?
+        end
+      end
+    end
+  end
+
+  context "(error messages)" do
+    setup do
+      rebuild_model
+    end
+
+    should "show default error message" do
+      Dummy.validates_attachment_size :avatar, :in => (100..200)
+      @dummy = Dummy.new(:avatar_file_size => 1)
+      @dummy.valid?
+
+      messages = @dummy.errors[:avatar_file_size]
+      assert_equal ["file size must be between 100 and 200 bytes"], messages
+    end
+
+    should "show custom error message when set in the model" do
+      Dummy.validates_attachment_size :avatar, :in => (100..200),
+        :message => "keep it between :min and :max bytes"
+      @dummy = Dummy.new(:avatar_file_size => 1)
+      @dummy.valid?
+
+      messages = @dummy.errors[:avatar_file_size]
+      assert_equal ["keep it between 100 and 200 bytes"], messages
+    end
+
+    should "show lambda error message when set in the model" do
+      Dummy.validates_attachment_size :avatar, :in => (100..200),
+        :message => lambda {"keep it between :min and :max bytes"}
+      @dummy = Dummy.new(:avatar_file_size => 1)
+      @dummy.valid?
+
+      messages = @dummy.errors[:avatar_file_size]
+      assert_equal ["keep it between 100 and 200 bytes"], messages
+    end
+
+    should "show i18n message" do
+      I18n.backend.store_translations(:en,
+        :paperclip => {:errors => {:size => "keep it between %{min} and %{max} bytes"}}
+      )
+      Dummy.validates_attachment_size :avatar, :in => (100..200)
+      @dummy = Dummy.new(:avatar_file_size => 1)
+      @dummy.valid?
+
+      messages = @dummy.errors[:avatar_file_size]
+      assert_equal ["keep it between 100 and 200 bytes"], messages
+    end
+  end
+end


### PR DESCRIPTION
This is my initial pull request for i18n support. I moved attachment size validations to a separate validator, added i18n support and added a separate test file for it. 

I'd like to get some feedback about this. If everything is good, then I'll start converting other validators.
