### PR TITLE
In the effort of decoupling Rails from unit specs, you can't have any co...

### DIFF
--- a/lib/paperclip/railtie.rb
+++ b/lib/paperclip/railtie.rb
@@ -18,6 +18,8 @@ module Paperclip
 
   class Railtie
     def self.insert
+      Paperclip.options[:logger] = Rails.logger if defined?(Rails)
+      
       if defined?(ActiveRecord)
         ActiveRecord::Base.send(:include, Paperclip::Glue)
         Paperclip.options[:logger] = ActiveRecord::Base.logger
@@ -25,8 +27,6 @@ module Paperclip
         ActiveRecord::ConnectionAdapters::AbstractAdapter.send(:include, Paperclip::Schema)
         ActiveRecord::ConnectionAdapters::Table.send(:include, Paperclip::Schema)
         ActiveRecord::ConnectionAdapters::TableDefinition.send(:include, Paperclip::Schema)
-      else
-        Paperclip.options[:logger] = Rails.logger
       end
 
       File.send(:include, Paperclip::Upfile)


### PR DESCRIPTION
...de that calls `Rails` (since it isn't available). In my unit specs that need Paperclip, I call `Paperclip::Railtie.insert` and all is good :)
