### PR TITLE
The default :url option is very dangerous.

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -25,7 +25,7 @@ module Paperclip
         :source_file_options   => {},
         :storage               => :filesystem,
         :styles                => {},
-        :url                   => "/system/:attachment/:id/:style/:filename",
+        :url                   => "/system/:class/:id/:attachment/:style/:filename",
         :url_generator         => Paperclip::UrlGenerator,
         :use_default_time_zone => true,
         :use_timestamp         => true,


### PR DESCRIPTION
 I am unsure if I am missing anything?

Without my proposed change, it will quite possibly destroy uploads already present on the system.
Simply adding the :class in there prevents this. Also I moved the :id to the front sice this is the logical hierarchy.
