### PR TITLE
Remove unnecessary mv/unlink from Filesystem#flush_writes

### DIFF
--- a/lib/paperclip/storage/filesystem.rb
+++ b/lib/paperclip/storage/filesystem.rb
@@ -38,12 +38,7 @@ module Paperclip
           file.close
           FileUtils.mkdir_p(File.dirname(path(style_name)))
           log("saving #{path(style_name)}")
-          begin
-            FileUtils.mv(file.path, path(style_name))
-          rescue SystemCallError
-            FileUtils.cp(file.path, path(style_name))
-            FileUtils.rm(file.path)
-          end
+          FileUtils.cp(file.path, path(style_name))
           FileUtils.chmod(0666&~File.umask, path(style_name))
         end
 

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -81,8 +81,6 @@ class IntegrationTest < Test::Unit::TestCase
         original.close
         tf.rewind
 
-        File.expects(:unlink).with(tf.instance_variable_get(:@tmpname))
-
         @d2.avatar.expects(:to_file).with(:original).returns(tf)
 
         @d2.avatar.reprocess!


### PR DESCRIPTION
This is handled by the after_flush_writes command and moving/unlinking the file can make it difficult to recover some unlikely failure modes.
