### PR TITLE
Allow presence of s3 url encoded keys 

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -194,7 +194,7 @@ module Paperclip
       end
 
       def s3_object style_name = default_style
-        s3_bucket.objects[path(style_name).sub(%r{^/},'')]
+        s3_bucket.objects[URI.escape(path(style_name).sub(%r{^/},''))]
       end
 
       def using_http_proxy?


### PR DESCRIPTION
Hi there, 
here is my solution to this issue: 

https://github.com/thoughtbot/paperclip/issues/735

I think it's a simple yet clean way to allow people to use paperclip to deal with their existing S3 file base. It does not break existing functionality neither it changes the default behavior. It's just an under the hood additional feature. I made my app run with it and it resolves my problem.
