### PR TITLE
Paperclip#run now respects swallow_stderr setting. Fix for #741

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -99,6 +99,7 @@ module Paperclip
       command_path = options[:command_path] || options[:image_magick_path]
       Cocaine::CommandLine.path = ( Cocaine::CommandLine.path ? [Cocaine::CommandLine.path, command_path ].flatten : command_path )
       local_options = local_options.merge(:logger => logger) if logging? && (options[:log_command] || local_options[:log_command])
+      local_options = local_options.merge(:swallow_stderr => options[:swallow_stderr]) if !local_options[:swallow_stderr] && !options[:swallow_stderr].nil?
       Cocaine::CommandLine.new(cmd, arguments, local_options).run
     end
 

--- a/test/paperclip_test.rb
+++ b/test/paperclip_test.rb
@@ -4,6 +4,7 @@ class PaperclipTest < Test::Unit::TestCase
   context "Calling Paperclip.run" do
     setup do
       Paperclip.options[:log_command] = false
+      Paperclip.options[:swallow_stderr] = nil
       Cocaine::CommandLine.expects(:new).with("convert", "stuff", {}).returns(stub(:run))
       @original_command_line_path = Cocaine::CommandLine.path
     end
@@ -21,6 +22,18 @@ class PaperclipTest < Test::Unit::TestCase
       Cocaine::CommandLine.path = "/opt/my_app/bin"
       Paperclip.run("convert", "stuff")
       assert_equal [Cocaine::CommandLine.path].flatten.include?("/opt/my_app/bin"), true
+    end
+
+    should "respect Paperclip.options[:swallow_stderr]" do
+      Paperclip.options[:swallow_stderr] = false
+      Cocaine::CommandLine.unstub(:new)
+      Cocaine::CommandLine.expects(:new).with("convert", "stuff", {:swallow_stderr => false}).returns(stub(:run))
+      Paperclip.run("convert", "stuff")
+
+      Paperclip.options[:swallow_stderr] = true
+      Cocaine::CommandLine.unstub(:new)
+      Cocaine::CommandLine.expects(:new).with("convert", "stuff", {:swallow_stderr => true}).returns(stub(:run))
+      Paperclip.run("convert", "stuff")
     end
   end
 


### PR DESCRIPTION
Paperclip will now merge in the swallow_stderr option when calling Cocaine::CommandLine.new in Paperclip#run.

Not overriding swallow_stderr if it is passed in to Paperclip#run.
