### PR TITLE
Check file existence in Storage::Fog#to_file.

### DIFF
--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -112,7 +112,7 @@ module Paperclip
         if @queued_for_write[style]
           @queued_for_write[style].rewind
           @queued_for_write[style]
-        else
+        elsif exists?(style)
           body      = directory.files.get(path(style)).body
           filename  = path(style)
           extname   = File.extname(filename)


### PR DESCRIPTION
Storage::Fog#to_file doesn't currently check if the file exists before
trying to download it with Fog. This is contrary to the behavior of
Storage::Filesystem#to_file, and causes errors when assigning in
Attachment#assign.

I believe that there is a similar issue in Storage::S3.
