### PR TITLE
Removes the redundant term "file size"

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -373,7 +373,7 @@ module Paperclip
       min     = options[:greater_than] || (options[:in] && options[:in].first) || 0
       max     = options[:less_than]    || (options[:in] && options[:in].last)  || (1.0/0)
       range   = (min..max)
-      message = options[:message] || "file size must be between :min and :max bytes"
+      message = options[:message] || "must be between :min and :max bytes"
       message = message.call if message.respond_to?(:call)
       message = message.gsub(/:min/, min.to_s).gsub(/:max/, max.to_s)
 


### PR DESCRIPTION
`validates_attachment_size` calls:

```
  message = options[:message] || "file size must be between :min and :max bytes"
  validates_inclusion_of :"#{name}_file_size",
                         :in        => range,
                         :message   => message,
                         :if        => options[:if],
                         :unless    => options[:unless],
                         :allow_nil => true
```

This creates an error message that looks like this:

`file size file size must be between....`

This removes the redundant "file size" from message.
