### PR TITLE
Prevents a file name from becoming blank when :restricted_characters => nil

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -482,6 +482,8 @@ module Paperclip
     def cleanup_filename(filename)
       if @options[:restricted_characters]
         filename.gsub(@options[:restricted_characters], '_')
+      else
+        filename
       end
     end
   end


### PR DESCRIPTION
# cleanup_filename return nil when :restricted_characters is nil.

(I think that passing nil means `not restricted'.)
