### PR TITLE
rewind files in flush_writes method of s3 and fog storage

### DIFF
--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -77,6 +77,7 @@ module Paperclip
       def flush_writes
         for style, file in @queued_for_write do
           log("saving #{path(style)}")
+          file.rewind
           retried = false
           begin
             directory.files.create(fog_file.merge(

--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -281,6 +281,7 @@ module Paperclip
         @queued_for_write.each do |style, file|
           begin
             log("saving #{path(style)}")
+            file.rewind
             acl = @s3_permissions[style] || @s3_permissions[:default]
             acl = acl.call(self, style) if acl.respond_to?(:call)
             write_options = {

--- a/test/storage/fog_test.rb
+++ b/test/storage/fog_test.rb
@@ -115,7 +115,12 @@ class FogTest < Test::Unit::TestCase
         @dummy.avatar.to_file.seek(10)
         assert_equal 0, @dummy.avatar.to_file.pos
       end
-            
+
+      should "rewind file in flush_writes" do
+        @dummy.avatar.queued_for_write.each { |style, file| file.expects(:rewind).with() }
+        @dummy.save
+      end
+
       should "pass the content type to the Fog::Storage::AWS::Files instance" do
         Fog::Storage::AWS::Files.any_instance.expects(:create).with do |hash|
           hash[:content_type]

--- a/test/storage/s3_test.rb
+++ b/test/storage/s3_test.rb
@@ -341,7 +341,13 @@ class S3Test < Test::Unit::TestCase
         @dummy.avatar.to_file.seek(10)
         assert_equal 0, @dummy.avatar.to_file.pos
       end
+
+    should "rewind file in flush_writes" do
+      @dummy.avatar.queued_for_write.each { |style, file| file.expects(:rewind).with() }
+      @dummy.save
     end
+
+  end
 
   context "Generating a secure url with an expiration" do
     setup do


### PR DESCRIPTION
Attachments that have been read by methods such as validators could have their read position changed, this will rewind so the entire file will be saved properly. 
