### PR TITLE
content_type for different styles

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -266,8 +266,8 @@ module Paperclip
 
     # Returns the content_type of the file as originally assigned, and lives
     # in the <attachment>_content_type attribute of the model.
-    def content_type
-      instance_read(:content_type)
+    def content_type(style=nil)
+      style ? MIME::Types.type_for(path(style)).first.content_type : instance_read(:content_type)
     end
 
     # Returns the last modified time of the file as originally assigned, and


### PR DESCRIPTION
Hi there
I've made a patch, I've added a parameter to Attachment#content_type to enable asking for the content_type of different styles.
Example:

  def show
    send_file @user.avatar.path(:thumb), :type => @user.avatar.content_type(:thumb)
  end
