### PR TITLE
Do not add duplicate paths to Cocaine::CommandLine.path for each run.

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -93,7 +93,7 @@ module Paperclip
     #
     def run(cmd, arguments = "", local_options = {})
       command_path = options[:command_path]
-      Cocaine::CommandLine.path = ( Cocaine::CommandLine.path ? [Cocaine::CommandLine.path, command_path ].flatten : command_path )
+      Cocaine::CommandLine.path = ( Cocaine::CommandLine.path ? [Cocaine::CommandLine.path].flatten | [command_path] : command_path )
       local_options = local_options.merge(:logger => logger) if logging? && (options[:log_command] || local_options[:log_command])
       Cocaine::CommandLine.new(cmd, arguments, local_options).run
     end

--- a/test/paperclip_test.rb
+++ b/test/paperclip_test.rb
@@ -22,6 +22,15 @@ class PaperclipTest < Test::Unit::TestCase
       Paperclip.run("convert", "stuff")
       assert_equal [Cocaine::CommandLine.path].flatten.include?("/opt/my_app/bin"), true
     end
+
+    should "not duplicate Cocaine::CommandLine.path on multiple runs" do
+      Cocaine::CommandLine.expects(:new).with("convert", "more_stuff", {}).returns(stub(:run))
+      Cocaine::CommandLine.path = nil
+      Paperclip.options[:command_path] = "/opt/my_app/bin"
+      Paperclip.run("convert", "stuff")
+      Paperclip.run("convert", "more_stuff")
+      assert_equal 1, [Cocaine::CommandLine.path].flatten.size
+    end
   end
 
   context "Calling Paperclip.run with a logger" do


### PR DESCRIPTION
When you set Paperclip.options[:command_path] and then call run multiple times, the path gets appended to Cocaine::CommandLine.path each time. This change keeps the path from being duplicated.
