### PR TITLE
Refreshing thumbnails on large datasets fails, this fixes it by iterating through them in batches

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -138,7 +138,7 @@ module Paperclip
     def each_instance_with_attachment(klass, name)
       unscope_method = class_for(klass).respond_to?(:unscoped) ? :unscoped : :with_exclusive_scope
       class_for(klass).send(unscope_method) do
-        class_for(klass).find(:all, :order => 'id').each do |instance|
+        class_for(klass).find_each do |instance|
           yield(instance) if instance.send(:"#{name}?")
         end
       end


### PR DESCRIPTION
Uses find_each instead of find(:all) to select records in a large dataset in batches of 1000 to avoid timeouts.
