### PR TITLE
Make sure Paperclip doesn't fail when using a numeric style name

### DIFF
--- a/lib/paperclip/interpolations.rb
+++ b/lib/paperclip/interpolations.rb
@@ -93,7 +93,7 @@ module Paperclip
     # If the style has a format defined, it will return the format instead
     # of the actual extension.
     def extension attachment, style_name
-      ((style = attachment.styles[style_name.to_sym]) && style[:format]) ||
+      ((style = attachment.styles[style_name.to_s.to_sym]) && style[:format]) ||
         File.extname(attachment.original_filename).gsub(/^\.+/, "")
     end
 

--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -95,7 +95,7 @@ module Paperclip
           @s3_permissions = set_permissions(@options[:s3_permissions])
           @s3_protocol    = @options[:s3_protocol]    ||
             Proc.new do |style, attachment|
-              permission  = (@s3_permissions[style.to_sym] || @s3_permissions[:default])
+              permission  = (@s3_permissions[style.to_s.to_sym] || @s3_permissions[:default])
               permission  = permission.call(attachment, style) if permission.is_a?(Proc)
               (permission == :public_read) ? 'http' : 'https'
             end


### PR DESCRIPTION
Here's a simplistic patch that lets me use numeric style names. It would probably be better to deal with this higher up the chain, since any new code that simply adds style.to_sym will fail again in the future. But I'm not familiar enough with the code base to do it cleanly.
