### PR TITLE
Table name interpolation

### DIFF
--- a/lib/paperclip/interpolations.rb
+++ b/lib/paperclip/interpolations.rb
@@ -84,6 +84,15 @@ module Paperclip
       attachment.instance.class.to_s.underscore.pluralize
     end
 
+    # Returns the table_name of the class.
+    #
+    # following Rails' defaults, this would be "users" for the User class or
+    # "admin_users" for the Admin::User class.  In the end, this is entirely
+    # up to the corresponding model, of course.
+    def table_name attachment = nil, style_name = nil
+      attachment.instance.class.table_name
+    end
+
     # Returns the basename of the file. e.g. "file" for "file.jpg"
     def basename attachment, style_name
       attachment.original_filename.gsub(/#{Regexp.escape(File.extname(attachment.original_filename))}$/, "")

--- a/test/interpolations_test.rb
+++ b/test/interpolations_test.rb
@@ -30,6 +30,16 @@ class InterpolationsTest < Test::Unit::TestCase
     assert_equal "things", Paperclip::Interpolations.class(attachment, :style)
   end
 
+  should "return the table_name of the instance" do
+    attachment = mock
+    klass = mock
+    attachment.expects(:instance).returns(attachment)
+    attachment.expects(:class).returns(klass)
+    klass.stubs(:to_s).returns("Namespaced::Thing")
+    klass.expects(:table_name).returns("namespaced_things")
+    assert_equal "namespaced_things", Paperclip::Interpolations.table_name(attachment, :style)
+  end
+
   should "return the basename of the file" do
     attachment = mock
     attachment.expects(:original_filename).returns("one.jpg").times(2)


### PR DESCRIPTION
As the table_name can be different from the pluralized class_name, I added as specific interpolation. (both make sense, though, in an STI-setting).

Basically, the patch just make interpolating "by hand" unnecessary and gives paperclip knowledge that there is a table_specific setting (though it looks the same across several models).
