### PR TITLE
Current validation check in AttachmentContentTypeValidator is wrong

### DIFF
--- a/lib/paperclip/validators/attachment_content_type_validator.rb
+++ b/lib/paperclip/validators/attachment_content_type_validator.rb
@@ -6,13 +6,11 @@ module Paperclip
         value = record.send(:read_attribute_for_validation, attribute)
         allowed_types = [options[:content_type]].flatten
 
-        unless value.blank?
-          allowed_types.any? do |type|
-            unless type === value
-              record.errors.add(attribute, :invalid, options.merge(
-                :types => allowed_types.join(', ')
-              ))
-            end
+        if value.present? 
+          unless allowed_types.any? { |type| type === value }
+            record.errors.add(attribute, :invalid, options.merge(
+              :types => allowed_types.join(', ')
+            ))
           end
         end
       end

--- a/test/validators/attachment_content_type_validator_test.rb
+++ b/test/validators/attachment_content_type_validator_test.rb
@@ -48,6 +48,18 @@ class AttachmentContentTypeValidatorTest < Test::Unit::TestCase
         assert @dummy.errors[:avatar_content_type].blank?
       end
     end
+    
+    context "as a list" do
+      setup do
+        build_validator :content_type => ["image/png", "image/jpg", "image/jpeg"]
+        @dummy.stubs(:avatar_content_type => "image/jpg")
+        @validator.validate(@dummy)
+      end
+
+      should "not set an error message" do
+        assert @dummy.errors[:avatar_content_type].blank?
+      end
+    end
   end
 
   context "with a disallowed type" do


### PR DESCRIPTION
Current validation check in AttachmentContentTypeValidator is simply wrong, it will add an error if any of the allowed_types fails comparison with value, so it will pass only if value is either empty or equals to each and every one of allowed_types.

Test suite on this validator uses only a single element as :allowed_types everywhere, so this error wasn't detected.
I've added a test to check this specific behavior.
