### PR TITLE
up/down methods convention in Rails migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,14 @@ In your model:
 
 In your migrations:
 
-    class AddAvatarColumnsToUser < ActiveRecord::Migration
-      def self.up
+    class AddAvatarColumnsToUsers < ActiveRecord::Migration
+      def up
         change_table :users do |t|
           t.has_attached_file :avatar
         end
       end
 
-      def self.down
+      def down
         drop_attached_file :users, :avatar
       end
     end
@@ -323,11 +323,11 @@ has an attribute named fingerprint.  Following the user model migration example
 above, the migration would look like the following.
 
     class AddAvatarFingerprintColumnToUser < ActiveRecord::Migration
-      def self.up
+      def up
         add_column :users, :avatar_fingerprint, :string
       end
 
-      def self.down
+      def down
         remove_column :users, :avatar_fingerprint
       end
     end

--- a/generators/paperclip/templates/paperclip_migration.rb.erb
+++ b/generators/paperclip/templates/paperclip_migration.rb.erb
@@ -1,5 +1,5 @@
 class <%= migration_name %> < ActiveRecord::Migration
-  def self.up
+  def up
 <% attachments.each do |attachment| -%>
     add_column :<%= class_name.underscore.camelize.tableize %>, :<%= attachment %>_file_name, :string
     add_column :<%= class_name.underscore.camelize.tableize %>, :<%= attachment %>_content_type, :string
@@ -8,7 +8,7 @@ class <%= migration_name %> < ActiveRecord::Migration
 <% end -%>
   end
 
-  def self.down
+  def down
 <% attachments.each do |attachment| -%>
     remove_column :<%= class_name.underscore.camelize.tableize %>, :<%= attachment %>_file_name
     remove_column :<%= class_name.underscore.camelize.tableize %>, :<%= attachment %>_content_type

--- a/lib/generators/paperclip/templates/paperclip_migration.rb.erb
+++ b/lib/generators/paperclip/templates/paperclip_migration.rb.erb
@@ -1,5 +1,5 @@
 class <%= migration_class_name %> < ActiveRecord::Migration
-  def self.up
+  def up
 <% attachment_names.each do |attachment| -%>
     add_column :<%= name.underscore.camelize.tableize %>, :<%= attachment %>_file_name, :string
     add_column :<%= name.underscore.camelize.tableize %>, :<%= attachment %>_content_type, :string
@@ -8,7 +8,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration
 <% end -%>
   end
 
-  def self.down
+  def down
 <% attachment_names.each do |attachment| -%>
     remove_column :<%= name.underscore.camelize.tableize %>, :<%= attachment %>_file_name
     remove_column :<%= name.underscore.camelize.tableize %>, :<%= attachment %>_content_type


### PR DESCRIPTION
I just noticed that in the README, the sample code for Rails migration still uses the Class methods (self.up/self.down) instead of simply just the instance methods (up/down). I updated the 2 code blocks in README, as well as the 2 generator templates in the source code.

I'm not exactly sure why there are 2 templates in the source code. But it seems to me the one under lib/ is somewhat incomplete (USAGE is not descriptive).

Lastly, I think the standard in Rails migration class naming is to refer to the table name instead of the model class name (e.g. AddSomeColumnToUsers refer to table name, while AddSomeColumnToUser refers to the model class name). I didn't change this in my commit because other people may not agree with this.
