### PR TITLE
Pluralize generated migration class and file name.

### DIFF
--- a/lib/generators/paperclip/paperclip_generator.rb
+++ b/lib/generators/paperclip/paperclip_generator.rb
@@ -19,7 +19,7 @@ class PaperclipGenerator < ActiveRecord::Generators::Base
   protected
 
   def migration_name
-    "add_attachment_#{attachment_names.join("_")}_to_#{name.underscore}"
+    "add_attachment_#{attachment_names.join("_")}_to_#{name.underscore.pluralize}"
   end
 
   def migration_file_name


### PR DESCRIPTION
As discussed in #815, migration class name should be pluralized. This change also pluralizes the file name for consistency.
