### PR TITLE
Add expiring_url next to public_url to Fog Storage for S3

### DIFF
--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -120,7 +120,7 @@ module Paperclip
         end
       end
 
-      def expiring_url(time = 3600, style = default_style)
+      def expiring_url(time = (Time.now + 3600), style = default_style)
         expiring_url = directory.files.get_http_url(path(style), time)
 
         if @options[:fog_host]
@@ -159,12 +159,7 @@ module Paperclip
 
       def host_name_for_directory
         if @options[:fog_directory].to_s =~ Fog::AWS_BUCKET_SUBDOMAIN_RESTRICTON_REGEX
-          # This:
-          "#{@options[:fog_directory]}."
-
-          # Should be modified to this:
-          # "#{@options[:fog_directory]}.s3.amazonaws.com"
-          # When fog with https://github.com/fog/fog/pull/857 gets released
+          "#{@options[:fog_directory]}.s3.amazonaws.com"
         else
           "s3.amazonaws.com/#{@options[:fog_directory]}"
         end

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('capybara')
   s.add_development_dependency('bundler')
   s.add_development_dependency('cocaine', '~> 0.2')
-  s.add_development_dependency('fog', '1.3.1')
+  s.add_development_dependency('fog')
   s.add_development_dependency('pry')
   s.add_development_dependency('launchy')
   s.add_development_dependency('rake')

--- a/test/storage/fog_test.rb
+++ b/test/storage/fog_test.rb
@@ -234,19 +234,11 @@ class FogTest < Test::Unit::TestCase
 
       context "with a valid bucket name for a subdomain" do
         should "provide an url in subdomain style" do
-          # The following line is the correct one when this pull request in Fog is released:
-          # https://github.com/fog/fog/pull/857
-          # assert_match /^http:\/\/papercliptests.s3.amazonaws.com\/avatars\/5k.png\?AWSAccessKeyId=.+$/, @dummy.avatar.expiring_url
-          # For now, use this passing one:
-          assert_match /^https:\/\/papercliptests.\/avatars\/5k.png\?\d*$/, @dummy.avatar.url
+          assert_match @dummy.avatar.url, /^https:\/\/papercliptests.s3.amazonaws.com\/avatars\/5k.png/
         end
 
         should "provide an url that expires in subdomain style" do
-          # The following line is the correct one when this pull request in Fog is released:
-          # https://github.com/fog/fog/pull/857
-          # assert_match /^http:\/\/papercliptests.s3.amazonaws.com\/avatars\/5k.png\?AWSAccessKeyId=.+$/, @dummy.avatar.expiring_url
-          # For now, use this passing one:
-          assert_match /^http:\/\/papercliptests.\/avatars\/5k.png\?AWSAccessKeyId=.+$/, @dummy.avatar.expiring_url
+          assert_match /^http:\/\/papercliptests.s3.amazonaws.com\/avatars\/5k.png\?AWSAccessKeyId=.+$/, @dummy.avatar.expiring_url
         end
       end
 


### PR DESCRIPTION
This pull request adds expiring_url to the Fog Storage module in the same way that it is used in the original aws-sdk S3 model.

It adds the expiring_url method with tests and it refactors a bit of code for the dynamic hostname and subdomain recognition.

IMPORTANT: There is a bug in Fog where subdomains are not generated correctly for bucket names that are valid subdomain names. This is fixed in https://github.com/fog/fog/pull/857. This pull request contains failing tests that should pass as soon as that new gem version is released. 

Please let me know wether I can change these tests to make them work with the current bugged Fog gem or to leave them as they are: failing for now but passing when a new Fog gem gets released.

Also: I had a bit of trouble of finding out the structure of fog_test.rb so please let me know if I modified and added my tests accordingly.

Of course: any feedback on coding style, method names or other stuff much appreciated!
