### PR TITLE
Loading rails should be optional.

### DIFF
--- a/lib/paperclip/railtie.rb
+++ b/lib/paperclip/railtie.rb
@@ -2,15 +2,17 @@ require 'paperclip'
 require 'paperclip/schema'
 
 module Paperclip
-  require 'rails'
-  class Railtie < Rails::Railtie
-    initializer 'paperclip.insert_into_active_record' do
-      ActiveSupport.on_load :active_record do
-        Paperclip::Railtie.insert
+  if defined? Rails::Railtie
+    require 'rails'
+    class Railtie < Rails::Railtie
+      initializer 'paperclip.insert_into_active_record' do
+        ActiveSupport.on_load :active_record do
+          Paperclip::Railtie.insert
+        end
       end
-    end
-    rake_tasks do
-      load "tasks/paperclip.rake"
+      rake_tasks do
+        load "tasks/paperclip.rake"
+      end
     end
   end
 


### PR DESCRIPTION
After upgrading from 2.7.0 to 3.0.2, my sinatra app won't start because paperclip tries to require rails.

``` ruby
/usr/local/rvm/gems/ruby-1.9.3-p0/gems/paperclip-3.0.2/lib/paperclip/railtie.rb:5:in `require': cannot load such file -- rails (LoadError)
```

This patch checks if `Rails::Railtie` is defined, and conditionally load railtie.
