### PR TITLE
Ensure file is rewind before saved on AWS using S3 or Fog

### DIFF
--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -77,6 +77,7 @@ module Paperclip
       def flush_writes
         for style, file in @queued_for_write do
           log("saving #{path(style)}")
+          file.rewind
           retried = false
           begin
             directory.files.create(fog_file.merge(
@@ -175,7 +176,7 @@ module Paperclip
         else
           @options[:fog_directory]
         end
-        
+
         @directory ||= connection.directories.new(:key => dir)
       end
     end

--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -287,6 +287,7 @@ module Paperclip
         @queued_for_write.each do |style, file|
           begin
             log("saving #{path(style)}")
+            file.rewind
             acl = @s3_permissions[style] || @s3_permissions[:default]
             acl = acl.call(self, style) if acl.respond_to?(:call)
             write_options = {

--- a/test/storage/fog_test.rb
+++ b/test/storage/fog_test.rb
@@ -111,6 +111,11 @@ class FogTest < Test::Unit::TestCase
         directory.destroy
       end
 
+      should "rewind file in flush_writes" do
+        @dummy.avatar.queued_for_write.each { |style, file| file.expects(:rewind).with() }
+        @dummy.save
+      end
+
       should "pass the content type to the Fog::Storage::AWS::Files instance" do
         Fog::Storage::AWS::Files.any_instance.expects(:create).with do |hash|
           hash[:content_type]

--- a/test/storage/s3_test.rb
+++ b/test/storage/s3_test.rb
@@ -532,6 +532,11 @@ class S3Test < Test::Unit::TestCase
         assert_match %r{^http://s3\.amazonaws\.com/testing/avatars/original/5k\.png}, @dummy.avatar.url
       end
 
+      should "rewind file in flush_writes when save" do
+        @dummy.avatar.queued_for_write.each { |style, file| file.expects(:rewind).with() }
+        @dummy.save
+      end
+
       context "and saved" do
         setup do
           object = stub


### PR DESCRIPTION
-  fix lost during merge of io_adapter commit (89c8d117e756815333a0e46d387cd64a1f4d37ab)
-  previous commit 7cb73846811b797fadfd8dca0917bafc7a06b84e
