### PR TITLE
Add readchar/readbyte methods on FileAdapter

### DIFF
--- a/lib/paperclip/io_adapters/file_adapter.rb
+++ b/lib/paperclip/io_adapters/file_adapter.rb
@@ -40,6 +40,15 @@ module Paperclip
       @tempfile.read(length, buffer)
     end
 
+    # We don't use this directly, but some post-processors does.
+    def readchar
+      @tempfile.readchar
+    end
+
+    def readbyte
+      @tempfile.readbyte
+    end
+
     # We don't use this directly, but aws/sdk does.
     def rewind
       @tempfile.rewind

--- a/test/io_adapters/file_adapter_test.rb
+++ b/test/io_adapters/file_adapter_test.rb
@@ -40,6 +40,16 @@ class FileAdapterTest < Test::Unit::TestCase
         assert_equal expected, @subject.fingerprint
       end
 
+      should "read a char of the file" do
+        expected = @file.readchar
+        assert_equal expected, @subject.readchar
+      end
+
+      should "read a byte of the file" do
+        expected = @file.readbyte
+        assert_equal expected, @subject.readbyte
+      end
+
       should "read the contents of the file" do
         expected = @file.read
         assert expected.length > 0


### PR DESCRIPTION
- Standard methods from File object abstraction.
- Needed by Attachment post-processors like EXIF extractions...
