### PR TITLE
Skip force_encoding for Ruby versions <1.9

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -94,13 +94,13 @@ module Paperclip
         if AWS::VERSION >= "1.3.9"
           AWS::Core::LogFormatter.class_eval do
             def summarize_hash(hash)
-              hash.map { |key, value| ":#{key}=>#{summarize_value(value)}".force_encoding('UTF-8') }.sort.join(',')
+              hash.map { |key, value| String.respond_to?(:force_encoding) ? ":#{key}=>#{summarize_value(value)}".force_encoding('UTF-8') : ":#{key}=>#{summarize_value(value)}" }.sort.join(',')
             end
           end
         else
           AWS::Core::ClientLogging.class_eval do
             def sanitize_hash(hash)
-              hash.map { |key, value| "#{sanitize_value(key)}=>#{sanitize_value(value)}".force_encoding('UTF-8') }.sort.join(',')
+              hash.map { |key, value| String.respond_to?(:force_encoding) ? "#{sanitize_value(key)}=>#{sanitize_value(value)}".force_encoding('UTF-8') : "#{sanitize_value(key)}=>#{sanitize_value(value)}" }.sort.join(',')
             end
           end
         end


### PR DESCRIPTION
Allows for Ruby 1.8.7 users to upgrade to 3.0.3 and not have issues when trying to reprocess a file stored in S3. Helps to address #827 for users on older Ruby versions that would otherwise not like to upgrade their applications to Ruby 1.9 to fix this issue.
