### PR TITLE
Rewind before generating fingerprint for Paperclip::StringioAdapter Class

### DIFF
--- a/lib/paperclip/io_adapters/stringio_adapter.rb
+++ b/lib/paperclip/io_adapters/stringio_adapter.rb
@@ -24,10 +24,12 @@ module Paperclip
     end
 
     def fingerprint
-      rewind # start reading from the beginning
-      finger = Digest::MD5.hexdigest(read)
-      rewind
-      finger
+     if (@cached_fingerprint.nil?)
+       rewind # start reading from the beginning
+       @cached_fingerprint = Digest::MD5.hexdigest(read)
+       rewind # for later read()
+     end
+     @cached_fingerprint
     end
 
     def read(length = nil, buffer = nil)

--- a/test/io_adapters/stringio_adapter_test.rb
+++ b/test/io_adapters/stringio_adapter_test.rb
@@ -34,10 +34,14 @@ class StringioFileProxyTest < Test::Unit::TestCase
       assert_equal Digest::MD5.hexdigest(@contents), @subject.fingerprint
     end
 
+    should "generate correct fingerprint after read" do
+      fingerprint = Digest::MD5.hexdigest(@subject.read)
+      assert_equal fingerprint, @subject.fingerprint
+    end
+
     should "generate same fingerprint" do
       assert_equal @subject.fingerprint, @subject.fingerprint
     end
-
 
     should "return the data contained in the StringIO" do
       assert_equal "abc123", @subject.read


### PR DESCRIPTION
Current fingerprint generates and stores same fingerprint in fingerprint field in the database because it generates MD5 hash from empty string.
Calling rewind method before generating MD5 hash fixes this problem.
