### PR TITLE
Adds the ability to retrieve a styled version of a file from the file store. (Redux)

### DIFF
--- a/lib/paperclip/io_adapters/attachment_adapter.rb
+++ b/lib/paperclip/io_adapters/attachment_adapter.rb
@@ -1,7 +1,13 @@
 module Paperclip
   class AttachmentAdapter
     def initialize(target)
-      @target = target
+      @target, @style = case target
+      when Paperclip::Attachment
+        [target, :original]
+      when Paperclip::Style
+        [target.attachment, target.name]
+      end
+
       cache_current_values
     end
 
@@ -57,9 +63,9 @@ module Paperclip
       dest = Tempfile.new([basename, extension])
       dest.binmode
       if src.respond_to? :copy_to_local_file
-        src.copy_to_local_file(:original, dest.path)
+        src.copy_to_local_file(@style, dest.path)
       else
-        FileUtils.cp(src.path(:original), dest.path)
+        FileUtils.cp(src.path(@style), dest.path)
       end
       dest
     end
@@ -67,5 +73,5 @@ module Paperclip
 end
 
 Paperclip.io_adapters.register Paperclip::AttachmentAdapter do |target|
-  Paperclip::Attachment === target
+  Paperclip::Attachment === target || Paperclip::Style === target
 end

--- a/test/io_adapters/attachment_adapter_test.rb
+++ b/test/io_adapters/attachment_adapter_test.rb
@@ -1,51 +1,111 @@
 require './test/helper'
 
 class AttachmentAdapterTest < Test::Unit::TestCase
+  
   def setup
-    rebuild_model :path => "tmp/:class/:attachment/:style/:filename"
+    rebuild_model :path => "tmp/:class/:attachment/:style/:filename", :styles => {:thumb => '50x50'}
     @attachment = Dummy.new.avatar
-    @file = File.new(fixture_file("5k.png"))
-    @file.binmode
-
-    @attachment.assign(@file)
-    @attachment.save
-    @subject = Paperclip.io_adapters.for(@attachment)
   end
+  
+  context "for an attachment" do
+    setup do
+      @file = File.new(fixture_file("5k.png"))
+      @file.binmode
 
-  def teardown
-    @file.close
+      @attachment.assign(@file)
+      @attachment.save
+      @subject = Paperclip.io_adapters.for(@attachment)
+    end
+
+    teardown do
+      @file.close
+    end
+
+    should "get the right filename" do
+      assert_equal "5k.png", @subject.original_filename
+    end
+
+    should "force binmode on tempfile" do
+      assert @subject.instance_variable_get("@tempfile").binmode?
+    end
+
+    should "get the content type" do
+      assert_equal "image/png", @subject.content_type
+    end
+
+    should "get the file's size" do
+      assert_equal 4456, @subject.size
+    end
+
+    should "return false for a call to nil?" do
+      assert ! @subject.nil?
+    end
+
+    should "generate a MD5 hash of the contents" do
+      expected = Digest::MD5.file(@file.path).to_s
+      assert_equal expected, @subject.fingerprint
+    end
+
+    should "read the contents of the file" do
+      expected = @file.read
+      actual = @subject.read
+      assert expected.length > 0
+      assert_equal expected.length, actual.length
+      assert_equal expected, actual
+    end
+    
   end
+  
+  context "for a style" do
+    setup do
+      @file = File.new(fixture_file("5k.png"))
+      @file.binmode
 
-  should "get the right filename" do
-    assert_equal "5k.png", @subject.original_filename
-  end
+      @attachment.assign(@file)
+    
+      @thumb = @attachment.queued_for_write[:thumb]
+    
+      @attachment.save
+      @subject = Paperclip.io_adapters.for(@attachment.styles[:thumb])
+    end
 
-  should "force binmode on tempfile" do
-    assert @subject.instance_variable_get("@tempfile").binmode?
-  end
+    teardown do
+      @file.close
+    end
 
-  should "get the content type" do
-    assert_equal "image/png", @subject.content_type
-  end
+    should "get the original filename" do
+      assert_equal "5k.png", @subject.original_filename
+    end
 
-  should "get the file's size" do
-    assert_equal 4456, @subject.size
-  end
+    should "force binmode on tempfile" do
+      assert @subject.instance_variable_get("@tempfile").binmode?
+    end
 
-  should "return false for a call to nil?" do
-    assert ! @subject.nil?
-  end
+    should "get the content type" do
+      assert_equal "image/png", @subject.content_type
+    end
 
-  should "generate a MD5 hash of the contents" do
-    expected = Digest::MD5.file(@file.path).to_s
-    assert_equal expected, @subject.fingerprint
-  end
+    should "get the thumbnail's file size" do
+      assert_equal @thumb.size, @subject.size
+    end
 
-  should "read the contents of the file" do
-    expected = @file.read
-    actual = @subject.read
-    assert expected.length > 0
-    assert_equal expected.length, actual.length
-    assert_equal expected, actual
+    should "return false for a call to nil?" do
+      assert ! @subject.nil?
+    end
+
+    should "generate a MD5 hash of the contents" do
+      expected = Digest::MD5.file(@thumb.path).to_s
+      assert_equal expected, @subject.fingerprint
+    end
+
+    should "read the contents of the thumbnail" do
+      @thumb.rewind
+      expected = @thumb.read
+      actual = @subject.read
+      assert expected.length > 0
+      assert_equal expected.length, actual.length
+      assert_equal expected, actual
+    end
+    
   end
 end


### PR DESCRIPTION
Since removing Paperclip::Attachment#to_file, it is impossible to retrieve the file contents of a styled attachment after it has been saved to the server.  This change adds the AttachmentStyleAdapter, allowing you to use the following code to retrieve a file object for style. Given a Photo with Paperclip

``` ruby
user.photo # Paperclip::Attachment
Paperclip.io_adapters(user.photo.styles[:thumb]) # Temporary file containing the 'thumb' version of the photo.
```

Previously PR here: https://github.com/thoughtbot/paperclip/pull/859
