### PR TITLE
The file command changed its MIME type for empty files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ GhostScript to be installed. On Mac OS X, you can also install that using Homebr
 
     brew install gs
 
+### Filetype Detection
+
+This assumes the `file` command version 5.08 or higher. This primarily
+affects unknown file types and empty files; these report different
+values before and after 5.08. Download the latest `file` command from
+the [official file Web site](http://darwinsys.com/file/).
 
 Installation
 ------------

--- a/test/io_adapters/file_adapter_test.rb
+++ b/test/io_adapters/file_adapter_test.rb
@@ -81,7 +81,7 @@ class FileAdapterTest < Test::Unit::TestCase
       teardown { @file.close }
 
       should "provide correct mime-type" do
-        assert_equal "application/x-empty", @subject.content_type
+        assert_equal "inode/x-empty", @subject.content_type
       end
     end
   end


### PR DESCRIPTION
file 5.08 is old now, so let's require it for the tests to pass.
