### PR TITLE
The file command changed its MIME type for empty files.

### DIFF
--- a/test/io_adapters/file_adapter_test.rb
+++ b/test/io_adapters/file_adapter_test.rb
@@ -91,7 +91,7 @@ class FileAdapterTest < Test::Unit::TestCase
       teardown { @file.close }
 
       should "provide correct mime-type" do
-        assert_equal "application/x-empty", @subject.content_type
+        assert_match %r{.*/x-empty}, @subject.content_type
       end
     end
   end


### PR DESCRIPTION
This pull request maintains compatibility with last year's `file` command.
