### PR TITLE
Make the refresh rake task save instances after reprocessing their attachments

### DIFF
--- a/lib/tasks/paperclip.rake
+++ b/lib/tasks/paperclip.rake
@@ -33,6 +33,7 @@ namespace :paperclip do
       names.each do |name|
         Paperclip.each_instance_with_attachment(klass, name) do |instance|
           instance.send(name).reprocess!(*styles)
+          instance.save
           errors << [instance.id, instance.errors] unless instance.errors.blank?
         end
       end


### PR DESCRIPTION
Attachment.reprocess! updates fields of the instance such as attachment_updated_at. Thus we need to save the instance after reprocessing attachments, which is missing from the refresh rake task.
