### PR TITLE
StringioAdapter no longer allows content_type and original_filename to be set.

### DIFF
--- a/lib/paperclip/io_adapters/stringio_adapter.rb
+++ b/lib/paperclip/io_adapters/stringio_adapter.rb
@@ -6,6 +6,7 @@ module Paperclip
       @tempfile = copy_to_tempfile(@target)
     end
 
+    attr_writer :original_filename, :content_type
     private
 
     def cache_current_values

--- a/test/io_adapters/stringio_adapter_test.rb
+++ b/test/io_adapters/stringio_adapter_test.rb
@@ -36,6 +36,16 @@ class StringioFileProxyTest < Test::Unit::TestCase
     should "return the data contained in the StringIO" do
       assert_equal "abc123", @subject.read
     end
-
+    
+    should 'accept a content_type' do
+      @subject.content_type = 'image/png'
+      assert_equal 'image/png', @subject.content_type
+    end
+    
+    should 'accept an orgiginal_filename' do
+      @subject.original_filename = 'image.png'
+      assert_equal 'image.png', @subject.original_filename
+    end
+    
   end
 end


### PR DESCRIPTION
My app interacts with a service that provides images as a base64 string inside an xml file (yes, I know, that sounds like fun). I attach said image to my model using paperclip.

Until the last release this was accomplished, without too much trouble by using:

```
sio = StringIO.new(Base64.decode64('base64 String goes here'))
file = Paperclip.io_adapters.for(sio)
file.content_type = 'image/png'
file.original_filename ='my_image.png'
paperclip_model.attachment = file
```

The 49b833a48acd33cca1264ec67f4ede3cfa06081d commit removes the attribute writers in question for StringioAdapter, which broke the functionality.

I added two tests and a quick fix.

Thanks for providing the gem. I use it widely in production.
