### PR TITLE
[#940] Raise error when style defined & not in path

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -77,6 +77,7 @@ module Paperclip
       @source_file_options   = options[:source_file_options]
       @whiny                 = options[:whiny]
 
+      initialize_path
       initialize_storage
     end
 
@@ -356,6 +357,17 @@ module Paperclip
 
     def valid_assignment? file #:nodoc:
       file.nil? || (file.respond_to?(:original_filename) && file.respond_to?(:content_type))
+    end
+
+    def initialize_path
+      if style_not_in_custom_path?
+        raise(Paperclip::Errors::StyleTokenNotFound)
+      end
+    end
+
+    def style_not_in_custom_path?
+      @options[:path] != Paperclip::Attachment.default_options[:path] &&
+        @options[:styles].present? && !@options[:path].include?(':style')
     end
 
     def initialize_storage #:nodoc:

--- a/lib/paperclip/errors.rb
+++ b/lib/paperclip/errors.rb
@@ -9,6 +9,11 @@ module Paperclip
     class StorageMethodNotFound < Paperclip::Error
     end
 
+    # Will be thrown when there are custom styles and those styles aren't
+    # included in the path
+    class StyleTokenNotFound < Paperclip::Error
+    end
+
     # Will be thrown when a command or executable is not found.
     class CommandNotFoundError < Paperclip::Error
     end

--- a/test/attachment_test.rb
+++ b/test/attachment_test.rb
@@ -309,7 +309,7 @@ class AttachmentTest < Test::Unit::TestCase
 
   context "An attachment with a default style and an extension interpolation" do
     setup do
-      @attachment = attachment :path => ":basename.:extension",
+      @attachment = attachment :path => ":style_:basename.:extension",
                                :styles => { :default => ["100x100", :png] },
                                :default_style => :default
       @file = StringIO.new("...")
@@ -317,7 +317,7 @@ class AttachmentTest < Test::Unit::TestCase
     end
     should "return the right extension for the path" do
       @attachment.assign(@file)
-      assert_equal "file.png", @attachment.path
+      assert_equal "default_file.png", @attachment.path
     end
   end
 

--- a/test/storage/s3_test.rb
+++ b/test/storage/s3_test.rb
@@ -228,7 +228,7 @@ class S3Test < Test::Unit::TestCase
       rebuild_model :styles  => { :large => ['500x500#', :jpg] },
                     :storage => :s3,
                     :bucket  => "bucket",
-                    :path => ":attachment/:basename.:extension",
+                    :path => ":attachment/:style/:basename.:extension",
                     :s3_credentials => {
                       'access_key_id' => "12345",
                       'secret_access_key' => "54321"

--- a/test/style_test.rb
+++ b/test/style_test.rb
@@ -5,7 +5,7 @@ class StyleTest < Test::Unit::TestCase
 
   context "A style rule" do
     setup do
-      @attachment = attachment :path => ":basename.:extension",
+      @attachment = attachment :path => ":basename_:style.:extension",
                                :styles => { :foo => {:geometry => "100x100#", :format => :png} },
                                :whiny => true
       @style = @attachment.styles[:foo]
@@ -33,9 +33,18 @@ class StyleTest < Test::Unit::TestCase
     end
   end
 
+  context "A path not containing a style rule" do
+    should "generate a warning when a :style token isn't found" do
+      assert_raises(Paperclip::Errors::StyleTokenNotFound) do
+        @attachment = attachment :path => ":basename_:extension",
+                                 :styles => { :foo => {:geometry => "100x100#", :format => :png} }
+      end
+    end
+  end
+
   context "A style rule with properties supplied as procs" do
     setup do
-      @attachment = attachment :path => ":basename.:extension",
+      @attachment = attachment :path => ":style_:basename.:extension",
                                :whiny_thumbnails => true,
                                :processors => lambda {|a| [:test]},
                                :styles => {
@@ -64,7 +73,7 @@ class StyleTest < Test::Unit::TestCase
       styles[:aslist] = ["100x100", :png]
       styles[:ashash] = {:geometry => "100x100", :format => :png}
       styles[:asstring] = "100x100"
-      @attachment = attachment :path => ":basename.:extension",
+      @attachment = attachment :path => ":style_:basename.:extension",
                                :styles => styles
     end
     should "have the right number of styles" do
@@ -97,7 +106,7 @@ class StyleTest < Test::Unit::TestCase
 
   context "An attachment with :convert_options" do
     setup do
-      @attachment = attachment :path => ":basename.:extension",
+      @attachment = attachment :path => ":style_:basename.:extension",
                                :styles => {:thumb => "100x100", :large => "400x400"},
                                :convert_options => {:all => "-do_stuff", :thumb => "-thumbnailize"}
       @style = @attachment.styles[:thumb]
@@ -117,7 +126,7 @@ class StyleTest < Test::Unit::TestCase
 
   context "An attachment with :source_file_options" do
     setup do
-      @attachment = attachment :path => ":basename.:extension",
+      @attachment = attachment :path => ":style_:basename.:extension",
                                :styles => {:thumb => "100x100", :large => "400x400"},
                                :source_file_options => {:all => "-density 400", :thumb => "-depth 8"}
       @style = @attachment.styles[:thumb]
@@ -137,7 +146,7 @@ class StyleTest < Test::Unit::TestCase
 
   context "A style rule with its own :processors" do
     setup do
-      @attachment = attachment :path => ":basename.:extension",
+      @attachment = attachment :path => ":style_:basename.:extension",
                                :styles => {
                                  :foo => {
                                    :geometry => "100x100#",
@@ -162,7 +171,7 @@ class StyleTest < Test::Unit::TestCase
 
   context "A style rule with :processors supplied as procs" do
     setup do
-      @attachment = attachment :path => ":basename.:extension",
+      @attachment = attachment :path => ":style_:basename.:extension",
                                :styles => {
                                  :foo => {
                                    :geometry => "100x100#",
@@ -184,7 +193,7 @@ class StyleTest < Test::Unit::TestCase
 
   context "An attachment with :convert_options and :source_file_options in :styles" do
     setup do
-      @attachment = attachment :path => ":basename.:extension",
+      @attachment = attachment :path => ":style_:basename.:extension",
                                :styles => {
                                  :thumb => "100x100",
                                  :large => {:geometry => "400x400",


### PR DESCRIPTION
- Add StyleTokenNotFound in Errors
- Adjust tests to make sure :style present where not currently defined
