### PR TITLE
Fix wrong path/URL for Fog storage when not passing them as explicit options

### DIFF
--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -42,7 +42,7 @@ module Paperclip
 
         base.instance_eval do
           unless @options[:url].to_s.match(/^:fog.*url$/)
-            @options[:path]  = @options[:path].gsub(/:url/, @options[:url])
+            @options[:path]  = @options[:path].gsub(/:url/, @options[:url]).gsub(/^:rails_root\/public\/system\//, '')
             @options[:url]   = ':fog_public_url'
           end
           Paperclip.interpolates(:fog_public_url) do |attachment, style|

--- a/test/storage/fog_test.rb
+++ b/test/storage/fog_test.rb
@@ -66,6 +66,29 @@ class FogTest < Test::Unit::TestCase
                      @dummy.avatar.path
       end
     end
+    
+    context "with no path or url given and using defaults" do
+      setup do
+        rebuild_model :styles => { :medium => "300x300>", :thumb => "100x100>" },
+                      :storage => :fog,
+                      :fog_directory => "paperclip",
+                      :fog_credentials => {
+                        :provider => 'AWS',
+                        :aws_access_key_id => 'AWS_ID',
+                        :aws_secret_access_key => 'AWS_SECRET'
+                      }
+        @file = File.new(fixture_file('5k.png'), 'rb')
+        @dummy = Dummy.new
+        @dummy.id = 1
+        @dummy.avatar = @file
+      end
+      
+      teardown { @file.close }
+      
+      should "have correct path and url from interpolated defaults" do
+        assert_equal "dummies/avatars/000/000/001/original/5k.png", @dummy.avatar.path
+      end
+    end
 
     setup do
       @fog_directory = 'papercliptests'


### PR DESCRIPTION
This Pull request fixes a bug in the Fog storage which uses Rails.root/public/system from the defaults. Of course, when using Fog and S3 this parts needs to be stripped of.

The S3 Storage already does this and I have added the same logic to the Fog storage. Also added a test to make sure defaults gets followed correctly for the default interpoliations.
