### PR TITLE
Fix syntax error on ruby 1.8.7

### DIFF
--- a/lib/paperclip/geometry.rb
+++ b/lib/paperclip/geometry.rb
@@ -149,7 +149,7 @@ module Paperclip
     # scale to the requested geometry and preserve the aspect ratio
     def scale_to(new_geometry)
       scale = [new_geometry.width.to_f / self.width.to_f , new_geometry.height.to_f / self.height.to_f].min
-      Paperclip::Geomery.new((self.width * scale).round, (self.height * scale).round)
+      Paperclip::Geometry.new((self.width * scale).round, (self.height * scale).round)
     end
   end
 end


### PR DESCRIPTION
Error message:
/home/user/.bundler/ruby/1.8/paperclip-8110922ed6cb/lib/paperclip/geometry.rb:152: syntax error, unexpected '\n', expecting tCOLON2 or '[' or '.'
