### PR TITLE
Set the proper S3 header for encryption.

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -137,8 +137,10 @@ module Paperclip
           end
 
           @s3_headers[:storage_class] = @options[:s3_storage_class] if @options[:s3_storage_class]
-          @s3_headers['x-amz-server-side-encryption'] = @options[:s3_server_side_encryption].to_s.upcase if
-            @options[:s3_server_side_encryption]
+
+          if @options[:s3_server_side_encryption] && @options[:s3_server_side_encryption] != ''
+            @s3_headers['x-amz-server-side-encryption'] = @options[:s3_server_side_encryption].to_s.upcase
+          end
 
           unless @options[:url].to_s.match(/^:s3.*url$/) || @options[:url] == ":asset_host"
             @options[:path] = @options[:path].gsub(/:url/, @options[:url]).gsub(/^:rails_root\/public\/system/, '')

--- a/test/storage/s3_test.rb
+++ b/test/storage/s3_test.rb
@@ -856,6 +856,46 @@ class S3Test < Test::Unit::TestCase
     end
   end
 
+  context "Can disable AES256 encryption multiple ways" do
+    [nil, false, ''].each do |tech|
+      setup do
+        rebuild_model(
+          :storage                   => :s3,
+          :bucket                    => "testing",
+          :path                      => ":attachment/:style/:basename.:extension",
+          :s3_credentials            => {
+            'access_key_id'          => "12345",
+            'secret_access_key'      => "54321"},
+          :s3_server_side_encryption => tech)
+      end
+
+      context "when assigned" do
+        setup do
+          @file = File.new(fixture_file('5k.png'), 'rb')
+          @dummy = Dummy.new
+          @dummy.avatar = @file
+        end
+
+        teardown { @file.close }
+
+        context "and saved" do
+          setup do
+            object = stub
+            @dummy.avatar.stubs(:s3_object).returns(object)
+            object.expects(:write).with(anything,
+              :content_type => "image/png",
+              :acl => :public_read)
+            @dummy.save
+          end
+
+          should "succeed" do
+            assert true
+          end
+        end
+      end
+    end
+  end
+
   context "An attachment with S3 storage and using AES256 encryption" do
     setup do
       rebuild_model :storage => :s3,


### PR DESCRIPTION
Based on the documentation at http://docs.amazonwebservices.com/AmazonS3/latest/dev/UsingServerSideEncryption.html, it appears that the header x-amz-server-side-encryption must be set. 
