### PR TITLE
Fix for an improper modification during iteration

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -167,7 +167,7 @@ module Paperclip
         styles = styles.call(self) if styles.respond_to?(:call)
 
         @normalized_styles = styles.dup
-        @normalized_styles.each_pair do |name, options|
+        styles.each_pair do |name, options|
           @normalized_styles[name.to_sym] = Paperclip::Style.new(name.to_sym, options.dup, self)
         end
       end


### PR DESCRIPTION
This should fix #985 on Ruby 1.9.3. Tests pass, but couldn't come up with anything genius other than brute force to ensure it works with Ruby 1.9.2 and 1.9.3.
