### PR TITLE
Account for fog returning nil when a remote file is not present

### DIFF
--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -140,6 +140,10 @@ module Paperclip
         log("copying #{path(style)} to local file #{local_dest_path}")
         local_file = ::File.open(local_dest_path, 'wb')
         file = directory.files.get(path(style))
+        if file.nil?
+          warn("#{path(style)} does not exist")
+          return false
+        end
         local_file.write(file.body)
         local_file.close
       rescue ::Fog::Errors::Error => e


### PR DESCRIPTION
Fog will not throw an exception when a remote file is not present,
instead it returns nil.

http://fog.io/1.5.0/rdoc/Fog/Storage/AWS/Files.html#method-i-get
