### PR TITLE
Allow to define default validator used in all attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,32 @@ Paperclip::Attachment.default_options[:fog_directory] = ""
 Paperclip::Attachment.default_options[:fog_host] = "http://localhost:3000"
 ```
 
+### Default validator
+Global validator for all your paperclip attachments can be defined by changing the `Paperclip::Attachment.default_validator`.
+This can be useful if you want to define max attachment size per application.
+
+If you're using Rails you can define a Hash with validation options in `config/application.rb` or in any of the `config/environments/*.rb` files on `config.paperclip_validator`. An example:
+
+```ruby
+module YourApp
+  class Application < Rails::Application
+    # Other code...
+
+    config.paperclip_validator = {:size => { :in => 0..10240 }}
+  end
+end
+```
+
+Another option is to directly modify the `Paperclip::Attachment.default_validator` Hash, this method works for non-Rails applications or is an option if you prefer to place the Paperclip default settings in an initializer.
+
+An example Rails initializer would look something like this:
+
+```ruby
+Paperclip::Attachment.default_validator = {:size => { :in => 0..10240 }}
+```
+
+Any options used in `validates_attachment` can also be used in `default_validator`.
+
 Migrations
 ----------
 

--- a/features/basic_integration.feature
+++ b/features/basic_integration.feature
@@ -12,6 +12,7 @@ Feature: Rails integration
     Given I add this snippet to config/application.rb:
       """
       config.paperclip_defaults = {:url => "/paperclip/custom/:attachment/:style/:filename"}
+      config.paperclip_validator = {:size => { :in => 0..10240 }}
       """
     Given I add this snippet to the User model:
       """
@@ -26,6 +27,13 @@ Feature: Rails integration
     Then I should see "Name: something"
     And I should see an image with a path of "/paperclip/custom/attachments/original/5k.png"
     And the file at "/paperclip/custom/attachments/original/5k.png" should be the same as "test/fixtures/5k.png"
+
+    When I go to the new user page
+    And I fill in "Name" with "something2"
+    And I attach the file "test/fixtures/12k.png" to "Attachment"
+    And I press "Submit"
+    Then I should not see "Name: something2"
+    And I should not see an image with a path of "/paperclip/custom/attachments/original/12k.png"
 
   Scenario: Filesystem integration test
     Given I add this snippet to the User model:

--- a/features/step_definitions/html_steps.rb
+++ b/features/step_definitions/html_steps.rb
@@ -2,6 +2,10 @@ Then %r{I should see an image with a path of "([^"]*)"} do |path|
   page.should have_css("img[src^='#{path}']")
 end
 
+Then %r{I should not see an image with a path of "([^"]*)"} do |path|
+  page.should_not have_css("img[src^='#{path}']")
+end
+
 Then %r{^the file at "([^"]*)" is the same as "([^"]*)"$} do |web_file, path|
   expected = IO.read(path)
   actual = if web_file.match %r{^https?://}

--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -204,6 +204,8 @@ module Paperclip
         attachment = record.attachment_for(name)
         attachment.send(:flush_errors)
       end
+
+      validates_attachment name, Paperclip::Attachment.default_validator if Paperclip::Attachment.default_validator
     end
 
     # Returns the attachment definitions defined by each call to

--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -31,6 +31,8 @@ module Paperclip
       }
     end
 
+    cattr_accessor :default_validator
+
     attr_reader :name, :instance, :default_style, :convert_options, :queued_for_write, :whiny,
                 :options, :interpolator, :source_file_options, :whiny
     attr_accessor :post_processing

--- a/lib/paperclip/railtie.rb
+++ b/lib/paperclip/railtie.rb
@@ -13,6 +13,10 @@ module Paperclip
       if app.config.respond_to?(:paperclip_defaults)
         Paperclip::Attachment.default_options.merge!(app.config.paperclip_defaults)
       end
+
+      if app.config.respond_to?(:paperclip_validator)
+        Paperclip::Attachment.default_validator = app.config.paperclip_validator
+      end
     end
 
     rake_tasks { load "tasks/paperclip.rake" }


### PR DESCRIPTION
This can be useful if you want to define max attachment size per application.
