### PR TITLE
uses new migration syntax for generators

### DIFF
--- a/lib/generators/paperclip/templates/paperclip_migration.rb.erb
+++ b/lib/generators/paperclip/templates/paperclip_migration.rb.erb
@@ -1,7 +1,7 @@
 class <%= migration_class_name %> < ActiveRecord::Migration
   def change
   <% attachment_names.each do |attachment| -%>
-    add_attachment :p<%= table_name %>, :<%= attachment %> 
+    add_attachment :<%= table_name %>, :<%= attachment %> 
   <% end -%>
   end
 end


### PR DESCRIPTION
I just noticed that the generator still uses what you call "vintage syntax" in the readme. 
