### PR TITLE
Fix rack content_type newline

### DIFF
--- a/lib/paperclip/io_adapters/uploaded_file_adapter.rb
+++ b/lib/paperclip/io_adapters/uploaded_file_adapter.rb
@@ -15,7 +15,7 @@ module Paperclip
 
     def cache_current_values
       @original_filename = @target.original_filename
-      @content_type = @target.content_type
+      @content_type = @target.content_type.to_s.strip
       @size = File.size(@target.path)
     end
   end

--- a/test/io_adapters/uploaded_file_adapter_test.rb
+++ b/test/io_adapters/uploaded_file_adapter_test.rb
@@ -10,7 +10,7 @@ class UploadedFileAdapterTest < Test::Unit::TestCase
 
         @file = UploadedFile.new(
           :original_filename => "5k.png",
-          :content_type => "image/png",
+          :content_type => "image/png\r",
           :head => "",
           :tempfile => tempfile,
           :path => tempfile.path


### PR DESCRIPTION
Inside of rack the variable `@env['rack.form_hash']` has the original culprit where the type is set to "image/jpeg\r".  Not sure where that originates, maybe an OS-specific issue?  It occurred in both Firefox and Chrome, as well as both on my Macbook (Snow Leopard) and on Heroku (cedar).

Fixes #817
