### PR TITLE
Link to paperclip-dropbox gem in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,8 @@ Paperclip ships with 3 storage adapters:
 If you would like to use Paperclip with another storage, you can install these
 gems along side with Paperclip:
 
-* [Windows Azure](https://github.com/gmontard/paperclip-azure-storage)
+* [paperclip-azure-storage](https://github.com/gmontard/paperclip-azure-storage)
+* [paperclip-dropbox](https://github.com/janko-m/paperclip-dropbox)
 
 ### Understanding Storage
 


### PR DESCRIPTION
I made the [paperclip-dropbox](https://github.com/janko-m/paperclip-dropbox) gem for extending Paperclip with Dropbox storage. It works properly, I tested it thoroughly, and I am using it myself. So I just linked to it in the readme.
