### PR TITLE
allow to use lambdas in only_process option

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -90,8 +90,11 @@ module Paperclip
       ensure_required_accessors!
       file = Paperclip.io_adapters.for(uploaded_file)
 
-      @options[:only_process].map!(&:to_sym)
-      self.clear(*@options[:only_process])
+      only_process = @options[:only_process].dup
+      only_process = only_process.call(self) if only_process.respond_to?(:call)
+      only_process.map!(&:to_sym)
+
+      self.clear(*only_process)
       return nil if file.nil?
 
       @queued_for_write[:original]   = file
@@ -104,7 +107,7 @@ module Paperclip
 
       @dirty = true
 
-      post_process(*@options[:only_process]) if post_processing
+      post_process(*only_process) if post_processing
 
       # Reset the file size if the original file was reprocessed.
       instance_write(:file_size,   @queued_for_write[:original].size)

--- a/test/attachment_test.rb
+++ b/test/attachment_test.rb
@@ -385,6 +385,25 @@ class AttachmentTest < Test::Unit::TestCase
     end
   end
 
+  context "An attachment with :only_process that is a proc" do
+    setup do
+      rebuild_model :styles => {
+                      :thumb => "100x100",
+                      :large => "400x400"
+                    },
+                    :only_process => lambda { |attachment| [:thumb] }
+
+      @file = StringIO.new("...")
+      @attachment = Dummy.new.avatar
+    end
+
+    should "only process the provided style" do
+      @attachment.expects(:post_process).with(:thumb)
+      @attachment.expects(:post_process).with(:large).never
+      @attachment.assign(@file)
+    end
+  end
+
   context "An attachment with :convert_options that is a proc" do
     setup do
       rebuild_model :styles => {


### PR DESCRIPTION
We can use lambdas in styles option. And can use different styles for different objects. But I want to process only 1 thumbnail immediately for every object, and styles for this thumb can be different for different objects. All other thumbs will be processed with 'reprocess!' command in background. 
