### PR TITLE
Render Attachment objects in JSON as the URL to the file

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -157,6 +157,10 @@ module Paperclip
       url(style_name)
     end
 
+    def as_json(options = nil)
+      to_s((options && options[:style]) || default_style)
+    end
+
     def default_style
       @options[:default_style]
     end


### PR DESCRIPTION
Right now, when rendering a model object through Rails' json rendering framework, the default Object renderer tries to render Paperclip::Attachment objects. However, the default Object renderer uses `instance_values` to do so. Once of the values inside an Attachment itself has an instance value that points back to Attachment leading to an infinite recursion. This results in either a stack too deep error or a `CircularReferenceError` from the rails method `check_for_circular_references` inside the JSON encoding utility.

Example:

``` ruby
class User < ActiveRecord::Base
  has_attached_file :avatar, ...
end

class UserController < ApplicationController
  def index
    render json: User.all, methods: [:avatar]
  end
end
```
