### PR TITLE
Add support for blacklisting content_types

### DIFF
--- a/test/validators/attachment_content_type_validator_test.rb
+++ b/test/validators/attachment_content_type_validator_test.rb
@@ -76,93 +76,189 @@ class AttachmentContentTypeValidatorTest < Test::Unit::TestCase
     end
   end
 
-  context "with an allowed type" do
-    context "as a string" do
-      setup do
-        build_validator :content_type => "image/jpg"
-        @dummy.stubs(:avatar_content_type => "image/jpg")
-        @validator.validate(@dummy)
+  context "whitelist format" do
+    context "with an allowed type" do
+      context "as a string" do
+        setup do
+          build_validator :content_type => "image/jpg"
+          @dummy.stubs(:avatar_content_type => "image/jpg")
+          @validator.validate(@dummy)
+        end
+
+        should "not set an error message" do
+          assert @dummy.errors[:avatar_content_type].blank?
+        end
       end
 
-      should "not set an error message" do
-        assert @dummy.errors[:avatar_content_type].blank?
+      context "as an regexp" do
+        setup do
+          build_validator :content_type => /^image\/.*/
+          @dummy.stubs(:avatar_content_type => "image/jpg")
+          @validator.validate(@dummy)
+        end
+
+        should "not set an error message" do
+          assert @dummy.errors[:avatar_content_type].blank?
+        end
+      end
+
+      context "as a list" do
+        setup do
+          build_validator :content_type => ["image/png", "image/jpg", "image/jpeg"]
+          @dummy.stubs(:avatar_content_type => "image/jpg")
+          @validator.validate(@dummy)
+        end
+
+        should "not set an error message" do
+          assert @dummy.errors[:avatar_content_type].blank?
+        end
       end
     end
 
-    context "as an regexp" do
-      setup do
-        build_validator :content_type => /^image\/.*/
-        @dummy.stubs(:avatar_content_type => "image/jpg")
-        @validator.validate(@dummy)
+    context "with a disallowed type" do
+      context "as a string" do
+        setup do
+          build_validator :content_type => "image/png"
+          @dummy.stubs(:avatar_content_type => "image/jpg")
+          @validator.validate(@dummy)
+        end
+
+        should "set a correct default error message" do
+          assert @dummy.errors[:avatar_content_type].present?
+          assert_includes @dummy.errors[:avatar_content_type], "is invalid"
+        end
       end
 
-      should "not set an error message" do
-        assert @dummy.errors[:avatar_content_type].blank?
-      end
-    end
+      context "as a regexp" do
+        setup do
+          build_validator :content_type => /^text\/.*/
+          @dummy.stubs(:avatar_content_type => "image/jpg")
+          @validator.validate(@dummy)
+        end
 
-    context "as a list" do
-      setup do
-        build_validator :content_type => ["image/png", "image/jpg", "image/jpeg"]
-        @dummy.stubs(:avatar_content_type => "image/jpg")
-        @validator.validate(@dummy)
+        should "set a correct default error message" do
+          assert @dummy.errors[:avatar_content_type].present?
+          assert_includes @dummy.errors[:avatar_content_type], "is invalid"
+        end
       end
 
-      should "not set an error message" do
-        assert @dummy.errors[:avatar_content_type].blank?
+      context "with :message option" do
+        context "without interpolation" do
+          setup do
+            build_validator :content_type => "image/png", :message => "should be a PNG image"
+            @dummy.stubs(:avatar_content_type => "image/jpg")
+            @validator.validate(@dummy)
+          end
+
+          should "set a correct error message" do
+            assert_includes @dummy.errors[:avatar_content_type], "should be a PNG image"
+          end
+        end
+
+        context "with interpolation" do
+          setup do
+            build_validator :content_type => "image/png", :message => "should have content type %{types}"
+            @dummy.stubs(:avatar_content_type => "image/jpg")
+            @validator.validate(@dummy)
+          end
+
+          should "set a correct error message" do
+            assert_includes @dummy.errors[:avatar_content_type], "should have content type image/png"
+          end
+        end
       end
     end
   end
 
-  context "with a disallowed type" do
-    context "as a string" do
-      setup do
-        build_validator :content_type => "image/png"
-        @dummy.stubs(:avatar_content_type => "image/jpg")
-        @validator.validate(@dummy)
-      end
-
-      should "set a correct default error message" do
-        assert @dummy.errors[:avatar_content_type].present?
-        assert_includes @dummy.errors[:avatar_content_type], "is invalid"
-      end
-    end
-
-    context "as a regexp" do
-      setup do
-        build_validator :content_type => /^text\/.*/
-        @dummy.stubs(:avatar_content_type => "image/jpg")
-        @validator.validate(@dummy)
-      end
-
-      should "set a correct default error message" do
-        assert @dummy.errors[:avatar_content_type].present?
-        assert_includes @dummy.errors[:avatar_content_type], "is invalid"
-      end
-    end
-
-    context "with :message option" do
-      context "without interpolation" do
+  context "blacklist format" do
+    context "with an allowed type" do
+      context "as a string" do
         setup do
-          build_validator :content_type => "image/png", :message => "should be a PNG image"
+          build_validator :not => "image/gif"
           @dummy.stubs(:avatar_content_type => "image/jpg")
           @validator.validate(@dummy)
         end
 
-        should "set a correct error message" do
-          assert_includes @dummy.errors[:avatar_content_type], "should be a PNG image"
+        should "not set an error message" do
+          assert @dummy.errors[:avatar_content_type].blank?
         end
       end
 
-      context "with interpolation" do
+      context "as an regexp" do
         setup do
-          build_validator :content_type => "image/png", :message => "should have content type %{types}"
+          build_validator :not => /^text\/.*/
           @dummy.stubs(:avatar_content_type => "image/jpg")
           @validator.validate(@dummy)
         end
 
-        should "set a correct error message" do
-          assert_includes @dummy.errors[:avatar_content_type], "should have content type image/png"
+        should "not set an error message" do
+          assert @dummy.errors[:avatar_content_type].blank?
+        end
+      end
+
+      context "as a list" do
+        setup do
+          build_validator :not => ["image/png", "image/jpg", "image/jpeg"]
+          @dummy.stubs(:avatar_content_type => "image/gif")
+          @validator.validate(@dummy)
+        end
+
+        should "not set an error message" do
+          assert @dummy.errors[:avatar_content_type].blank?
+        end
+      end
+    end
+
+    context "with a disallowed type" do
+      context "as a string" do
+        setup do
+          build_validator :not => "image/png"
+          @dummy.stubs(:avatar_content_type => "image/png")
+          @validator.validate(@dummy)
+        end
+
+        should "set a correct default error message" do
+          assert @dummy.errors[:avatar_content_type].present?
+          assert_includes @dummy.errors[:avatar_content_type], "is invalid"
+        end
+      end
+
+      context "as a regexp" do
+        setup do
+          build_validator :not => /^text\/.*/
+          @dummy.stubs(:avatar_content_type => "text/plain")
+          @validator.validate(@dummy)
+        end
+
+        should "set a correct default error message" do
+          assert @dummy.errors[:avatar_content_type].present?
+          assert_includes @dummy.errors[:avatar_content_type], "is invalid"
+        end
+      end
+
+      context "with :message option" do
+        context "without interpolation" do
+          setup do
+            build_validator :not => "image/png", :message => "should not be a PNG image"
+            @dummy.stubs(:avatar_content_type => "image/png")
+            @validator.validate(@dummy)
+          end
+
+          should "set a correct error message" do
+            assert_includes @dummy.errors[:avatar_content_type], "should not be a PNG image"
+          end
+        end
+
+        context "with interpolation" do
+          setup do
+            build_validator :not => "image/png", :message => "should not have content type %{types}"
+            @dummy.stubs(:avatar_content_type => "image/png")
+            @validator.validate(@dummy)
+          end
+
+          should "set a correct error message" do
+            assert_includes @dummy.errors[:avatar_content_type], "should not have content type image/png"
+          end
         end
       end
     end
@@ -185,8 +281,12 @@ class AttachmentContentTypeValidatorTest < Test::Unit::TestCase
       end
     end
 
-    should "not raise arguemnt error if :content_type was given" do
+    should "not raise argument error if :content_type was given" do
       build_validator :content_type => "image/jpg"
+    end
+
+    should "not raise argument error if :not was given" do
+      build_validator :not => "image/jpg"
     end
   end
 end


### PR DESCRIPTION
Paperclip currently has support for validating content types using a whitelist approach, e.g.:

``` ruby
validates_attachment :image, :content_type => { :content_type => "image/jpg" }
```

This branch adds support for blacklisting content types, as follows:

``` ruby
validates_attachment :image, :content_type => { :not => "application/zip" }
```

It works the exact same way as the whitelist but just does the opposite check. You can send in a string, array, or regex.
