### PR TITLE
* Updating the attachment fingerprint in the rake metadata task

### DIFF
--- a/lib/tasks/paperclip.rake
+++ b/lib/tasks/paperclip.rake
@@ -46,11 +46,12 @@ namespace :paperclip do
       names = Paperclip::Task.obtain_attachments(klass)
       names.each do |name|
         Paperclip.each_instance_with_attachment(klass, name) do |instance|
+          puts instance
           if file = Paperclip.io_adapters.for(instance.send(name))
             instance.send("#{name}_file_name=", instance.send("#{name}_file_name").strip)
             instance.send("#{name}_content_type=", file.content_type.to_s.strip)
             instance.send("#{name}_file_size=", file.size) if instance.respond_to?("#{name}_file_size")
-            instance.send("#{name}_fingerprint=", instance.send(name).generate_fingerprint(file)) if instance.respond_to?("#{name}_fingerprint")
+            instance.send("#{name}_fingerprint=", file.fingerprint) if instance.respond_to?("#{name}_fingerprint")
             instance.save(:validate => false)
           else
             true


### PR DESCRIPTION
The paperclip rake tasks do not update the attachment's fingerprint if it is present. I've added a one-liner to do this in the `metadata` task. However, it may be required in other tasks as well.

I've come across the following **gotcha** while making this change. Suppose, I'm adding a fingerprint to the attachment as an afterthought through the migration. Along with adding the fingerprint, I also change the URL to include the fingerprint as given below: 

```
  has_attached_file(:image, 
                    :styles => { :list => '263x200#',
                      :thumbnail => '100x100#',
                      :list_wide => '567x288#' },
                    :url => "/system/images/:id/:attachment/:style/:fingerprint-:filename",
                    :use_timestamp => false)
```

Now, the rake `metadata` task expects the file to be present in the **path** described by `:url`, i.e. it starts looking for files prefixed with the fingerprint and obviously doesn't find them. Sticking to the old URL while running the `metadata` tasks is a workaround -- change the URL **after** all the fingerprints have been updated in the DB. Isn't this a bug? The configuration has changed the URL, not the **path**?
