### PR TITLE
Check attachment paths for duplicates, not URLs

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -179,7 +179,7 @@ module Paperclip
 
       attachment_definitions[name] = Paperclip::AttachmentOptions.new(options)
       Paperclip.classes_with_attachments << self.name
-      Paperclip.check_for_url_clash(name,attachment_definitions[name][:url],self.name)
+      Paperclip.check_for_path_clash(name,attachment_definitions[name][:path],self.name)
 
       after_save :save_attached_files
       before_destroy :prepare_for_destroy

--- a/lib/paperclip/helpers.rb
+++ b/lib/paperclip/helpers.rb
@@ -43,13 +43,13 @@ module Paperclip
       end
     end
 
-    def check_for_url_clash(name,url,klass)
-      @names_url ||= {}
-      default_url = url || Attachment.default_options[:url]
-      if @names_url[name] && @names_url[name][:url] == default_url && @names_url[name][:class] != klass && @names_url[name][:url] !~ /:class/
-        log("Duplicate URL for #{name} with #{default_url}. This will clash with attachment defined in #{@names_url[name][:class]} class")
+    def check_for_path_clash(name,path,klass)
+      @names_path ||= {}
+      default_path = path || Attachment.default_options[:path]
+      if @names_path[name] && @names_path[name][:path] == default_path && @names_path[name][:class] != klass && @names_path[name][:path] !~ /:class/
+        log("Duplicate path for #{name} with #{default_path}. This will clash with attachment defined in #{@names_path[name][:class]} class")
       end
-      @names_url[name] = {:url => default_url, :class => klass}
+      @names_path[name] = {:path => default_path, :class => klass}
     end
 
     def reset_duplicate_clash_check!

--- a/test/paperclip_test.rb
+++ b/test/paperclip_test.rb
@@ -106,24 +106,34 @@ class PaperclipTest < Test::Unit::TestCase
       end
     end
 
-    should "generate warning if attachment is redefined with the same url string" do
-      expected_log_msg = "Duplicate URL for blah with /system/:id/:style/:filename. This will clash with attachment defined in Dummy class"
+    should "generate warning if attachment is redefined with the same path string" do
+      expected_log_msg = "Duplicate path for blah with /system/:id/:style/:filename. This will clash with attachment defined in Dummy class"
       Paperclip.expects(:log).with(expected_log_msg)
       Dummy.class_eval do
-        has_attached_file :blah, :url => '/system/:id/:style/:filename'
+        has_attached_file :blah, :path => '/system/:id/:style/:filename'
       end
       Dummy2.class_eval do
-        has_attached_file :blah, :url => '/system/:id/:style/:filename'
+        has_attached_file :blah, :path => '/system/:id/:style/:filename'
       end
     end
 
-    should "not generate warning if attachment is redifined with the same url string but has :class in it" do
+    should "not generate warning if attachment is redefined with the same path string but has :class in it" do
       Paperclip.expects(:log).never
       Dummy.class_eval do
-        has_attached_file :blah, :url => "/system/:class/:attachment/:id/:style/:filename"
+        has_attached_file :blah, :path => "/system/:class/:attachment/:id/:style/:filename"
       end
       Dummy2.class_eval do
-        has_attached_file :blah, :url => "/system/:class/:attachment/:id/:style/:filename"
+        has_attached_file :blah, :path => "/system/:class/:attachment/:id/:style/:filename"
+      end
+    end
+
+    should "not generate warning if attachment is defined with the same URL string" do
+      Paperclip.expects(:log).never
+      Dummy.class_eval do
+        has_attached_file :blah, :path => "/system/:class/:attachment/:id/:style/:filename", :url => ":s3_alias_url"
+      end
+      Dummy2.class_eval do
+        has_attached_file :blah, :path => "/system/:class/:attachment/:id/:style/:filename", :url => ":s3_alias_url"
       end
     end
   end


### PR DESCRIPTION
Hi all,

As per comments in #588, #589 and #660, attachments using certain interpolations for the attachment URL were mistakenly being flagged as being duplicates, even though the interpolation expands to a unique location for each model.

This commit (partially) addresses the issue by checking the attachment path instead, as suggested in #588. This fixes what is probably the most common affected scenario, attachments using S3 storage, and thus the `:s3_alias_url` interpolation (or similar).

However, the problem will remain for users who use interpolations other than :class to distinguish attachment paths for different models. Without expanding all path interpolations, the checker can't tell whether they're truly unique for each model or not. Therefore this approach is always going to potentially generate false positives. It's not clear to me how best to address this (and I'm not sure how many users will really be affected), so I'm submitting this patch in the interim.

Cheers,
Simon
