### PR TITLE
Windows 7 issue, 'type' is nil. Needs to be set to SENSIBLE_DEFAULT

### DIFF
--- a/lib/paperclip/content_type_detector.rb
+++ b/lib/paperclip/content_type_detector.rb
@@ -57,7 +57,7 @@ module Paperclip
         SENSIBLE_DEFAULT
       end
 
-      if type.match(/\(.*?\)/)
+      if type.nil? || type.match(/\(.*?\)/)
         type = SENSIBLE_DEFAULT
       end
       type.split(/[:;\s]+/)[0]


### PR DESCRIPTION
The type is not set to a valid value when the file command fails on windows. We catch most other instances of failure but miss this specific one. Very tiny code change. 

Tested with Jruby 1.7.0 RC1, Windows 7.
