### PR TITLE
[filesystem storage] Allow to specify permissions to override default umask

### DIFF
--- a/lib/paperclip/storage/filesystem.rb
+++ b/lib/paperclip/storage/filesystem.rb
@@ -35,8 +35,8 @@ module Paperclip
               new_file.write(chunk)
             end
           end
-          FileUtils.chmod((@options[:fs_permissions]&~0111) || (0666&~File.umask), path(style_name)) unless
-            @options[:fs_permissions] == false
+          FileUtils.chmod((@options[:override_file_permissions]&~0111) || (0666&~File.umask), path(style_name)) unless
+            @options[:override_file_permissions] == false
           file.rewind
         end
 

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -296,7 +296,7 @@ class IntegrationTest < Test::Unit::TestCase
   [0666,0664,0640].each do |perms|
     context "when the perms are #{perms}" do
       setup do
-        rebuild_model :fs_permissions => perms
+        rebuild_model :override_file_permissions => perms
         @dummy = Dummy.new
         @file  = File.new(fixture_file("5k.png"), 'rb')
       end
@@ -316,7 +316,7 @@ class IntegrationTest < Test::Unit::TestCase
   should "skip chmod operation, when override_file_permissions is set to false (e.g. useful when using CIFS mounts)" do
     FileUtils.expects(:chmod).never
 
-    rebuild_model :fs_permissions => false
+    rebuild_model :override_file_permissions => false
     dummy = Dummy.create!
     dummy.avatar = @file
     dummy.save


### PR DESCRIPTION
Inspired from dcdcb83baaca22964bdc8e76747cafa0c1bb87b3

That's a feature I needed because of a server using 0067 as umask (and needing g=r permissions to be able to serve my images)...
