### PR TITLE
Fix issue where calling expiring_url when using Fog with local storage generates exception

### DIFF
--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -128,10 +128,14 @@ module Paperclip
       end
 
       def expiring_url(time = (Time.now + 3600), style = default_style)
-        expiring_url = directory.files.get_http_url(path(style), time)
+        if fog_credentials[:provider] == 'AWS'
+          expiring_url = directory.files.get_http_url(path(style), time)
 
-        if @options[:fog_host]
-          expiring_url.gsub!(/#{host_name_for_directory}/, dynamic_fog_host_for_style(style))
+          if @options[:fog_host]
+            expiring_url.gsub!(/#{host_name_for_directory}/, dynamic_fog_host_for_style(style))
+          end
+        else
+          expiring_url = public_url
         end
 
         return expiring_url

--- a/test/storage/fog_test.rb
+++ b/test/storage/fog_test.rb
@@ -1,10 +1,10 @@
 require './test/helper'
 require 'fog'
 
-Fog.mock!
-
 class FogTest < Test::Unit::TestCase
   context "" do
+    setup { Fog.mock! }
+
     context "with credentials provided in a path string" do
       setup do
         rebuild_model :styles => { :medium => "300x300>", :thumb => "100x100>" },
@@ -379,5 +379,30 @@ class FogTest < Test::Unit::TestCase
       end
     end
 
+  end
+
+  context "when using local storage" do
+    setup do
+      Fog.unmock!
+      rebuild_model :styles => { :medium => "300x300>", :thumb => "100x100>" },
+                    :storage => :fog,
+                    :url => '/:attachment/:filename',
+                    :fog_directory => "paperclip",
+                    :fog_credentials => { :provider => :local, :local_root => "." },
+                    :fog_host => 'localhost'
+
+      @file = File.new(fixture_file('5k.png'), 'rb')
+      @dummy = Dummy.new
+      @dummy.avatar = @file
+    end
+
+    teardown do
+      @file.close
+      Fog.mock!
+    end
+
+    should "return the public url in place of the expiring url" do
+      assert_match @dummy.avatar.public_url, @dummy.avatar.expiring_url
+    end
   end
 end


### PR DESCRIPTION
When using Fog in development, swapping in local storage in place of AWS S3 causes the #expiring_url method to raise an exception, as Fog::Storage::Local::Files does not have a #get_http_url method. In order to enable swapping storage engines without building special view helpers for expriring_urls in views, this patch has #expiring_url return #public_url when Fog's storage provider is not AWS.
