### PR TITLE
Make filesystem CIFS aware

### DIFF
--- a/lib/paperclip/storage/filesystem.rb
+++ b/lib/paperclip/storage/filesystem.rb
@@ -35,7 +35,7 @@ module Paperclip
               new_file.write(chunk)
             end
           end
-          FileUtils.chmod(0666&~File.umask, path(style_name))
+          FileUtils.chmod(0666&~File.umask, path(style_name)) unless @options[:filesystem_cifs]==true
           file.rewind
         end
 

--- a/test/storage/filesystem_test.rb
+++ b/test/storage/filesystem_test.rb
@@ -67,5 +67,31 @@ class FileSystemTest < Test::Unit::TestCase
         assert_match /.+\/spaced_file\.png/, @dummy.avatar.url
       end
     end
+
+    context "is sensible to cifs shares" do
+      setup do
+        @file = File.open(fixture_file('5k.png'))
+      end
+
+      teardown { @file.close }
+
+      should "skip chmod operation, when cifs is ON" do
+        FileUtils.expects(:chmod).never
+
+        rebuild_model :filesystem_cifs => true
+        dummy = Dummy.create!
+        dummy.avatar = @file
+        dummy.save
+      end
+
+      should "run normally, when cifs is OFF or not set" do
+        FileUtils.expects(:chmod).once
+
+        rebuild_model
+        dummy = Dummy.create!
+        dummy.avatar = @file
+        dummy.save
+      end
+    end
   end
 end


### PR DESCRIPTION
We ran into a problem, when using the filesystem Module and writing to a CIFS-mount. 
In fact the only problem that arises, is that CIFS mounts do not like `chmod`.

For example [Twig](https://github.com/fabpot/Twig/pull/705) had the same issue, and dealt with it, by suppressing the warning.

I propose another solution, which takes an additional config, like so:

```
config.paperclip_defaults = {
    :storage => :filesystem,
    :filesystem_cifs => true
}
```

What do you think?
Good enough for main-trunk?

Kind regards,

René
