### PR TITLE
Allow setting of escape url as a default option

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -12,6 +12,7 @@ module Paperclip
         :convert_options       => {},
         :default_style         => :original,
         :default_url           => "/:attachment/:style/missing.png",
+        :escape_url            => true,
         :restricted_characters => /[&$+,\/:;=?@<>\[\]\{\}\|\\\^~%# ]/,
         :hash_data             => ":class/:attachment/:id/:style/:updated_at",
         :hash_digest           => "SHA1",
@@ -60,6 +61,7 @@ module Paperclip
     # +preserve_files+ - whether to keep files on the filesystem when deleting or clearing the attachment. Defaults to false
     # +interpolator+ - the object used to interpolate filenames and URLs. Defaults to Paperclip::Interpolations
     # +url_generator+ - the object used to generate URLs, using the interpolator. Defaults to Paperclip::UrlGenerator
+    # +escape_url+ - Perform URI escaping to URLs. Defaults to true
     def initialize(name, instance, options = {})
       @name              = name
       @instance          = instance
@@ -134,7 +136,7 @@ module Paperclip
     # +#new(Paperclip::Attachment, options_hash)+
     # +#for(style_name, options_hash)+
     def url(style_name = default_style, options = {})
-      default_options = {:timestamp => @options[:use_timestamp], :escape => true}
+      default_options = {:timestamp => @options[:use_timestamp], :escape => @options[:escape_url]}
 
       if options == true || options == false # Backwards compatibility.
         @url_generator.for(style_name, default_options.merge(:timestamp => options))

--- a/test/attachment_test.rb
+++ b/test/attachment_test.rb
@@ -115,6 +115,28 @@ class AttachmentTest < Test::Unit::TestCase
     assert mock_url_generator_builder.has_generated_url_with_options?(:escape => true, :timestamp => true)
   end
 
+  should "pass the option :escape => true if :escape_url is true and :escape is not passed" do
+    mock_url_generator_builder = MockUrlGeneratorBuilder.new
+    attachment = Paperclip::Attachment.new(:name,
+                                           :instance,
+                                           :url_generator => mock_url_generator_builder,
+                                           :escape_url => true)
+
+    attachment.url(:style_name)
+    assert mock_url_generator_builder.has_generated_url_with_options?(:escape => true)
+  end
+
+  should "pass the option :escape => false if :escape_url is false and :escape is not passed" do
+    mock_url_generator_builder = MockUrlGeneratorBuilder.new
+    attachment = Paperclip::Attachment.new(:name,
+                                           :instance,
+                                           :url_generator => mock_url_generator_builder,
+                                           :escape_url => false)
+
+    attachment.url(:style_name)
+    assert mock_url_generator_builder.has_generated_url_with_options?(:escape => false)
+  end
+
   should "return the path based on the url by default" do
     @attachment = attachment :url => "/:class/:id/:basename"
     @model = @attachment.instance


### PR DESCRIPTION
Allow developers to escape URLs by default.
## Example

``` ruby
Paperclip::Attachment.default_options.update({
  :escape_url => false
})
```
## Why?

See [this issue](http://stackoverflow.com/questions/8053473/using-fog-for-rackspace-cloudfiles-eu-with-paperclip#11768980) on Stack Overflow.

**TL;DR:** Need to call `.url(:style, :escape => false)` for use with Rackspace CloudFiles. Don't want to have to do this for every image call.
