### PR TITLE
Default fog_public option to true *again* (as stated in documentation).

### DIFF
--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -70,14 +70,14 @@ module Paperclip
       end
 
       def fog_public(style = default_style)
-        if defined?(@options[:fog_public])
-          if defined?(@options[:fog_public][style])
-            return @options[:fog_public][style]
+        if @options.has_key?(:fog_public)
+          if @options[:fog_public].respond_to?(:has_key?) && @options[:fog_public].has_key?(style)
+            @options[:fog_public][style]
           else
-            return @options[:fog_public]
+            @options[:fog_public]
           end
         else
-          return true
+          true
         end
       end
 

--- a/test/storage/fog_test.rb
+++ b/test/storage/fog_test.rb
@@ -252,7 +252,7 @@ class FogTest < Test::Unit::TestCase
           @dummy.save
         end
 
-        should 'set the @fog_public for a perticular style to false' do
+        should 'set the @fog_public for a particular style to false' do
           assert_equal false, @dummy.avatar.instance_variable_get('@options')[:fog_public]
           assert_equal false, @dummy.avatar.fog_public(:thumb)
         end
@@ -267,9 +267,22 @@ class FogTest < Test::Unit::TestCase
           @dummy.save
         end
 
-        should 'set the fog_public for a perticular style to correct value' do
+        should 'set the fog_public for a particular style to correct value' do
           assert_equal false, @dummy.avatar.fog_public(:medium)
           assert_equal true, @dummy.avatar.fog_public(:thumb)
+        end
+      end
+
+      context "with fog_public not set" do
+        setup do
+          rebuild_model(@options)
+          @dummy = Dummy.new
+          @dummy.avatar = StringIO.new('.')
+          @dummy.save
+        end
+
+        should "default fog_public to true" do
+          assert_equal true, @dummy.avatar.fog_public
         end
       end
 


### PR DESCRIPTION
Pretty serious bug. The documentation says `fog_public` defaults to true but it defaults to false.

This was previously fixed in pull request #539 but no spec was added at that time, and it has since been broken.

I fixed it and added a spec.
