### PR TITLE
Add #blank? to Attachment

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -310,6 +310,10 @@ module Paperclip
 
     alias :present? :file?
 
+    def blank?
+      not present?
+    end
+
     # Determines whether the instance responds to this attribute. Used to prevent
     # calculations on fields we won't even store.
     def instance_respond_to?(attr)

--- a/test/attachment_test.rb
+++ b/test/attachment_test.rb
@@ -6,6 +6,29 @@ class Dummy; end
 
 class AttachmentTest < Test::Unit::TestCase
 
+  context "presence" do
+    setup do
+      rebuild_class
+      @dummy = Dummy.new
+    end
+
+    context "when file not set" do
+      should "not be present" do
+        assert @dummy.avatar.blank?
+        refute @dummy.avatar.present?
+      end
+    end
+
+    context "when file set" do
+      setup { @dummy.avatar = File.new(fixture_file("50x50.png"), "rb") }
+
+      should "be present" do
+        refute @dummy.avatar.blank?
+        assert @dummy.avatar.present?
+      end
+    end
+  end
+
   should "process :original style first" do
     file = File.new(fixture_file("50x50.png"), 'rb')
     rebuild_class :styles => { :small => '100x>', :original => '42x42#' }


### PR DESCRIPTION
I was thinking that it would be logical if `Attachment`s also had `#blank?` (along with `#present?`).
