### PR TITLE
Allow rbx to fail in 1.9 mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ rvm:
   - 1.9.2
   - 1.9.3
   - jruby-19mode
+  - rbx-19mode
 
 before_script: "sudo ntpdate -ub ntp.ubuntu.com pool.ntp.org; true"
 script: "bundle exec rake clean test cucumber"
@@ -14,3 +15,4 @@ gemfile:
 matrix:
   allow_failures:
     - rvm: jruby-19mode
+    - rvm: rbx-19mode


### PR DESCRIPTION
If it passes on first run then it'd be nice to remove
the allowed failure. Thanks.
