### PR TITLE
Add FakeModel#valid?

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -125,6 +125,10 @@ class FakeModel
 
   def run_paperclip_callbacks name, *args
   end
+
+  def valid?
+    errors.empty?
+  end
 end
 
 def attachment(options={})


### PR DESCRIPTION
https://github.com/thoughtbot/paperclip/commit/1544a7b2f054b53a52aa53a12f471d1a1bb36ca6 broke tests using `FakeModel` which does not respod to `valid?`. This commit extends  `FakeModel` with that method and fixes tests.
