### PR TITLE
fix generator deprecation warning

### DIFF
--- a/lib/generators/paperclip/templates/paperclip_migration.rb.erb
+++ b/lib/generators/paperclip/templates/paperclip_migration.rb.erb
@@ -2,7 +2,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration
   def self.up
     change_table :<%= table_name %> do |t|
 <% attachment_names.each do |attachment| -%>
-      t.has_attached_file :<%= attachment %>
+      t.attachment :<%= attachment %>
 <% end -%>
     end
   end

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -20,7 +20,7 @@ class GeneratorTest < Rails::Generators::TestCase
           assert_class_method :up, migration do |up|
             expected = <<-migration
               change_table :users do |t|
-                t.has_attached_file :avatar
+                t.attachment :avatar
               end
             migration
 
@@ -50,8 +50,8 @@ class GeneratorTest < Rails::Generators::TestCase
           assert_class_method :up, migration do |up|
             expected = <<-migration
               change_table :users do |t|
-                t.has_attached_file :avatar
-                t.has_attached_file :photo
+                t.attachment :avatar
+                t.attachment :photo
               end
             migration
 


### PR DESCRIPTION
While setting up my app with paperclip I found that the migration generator created some code that triggered a deprecation warning. It seems like the method has been renamed, but not yet in the template that is used for the generation of the migration.

replace t.has_attached_file with t.attachment. Also changed the tests accordingly.

I did not get a passing codebase but my results are the same as in the latest travis builds. When the repo is green again I can do a rebase if required. It's not a big bugfix, tiny as they come actually, so it should be easy to keep up-to-date.
