### PR TITLE
Ensure the handle is closed after using OpenURI to get a remote file

### DIFF
--- a/lib/paperclip/io_adapters/uri_adapter.rb
+++ b/lib/paperclip/io_adapters/uri_adapter.rb
@@ -32,6 +32,7 @@ module Paperclip
       while data = src.read(16*1024)
         destination.write(data)
       end
+      src.close
       destination.rewind
       destination
     end

--- a/test/io_adapters/uri_adapter_test.rb
+++ b/test/io_adapters/uri_adapter_test.rb
@@ -14,6 +14,10 @@ class UriProxyTest < Test::Unit::TestCase
       assert_equal "thoughtbot-logo.png", @subject.original_filename
     end
 
+    should 'close open handle after reading' do
+      assert_equal true, @open_return.closed?
+    end
+
     should "return a content type" do
       assert_equal "image/png", @subject.content_type
     end


### PR DESCRIPTION
In reference to https://github.com/thoughtbot/paperclip/issues/1022 - this does $SUBJECT
