### PR TITLE
New rake task for changing attachment options

### DIFF
--- a/lib/tasks/paperclip.rake
+++ b/lib/tasks/paperclip.rake
@@ -46,7 +46,7 @@ namespace :paperclip do
         attachment = instance.send(name)
         if file = Paperclip.io_adapters.for(attachment)
           options = attachment.options
-          # Check that :path and :url are different at least
+          # Check that :path or :url is different at least
           unless ENV['FORCE'] || ENV['force'] ||
                  (new_options[:url] && options[:url] != new_options[:url]) ||
                  (new_options[:path] && options[:path] != new_options[:path])
@@ -58,8 +58,13 @@ If you're willing to risk file overwrites, re-run the task with FORCE=true
 
           # Create a new Attachment instance for initialization
           options.merge!(new_options)
+
+          # Updated_at is a default interpolator in :hash_data, so manually set
+          # it to avoid unintended issues with :hash paths
+          original_update_time = attachment.updated_at
           new_att = Paperclip::Attachment.new(name, instance, options)
           new_att.assign(file)
+          new_att.instance_write(:updated_at, original_update_time)
           unless new_att.save
             puts "errors while changing options for #{klass} ID #{instance.id}:"
             puts " " + instance.errors.full_messages.join("\n ") + "\n"


### PR DESCRIPTION
I found myself facing the not-uncommon problem of wanting to move my paperclip attachments to Amazon S3, as well as the perhaps less common problem of needing to change the hash_secret. After some Googling without finding anything that felt quite right, I tried to make a solution flexible enough for any kind of option change. It's nevertheless wise not to accept new uploads while making this kind of migration!

The new rake task paperclip:change_options takes the same environment variables as the refresh functions: CLASS and an optional ATTACHMENT. It reads the options in config/new_paperclip_options.yml as an ERB YAML file, just like database.yml, and merges them onto the attachment's existing options. A temporary attachment instance is then created and saved with the modified options, but the original attachment and model are unaffected.

Once the task has been run, you can update the actual has_attached_file options to match new_paperclip_options.yml. After deploying, paperclip will find the new files instead. In case of typos in the options or meteor strike, reversion is also painless since the original files are not affected at all.

I did not see any tests for the other rake tasks, so I wasn't sure what to do to test this, but I'd be happy to add a commit with specs if you can point me in the right direction. I did migrate my own app's user content to S3 with a new hash_secret using this without any trouble.
