### PR TITLE
backport of "Check attachment paths for duplicates, not URLs"

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -191,14 +191,15 @@ module Paperclip
       end
     end
 
-    def check_for_url_clash(name,url,klass)
-      @names_url ||= {}
-      default_url = url || Attachment.default_options[:url]
-      if @names_url[name] && @names_url[name][:url] == default_url && @names_url[name][:class] != klass && @names_url[name][:url] !~ /:class/
-        log("Duplicate URL for #{name} with #{default_url}. This will clash with attachment defined in #{@names_url[name][:class]} class")
+    def check_for_path_clash(name,path,klass)
+      @names_path ||= {}
+      default_path = path || Attachment.default_options[:path]
+      if @names_path[name] && @names_path[name][:path] == default_path && @names_path[name][:class] != klass && @names_path[name][:path] !~ /:class/
+        log("Duplicate path for #{name} with #{default_path}. This will clash with attachment defined in #{@names_path[name][:class]} class")
       end
-      @names_url[name] = {:url => default_url, :class => klass}
+      @names_path[name] = {:path => default_path, :class => klass}
     end
+
 
     def reset_duplicate_clash_check!
       @names_url = nil
@@ -332,7 +333,7 @@ module Paperclip
 
       attachment_definitions[name] = Paperclip::AttachmentOptions.new(options)
       Paperclip.classes_with_attachments << self.name
-      Paperclip.check_for_url_clash(name,attachment_definitions[name][:url],self.name)
+      Paperclip.check_for_path_clash(name,attachment_definitions[name][:path],self.name)
 
       after_save :save_attached_files
       before_destroy :prepare_for_destroy

--- a/test/paperclip_test.rb
+++ b/test/paperclip_test.rb
@@ -85,23 +85,34 @@ class PaperclipTest < Test::Unit::TestCase
       end
     end
 
-    should "generate warning if attachment is redefined with the same url string" do
-      Paperclip.expects(:log).with("Duplicate URL for blah with /system/:attachment/:id/:style/:filename. This will clash with attachment defined in Dummy class")
+    should "generate warning if attachment is redefined with the same path string" do
+      expected_log_msg = "Duplicate path for blah with /system/:id/:style/:filename. This will clash with attachment defined in Dummy class"
+      Paperclip.expects(:log).with(expected_log_msg)
       Dummy.class_eval do
-        has_attached_file :blah
+        has_attached_file :blah, :path => '/system/:id/:style/:filename'
       end
       Dummy2.class_eval do
-        has_attached_file :blah
+        has_attached_file :blah, :path => '/system/:id/:style/:filename'
       end
     end
 
-    should "not generate warning if attachment is redifined with the same url string but has :class in it" do
+    should "not generate warning if attachment is redefined with the same path string but has :class in it" do
       Paperclip.expects(:log).never
       Dummy.class_eval do
-        has_attached_file :blah, :url => "/system/:class/:attachment/:id/:style/:filename"
+        has_attached_file :blah, :path => "/system/:class/:attachment/:id/:style/:filename"
       end
       Dummy2.class_eval do
-        has_attached_file :blah, :url => "/system/:class/:attachment/:id/:style/:filename"
+        has_attached_file :blah, :path => "/system/:class/:attachment/:id/:style/:filename"
+      end
+    end
+
+    should "not generate warning if attachment is defined with the same URL string" do
+      Paperclip.expects(:log).never
+      Dummy.class_eval do
+        has_attached_file :blah, :path => "/system/:class/:attachment/:id/:style/:filename", :url => ":s3_alias_url"
+      end
+      Dummy2.class_eval do
+        has_attached_file :blah, :path => "/system/:class/:attachment/:id/:style/:filename", :url => ":s3_alias_url"
       end
     end
   end


### PR DESCRIPTION
Backport of patch to v2.7 branch.  Original patch details:

> As per discussion in issue #660, attachments using alias interpolations
> for the attachment URL mistakenly get flagged as being duplicates,
> although the interpolation expands to a unique location.
> 
> This commit (partially) addresses the issue by checking the attachment path
> instead. However, the problem will remain for users who use
> interpolations other than :class to distinguish attachment paths for
> different models.
