### PR TITLE
Special characters in filename raises an error on temp file creation: Paperclip::Errors::NotIdentifiedByImageMagickError

### DIFF
--- a/lib/paperclip/tempfile_factory.rb
+++ b/lib/paperclip/tempfile_factory.rb
@@ -1,7 +1,7 @@
 module Paperclip
   class TempfileFactory
 
-    ILLEGAL_FILENAME_CHARACTERS = /^~/
+    ILLEGAL_FILENAME_CHARACTERS = /[&$+,\/:;=?@<>\[\]\{\}\|\\\^~%# ]/
 
     def generate(name)
       @name = name

--- a/test/tempfile_factory_test.rb
+++ b/test/tempfile_factory_test.rb
@@ -1,13 +1,19 @@
 require './test/helper'
 
 class Paperclip::TempfileFactoryTest < Test::Unit::TestCase
+    
   should "be able to generate a tempfile with the right name" do
     file = subject.generate("omg.png")
   end
-  should "be able to generate a tempfile with the right name with a tilde at the beginning" do
-    file = subject.generate("~omg.png")
-  end
-  should "be able to generate a tempfile with the right name with a tilde at the end" do
-    file = subject.generate("omg.png~")
+
+  context "Name of temp file" do
+
+    should "should not contain illegal character" do
+      "&$+,/:;=?@<>[]{}|\^~%# ".split(//).each do |character|
+        file = subject.generate("#{character}filename.png")
+        !File.basename(file.path).include? character
+      end
+    end
+
   end
 end


### PR DESCRIPTION
I'm using rails with ckeditor gem, mongoid-paperclip gem, aws-s3 gem in my project. When I try to upload a file that contains special characters, if fails, and raises the error: 

```
Paperclip::Errors::NotIdentifiedByImageMagickError
```

After some digging I found that the method who fails is in lib/paperclip/geometry_detector_factory.rb line 18:

```
Paperclip.run("identify", "-format '%wx%h,%[exif:orientation]' :file", :file => "#{path}[0]")
```

I tried to run the command with two tempfiles in rails console:

One without special characters:

```
1.9.3p194 :004 > Paperclip.run("identify", "-format %m :file", :file => "/tmp/temp20130110-28658-1epo2cs.png[0]")
Command :: identify -format %m '/tmp/temp20130110-28658-1epo2cs.png[0]'
=> "PNG\n" 
```

and one with special characters:

```
Paperclip.run("identify", "-format %m :file", :file => "/tmp/photo:d20130110-24387-18rbumv.png[0]")
Command :: identify -format %m '/tmp/photo:d20130110-24387-18rbumv.png[0]'
identify.im6: unable to open image `d20130110-24387-18rbumv.png': No such file or directory @ error/blob.c/OpenBlob/2638.
identify.im6: unable to open file `d20130110-24387-18rbumv.png' @ error/png.c/ReadPNGImage/3667.
```

Cocaine::ExitStatusError: Command 'identify -format %m :file' returned 1. Expected 0

My pull request just changes every special character into an underscore when the temp file gets created. I don't know paperclip good enough to be sure that nothing breaks because of this. But it seems to work, and all the test passed as well, so...
