### PR TITLE
Memoize :class and :attachment interpolations for speed

### DIFF
--- a/lib/paperclip/interpolations.rb
+++ b/lib/paperclip/interpolations.rb
@@ -81,7 +81,8 @@ module Paperclip
     # all class names. Calling #class will return the expected class.
     def class attachment = nil, style_name = nil
       return super() if attachment.nil? && style_name.nil?
-      attachment.instance.class.to_s.underscore.pluralize
+      klass = attachment.instance.class
+      InterpolationMemos.klass[klass] ||= klass.to_s.underscore.pluralize
     end
 
     # Returns the basename of the file. e.g. "file" for "file.jpg"
@@ -169,12 +170,25 @@ module Paperclip
     # Returns the pluralized form of the attachment name. e.g.
     # "avatars" for an attachment of :avatar
     def attachment attachment, style_name
-      attachment.name.to_s.downcase.pluralize
+      name = attachment.name
+      InterpolationMemos.attachment[name] ||= name.to_s.downcase.pluralize
     end
 
     # Returns the style, or the default style if nil is supplied.
     def style attachment, style_name
       style_name || attachment.default_style
     end
+
+    module InterpolationMemos
+      extend self
+      def klass
+        @klass_memos ||= {}
+      end
+
+      def attachment
+        @attachment_memos ||= {}
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Hi,

In our app we use paperclip very heavily, and often have pages with ~100 paperclip-generated URLs on them. Doing some profiling recently, I noticed that these were very expensive, on some pages taking ~200ms in total (others seem to have noticed this too, e.g. in issue #557).

The main expense is in performing interpolations on the path/URL patterns. In particular, the `:class` and `:attachment` interpolations are very expensive, mostly (as far as I can tell) as a result of calling the `#pluralize` inflection.

As these will never change, memoizing them improves their performance significantly. The attached patch does this with some hashes stored in a nested module. For 10k calls to `#image(:original)` on an example model in our app, this resulted in about an order of magnitude improvement:

```
                          user     system      total        real
without memoization: 12.120000   0.400000  12.520000 ( 12.540598)
with memoization:     1.820000   0.000000   1.820000 (  1.829574) 
```

I'm not completely happy with having the memos stored as global state like this, but as the interpolations are currently implemented as global methods on the Interpolations module, I don't see much alternative, and thought the performance gains were sufficiently large to make it worth submitting as is. I'd be interested to hear your thoughts...

All the best,
Simon
