### PR TITLE
Fix s3 writes with style procs

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -311,9 +311,10 @@ module Paperclip
             end
 
             style_specific_options = styles[style]
-            if style_specific_options.is_a?(Hash)
-              merge_s3_headers( style_specific_options[:s3_headers], @s3_headers, @s3_metadata) if style_specific_options.has_key?(:s3_headers)
-              @s3_metadata.merge!(style_specific_options[:s3_metadata]) if style_specific_options.has_key?(:s3_metadata)
+
+            if style_specific_options
+              merge_s3_headers( style_specific_options[:s3_headers], @s3_headers, @s3_metadata) if style_specific_options[:s3_headers]
+              @s3_metadata.merge!(style_specific_options[:s3_metadata]) if style_specific_options[:s3_metadata]
             end
 
             write_options[:metadata] = @s3_metadata unless @s3_metadata.empty?


### PR DESCRIPTION
Hi @thoughtbot,

S3#flush_writes was accessing the styles option without checking for a
proc. We can just use the instance's styles method to have it done for
us.

(Updated)

@donaldpiret correctly pointed out that the custom s3 options are being set inside a conditional guarded by a type check. This PR refactors the code for the s3 options so that the guards are not `Hash`-specific.
