### PR TITLE
Add default_url option to Quick Start example

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ In your model:
 ```ruby
 class User < ActiveRecord::Base
   attr_accessible :avatar
-  has_attached_file :avatar, :styles => { :medium => "300x300>", :thumb => "100x100>" }
+  has_attached_file :avatar, :styles => { :medium => "300x300>", :thumb => "100x100>" }, :default_url => "/images/:style/missing.png"
 end
 ```
 


### PR DESCRIPTION
It took me a lot of digging to figure out how to add the
`:default_url` option, but it seems a common option that many
people will need to modify. Putting it anywhere in the README
will help those who just cmd-F on the page, like me.
