### PR TITLE
Clearing an attachment when preserve_files is enabled has no effect

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -231,10 +231,8 @@ module Paperclip
     # nil to the attachment *and saving*. This is permanent. If you wish to
     # wipe out the existing attachment but not save, use #clear.
     def destroy
-      unless @options[:preserve_files]
-        clear
-        save
-      end
+      clear
+      save
     end
 
     # Returns the uploaded file if present.
@@ -452,10 +450,12 @@ module Paperclip
     end
 
     def queue_all_for_delete #:nodoc:
-      return if @options[:preserve_files] || !file?
-      @queued_for_delete += [:original, *styles.keys].uniq.map do |style|
-        path(style) if exists?(style)
-      end.compact
+      return if !file?
+      unless @options[:preserve_files]
+        @queued_for_delete += [:original, *styles.keys].uniq.map do |style|
+          path(style) if exists?(style)
+        end.compact
+      end
       instance_write(:file_name, nil)
       instance_write(:content_type, nil)
       instance_write(:file_size, nil)

--- a/test/attachment_test.rb
+++ b/test/attachment_test.rb
@@ -1317,6 +1317,12 @@ class AttachmentTest < Test::Unit::TestCase
       assert_file_exists(@path)
     end
 
+    should "clear out attachment data when attachment is destroyed" do
+      @attachment.destroy
+      assert !@attachment.exists?
+      assert_nil @dummy.avatar_file_name
+    end
+
     should "not delete the file when model is destroyed" do
       @dummy.destroy
       assert_file_exists(@path)


### PR DESCRIPTION
If you have an attachment where the preserve_files option is enabled and you attempt to clear the attachment, nothing happens.  After the save and reload the attachment will still exist and respond as if you never tried to clear it.

This pull request simply clears out the attachment fields on the instance, just like a call to clear when preserve_files is not enabled, only skipping adding the files to queued_for_delete. This way, the attachment behaves exactly as you expect. After clearing the attachment and saving the instance, the attachment will no longer be connected to the instance but the file will not be deleted.
