### PR TITLE
Make checking attachment path clashes optional

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -75,12 +75,13 @@ module Paperclip
   #   nil, which uses the first executable found in the user's search path.
   def self.options
     @options ||= {
-      :whiny             => true,
-      :image_magick_path => nil,
-      :command_path      => nil,
-      :log               => true,
-      :log_command       => true,
-      :swallow_stderr    => true
+      :whiny                => true,
+      :image_magick_path    => nil,
+      :command_path         => nil,
+      :log                  => true,
+      :log_command          => true,
+      :swallow_stderr       => true,
+      :check_for_path_clash => true,
     }
   end
 
@@ -183,7 +184,10 @@ module Paperclip
 
       attachment_definitions[name] = Paperclip::AttachmentOptions.new(options)
       Paperclip.classes_with_attachments << self.name
-      Paperclip.check_for_path_clash(name,attachment_definitions[name][:path],self.name)
+
+      if Paperclip.options[:check_for_path_clash]
+        Paperclip.check_for_path_clash(name,attachment_definitions[name][:path],self.name)
+      end
 
       after_save :save_attached_files
       before_destroy :prepare_for_destroy

--- a/test/paperclip_test.rb
+++ b/test/paperclip_test.rb
@@ -125,6 +125,16 @@ class PaperclipTest < Test::Unit::TestCase
       end
     end
 
+    should "not generate warning if clash checking is disabled" do
+      Paperclip.options[:check_for_path_clash] = false
+      Dummy.class_eval do
+        has_attached_file :blah, :path => '/system/:id/:style/:filename'
+      end
+      Dummy2.class_eval do
+        has_attached_file :blah, :path => '/system/:id/:style/:filename'
+      end
+    end
+
     should "not generate warning if attachment is redefined with the same path string but has :class in it" do
       Paperclip.expects(:log).never
       Dummy.class_eval do


### PR DESCRIPTION
Hi,

As the attachment clash checker is still generating false positives (#1143) despite being modified to look at attachment paths rather than URLs, I thought it would be useful to add an option to disable it - code and test attached.

Alternatively, since it was originally introduced to address unsafe default settings that have been fixed since v3.0, perhaps it's safe to completely remove? If you'd prefer, I can submit a PR to do that instead...

Cheers,
Simon
