### PR TITLE
Gemfile.lock updated for Paperclip 3.4.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    paperclip (3.4.0)
+    paperclip (3.4.1)
       activemodel (>= 3.0.0)
       activerecord (>= 3.0.0)
       activesupport (>= 3.0.0)


### PR DESCRIPTION
Since Gemfile.lock is checked in, seems like it wants to be updated following the 3.4.1 release?
