### PR TITLE
Changed Spec::Runner to RSpec.

### DIFF
--- a/lib/paperclip/matchers.rb
+++ b/lib/paperclip/matchers.rb
@@ -15,7 +15,7 @@ module Paperclip
     #
     # And _include_ the module:
     #
-    #   Spec::Runner.configure do |config|
+    #   RSpec.configure do |config|
     #     config.include Paperclip::Shoulda::Matchers
     #   end
     #


### PR DESCRIPTION
It's just a simple documentation fix. I used your exmaple and I got deprecated warnings with RSpec 2.12.
