### PR TITLE
Fix tests from animated gif layers optimize change

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -197,3 +197,11 @@ end
 def assert_file_not_exists(path)
   assert !File.exists?(path), %(Expect "#{path}" to not exists.)
 end
+
+def assert_frame_dimensions(range, frames)
+  frames.each_with_index do |frame, idx|
+    frame.split('x').each_with_index do |dim, idx|
+      assert range.include?(dim.to_i), "Frame #{idx}[#{idx}] should have been within #{range.inspect}, but was #{dim}"
+    end
+  end
+end

--- a/test/thumbnail_test.rb
+++ b/test/thumbnail_test.rb
@@ -380,8 +380,10 @@ class ThumbnailTest < Test::Unit::TestCase
 
       should "create the 12 frames thumbnail when sent #make" do
         dst = @thumb.make
-        cmd = %Q[identify -format "%wx%h" "#{dst.path}"]
-        assert_equal ("50x5050x5050x5050x5050x5050x49")*2, `#{cmd}`.chomp
+        cmd = %Q[identify -format "%wx%h," "#{dst.path}"]
+        frames = `#{cmd}`.chomp.split(',')
+        assert_equal 12, frames.size
+        assert_frame_dimensions (45..50), frames
       end
 
       should "use the -coalesce option" do
@@ -400,8 +402,10 @@ class ThumbnailTest < Test::Unit::TestCase
 
       should "create the 12 frames thumbnail when sent #make" do
         dst = @thumb.make
-        cmd = %Q[identify -format "%wx%h" "#{dst.path}"]
-        assert_equal ("50x5050x5050x5050x5050x5050x49")*2, `#{cmd}`.chomp
+        cmd = %Q[identify -format "%wx%h," "#{dst.path}"]
+        frames = `#{cmd}`.chomp.split(',')
+        assert_equal 12, frames.size
+        assert_frame_dimensions (45..50), frames
       end
 
       should "use the -coalesce option" do
@@ -421,9 +425,10 @@ class ThumbnailTest < Test::Unit::TestCase
 
       should "create the 12 frames thumbnail when sent #make" do
         dst = @thumb.make
-        cmd = %Q[identify -format "%wx%h" "#{dst.path}"]
-        assert_equal "60x6059x5959x5959x5960x5959x5859x6059x5959x5959x5960x5959x58", `#{cmd}`.chomp
-
+        cmd = %Q[identify -format "%wx%h," "#{dst.path}"]
+        frames = `#{cmd}`.chomp.split(',')
+        assert_equal 12, frames.size
+        assert_frame_dimensions (55..60), frames
       end
 
       should "use the -coalesce option" do
@@ -443,8 +448,10 @@ class ThumbnailTest < Test::Unit::TestCase
 
       should "create the 12 frames thumbnail when sent #make" do
         dst = @thumb.make
-        cmd = %Q[identify -format "%wx%h" "#{dst.path}"]
-        assert_equal "70x7067x6867x6868x6769x6767x6768x6967x6867x6868x6769x6767x67", `#{cmd}`.chomp
+        cmd = %Q[identify -format "%wx%h," "#{dst.path}"]
+        frames = `#{cmd}`.chomp.split(',')
+        assert_equal 12, frames.size
+        assert_frame_dimensions (60..70), frames
       end
 
       should "use the -coalesce option" do


### PR DESCRIPTION
### WHAT

Adds an `assert_frame_dimensions` test helper for testing the size of generated gif frames, and fixes appropriate tests.
### WHY

When we added the last optimized animated gif option, different build boxes generated slightly different sized frames of GIFs. This just tests that they're within a range.
