### PR TITLE
Remove attachment path clash checker

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -182,7 +182,6 @@ module Paperclip
 
       attachment_definitions[name] = Paperclip::AttachmentOptions.new(options)
       Paperclip.classes_with_attachments << self.name
-      Paperclip.check_for_path_clash(name,attachment_definitions[name][:path],self.name)
 
       after_save :save_attached_files
       before_destroy :prepare_for_destroy

--- a/lib/paperclip/helpers.rb
+++ b/lib/paperclip/helpers.rb
@@ -49,15 +49,6 @@ module Paperclip
       end
     end
 
-    def check_for_path_clash(name,path,klass)
-      @names_path ||= {}
-      default_path = path || Attachment.default_options[:path]
-      if @names_path[name] && @names_path[name][:path] == default_path && @names_path[name][:class] != klass && @names_path[name][:path] !~ /:class/
-        log("Duplicate path for #{name} with #{default_path}. This will clash with attachment defined in #{@names_path[name][:class]} class")
-      end
-      @names_path[name] = {:path => default_path, :class => klass}
-    end
-
     def reset_duplicate_clash_check!
       @names_url = nil
     end

--- a/test/paperclip_test.rb
+++ b/test/paperclip_test.rb
@@ -107,45 +107,6 @@ class PaperclipTest < Test::Unit::TestCase
     end
   end
 
-  context "Attachments with clashing URLs should raise error" do
-    setup do
-      class Dummy2 < ActiveRecord::Base
-        include Paperclip::Glue
-      end
-    end
-
-    should "generate warning if attachment is redefined with the same path string" do
-      expected_log_msg = "Duplicate path for blah with /system/:id/:style/:filename. This will clash with attachment defined in Dummy class"
-      Paperclip.expects(:log).with(expected_log_msg)
-      Dummy.class_eval do
-        has_attached_file :blah, :path => '/system/:id/:style/:filename'
-      end
-      Dummy2.class_eval do
-        has_attached_file :blah, :path => '/system/:id/:style/:filename'
-      end
-    end
-
-    should "not generate warning if attachment is redefined with the same path string but has :class in it" do
-      Paperclip.expects(:log).never
-      Dummy.class_eval do
-        has_attached_file :blah, :path => "/system/:class/:attachment/:id/:style/:filename"
-      end
-      Dummy2.class_eval do
-        has_attached_file :blah, :path => "/system/:class/:attachment/:id/:style/:filename"
-      end
-    end
-
-    should "not generate warning if attachment is defined with the same URL string" do
-      Paperclip.expects(:log).never
-      Dummy.class_eval do
-        has_attached_file :blah, :path => "/system/:class/:attachment/:id/:style/:filename", :url => ":s3_alias_url"
-      end
-      Dummy2.class_eval do
-        has_attached_file :blah, :path => "/system/:class/:attachment/:id/:style/:filename", :url => ":s3_alias_url"
-      end
-    end
-  end
-
   context "An ActiveRecord model with an 'avatar' attachment" do
     setup do
       rebuild_model :path => "tmp/:class/omg/:style.:extension"


### PR DESCRIPTION
As requested in #1143, this removes the attachment path clash checker, as there seemed to be broad agreement that it's redundant now that the default settings are safe.
