### PR TITLE
Test case for valid_assignment?

### DIFF
--- a/test/attachment_processing_test.rb
+++ b/test/attachment_processing_test.rb
@@ -26,4 +26,23 @@ class AttachmentProcessingTest < Test::Unit::TestCase
 
     attachment.assign(file)
   end
+
+  should 'process attachments given a valid assignment and a valid parent' do
+    file = File.new(fixture_file("5k.png"))
+    build_parent
+    Dummy.belongs_to :parent, :inverse_of => :dummies
+    Dummy.validates_attachment_content_type :avatar, :content_type => "image/png"
+    Dummy.validates_attachment_presence :avatar, :if => :parent_checked?
+    Dummy.class_eval do
+      define_method(:parent_checked?) do
+        parent.checked?
+      end
+    end
+
+    instance = Parent.new(:checked => true, :dummies_attributes => { 0 => { :avatar => file }})
+    attachment = instance.dummies.first.avatar
+    attachment.expects(:post_process)
+
+    attachment.assign(file)
+  end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -93,8 +93,24 @@ def rebuild_model options = {}
     table.column :avatar_file_size, :integer
     table.column :avatar_updated_at, :datetime
     table.column :avatar_fingerprint, :string
+    table.column :parent_id, :integer
   end
   rebuild_class options
+end
+
+def build_parent
+  ActiveRecord::Base.connection.create_table :parents, :force => true do |table|
+    table.column :checked, :boolean
+  end
+
+  build_parent_class
+end
+
+def build_parent_class
+  reset_class("Parent").tap do |klass|
+    klass.has_many :dummies, :inverse_of => :parent
+    klass.accepts_nested_attributes_for :dummies
+  end
 end
 
 def rebuild_class options = {}


### PR DESCRIPTION
ref #878

When the `valid?` method is being called, the AR object loses track of the parent AR.

I wrote a test which reproduce the behavior.
