### PR TITLE
Changed RSpec module name

### DIFF
--- a/lib/paperclip/matchers.rb
+++ b/lib/paperclip/matchers.rb
@@ -15,7 +15,7 @@ module Paperclip
     #
     # And _include_ the module:
     #
-    #   Spec::Runner.configure do |config|
+    #   RSpec.configure do |config|
     #     config.include Paperclip::Shoulda::Matchers
     #   end
     #


### PR DESCRIPTION
I changed the comment to use RSpec.configure since Spec::Runner.configure is deprecated in RSpec 2.
