### PR TITLE
Validate the attachment before we attach without calling valid?

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -105,7 +105,7 @@ module Paperclip
 
       @dirty = true
 
-      post_process(*only_process) if post_processing && valid_assignment?
+      post_process(*only_process) if post_processing
 
       # Reset the file size if the original file was reprocessed.
       instance_write(:file_size,   @queued_for_write[:original].size)

--- a/lib/paperclip/validators/attachment_presence_validator.rb
+++ b/lib/paperclip/validators/attachment_presence_validator.rb
@@ -2,12 +2,10 @@ require 'active_model/validations/presence'
 
 module Paperclip
   module Validators
-    class AttachmentPresenceValidator < ActiveModel::Validations::PresenceValidator
-      def validate(record)
-        [attributes].flatten.map do |attribute|
-          if record.send(:read_attribute_for_validation, "#{attribute}_file_name").blank?
-            record.errors.add(attribute, :blank, options)
-          end
+    class AttachmentPresenceValidator < ActiveModel::EachValidator
+      def validate_each(record, attribute, value)
+        if record.send("#{attribute}_file_name").blank?
+          record.errors.add(attribute, :blank, options)
         end
       end
     end

--- a/test/validators_test.rb
+++ b/test/validators_test.rb
@@ -7,7 +7,7 @@ class ValidatorsTest < Test::Unit::TestCase
 
   context "using the helper" do
     setup do
-      Dummy.validates_attachment :avatar, :presence => true, :content_type => { :content_type => "image/jpg" }, :size => { :in => 0..10.kilobytes }
+      Dummy.validates_attachment :avatar, :presence => true, :content_type => { :content_type => "image/jpeg" }, :size => { :in => 0..10.kilobytes }
     end
 
     should "add the attachment_presence validator to the class" do
@@ -20,6 +20,13 @@ class ValidatorsTest < Test::Unit::TestCase
 
     should "add the attachment_size validator to the class" do
       assert Dummy.validators_on(:avatar).any?{ |validator| validator.kind == :attachment_size }
+    end
+
+    should 'prevent you from attaching a file that violates that validation' do
+      Dummy.class_eval{ validate(:name) { raise "DO NOT RUN THIS" } }
+      dummy = Dummy.new(:avatar => File.new(fixture_file("12k.png")))
+      assert_equal [:avatar_content_type, :avatar_file_size], dummy.errors.keys
+      assert_raise(RuntimeError){ dummy.valid? }
     end
   end
 end


### PR DESCRIPTION
Using the ActiveRecord validations is smart in order to lessen load on
the project to develop our own validators, but it's problematic in that
calling `valid?` on the record fires off all the other validations --
including those on fields which may not be set yet because of
mass-assignment. This commit will "pre-validate" the attachment's fields
so that it doesn't process an invalid attachment, but it does so by
running its validations manually on assignment.
