### PR TITLE
#expiring_url should return the specified default_url for missing attachments

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -164,6 +164,8 @@ module Paperclip
         if path
           base_options = { :expires => time, :secure => use_secure_protocol?(style_name) }
           s3_object(style_name).url_for(:read, base_options.merge(s3_url_options)).to_s
+        else
+          url
         end
       end
 

--- a/test/storage/s3_test.rb
+++ b/test/storage/s3_test.rb
@@ -539,6 +539,18 @@ class S3Test < Test::Unit::TestCase
     end
   end
 
+  context "#expiring_url" do
+    setup { @dummy = Dummy.new }
+
+    context "with no attachment" do
+      setup { assert(!@dummy.avatar.exists?) }
+
+      should "return the default URL" do
+        assert_equal(@dummy.avatar.url, @dummy.avatar.expiring_url)
+      end
+    end
+  end
+
   context "Generating a url with an expiration for each style" do
     setup do
       rebuild_model :storage => :s3,


### PR DESCRIPTION
As described here: https://github.com/thoughtbot/paperclip/issues/746
