### PR TITLE
Remove ordering by id during refresh rake task

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -142,7 +142,7 @@ module Paperclip
     def each_instance_with_attachment(klass, name)
       unscope_method = class_for(klass).respond_to?(:unscoped) ? :unscoped : :with_exclusive_scope
       class_for(klass).send(unscope_method) do
-        class_for(klass).find(:all, :order => 'id').each do |instance|
+        class_for(klass).all.each do |instance|
           yield(instance) if instance.send(:"#{name}?")
         end
       end


### PR DESCRIPTION
Ordering by id breaks compatibility with tables having no column named "id" (e.g. if using a legacy database) without real benefit. While ordering makes multiple runs with errors deterministic, I suggest to rely on the database engine to return unordered results in a deterministic way (e.g. on-disk order). If ordering is a requirement, I suggest to put this feature back only without hardcoding the primary key name. Some people may even use composite primary keys which would break this in the same way.
