### PR TITLE
Remove isof output

### DIFF
--- a/lib/paperclip/tempfile_factory.rb
+++ b/lib/paperclip/tempfile_factory.rb
@@ -6,7 +6,6 @@ module Paperclip
       @name = name
       file = Tempfile.new([basename, extension])
       file.binmode
-      puts `lsof -p #{$$}`
       file
     end
 


### PR DESCRIPTION
This seems to be a debug output and actually floods testcases and seeds using file fixtures.
