### PR TITLE
Remove conditional version check on AWS SDK

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -99,14 +99,14 @@ module Paperclip
           raise e
         end unless defined?(AWS::Core)
 
-        # Overriding AWS::Core::LogFormatter to make sure it return a UTF-8 string
-        if AWS::VERSION >= "1.3.9"
+        # Overriding log formatter to make sure it return a UTF-8 string
+        if defined?(AWS::Core::LogFormatter)
           AWS::Core::LogFormatter.class_eval do
             def summarize_hash(hash)
               hash.map { |key, value| ":#{key}=>#{summarize_value(value)}".force_encoding('UTF-8') }.sort.join(',')
             end
           end
-        else
+        elsif defined?(AWS::Core::ClientLogging)
           AWS::Core::ClientLogging.class_eval do
             def sanitize_hash(hash)
               hash.map { |key, value| "#{sanitize_value(key)}=>#{sanitize_value(value)}".force_encoding('UTF-8') }.sort.join(',')


### PR DESCRIPTION
Uh oh! It finally happened-- the `aws-sdk` gem rev'd to 1.10.0, which, although is still in 1.x, seemed to have broken a naive `AWS::VERSION` check at: https://github.com/thoughtbot/paperclip/blob/master/lib/paperclip/storage/s3.rb#L103

Since the comparison thinks 1.3 > 1.1 as a string, it breaks loading of paperclip, which was [reported on our forums](https://forums.aws.amazon.com/thread.jspa?threadID=124605&tstart=0) today.

I've gone ahead and fixed the offending code, using a defined? check on the classes instead, which should be much more future-proof and robust.

Tests seem to pass for me.
