### PR TITLE
Stub continue_timeout= for Net::HTTP 1.9.3

### DIFF
--- a/features/support/fakeweb.rb
+++ b/features/support/fakeweb.rb
@@ -4,7 +4,10 @@ FakeWeb.allow_net_connect = false
 
 module FakeWeb
   class StubSocket
-    def read_timeout=(ignored)
+    def read_timeout=(_ignored)
+    end
+
+    def continue_timeout=(_ignored)
     end
   end
 end


### PR DESCRIPTION
This is to fix the remaining CI failure.
