### PR TITLE
Fix bundler dependency resolution during development

### DIFF
--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -49,5 +49,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake')
   s.add_development_dependency('fakeweb')
   s.add_development_dependency('railties')
-  s.add_development_dependency('actionmailer')
+  s.add_development_dependency('actionmailer', '>= 3.0.0')
 end


### PR DESCRIPTION
This allows bundler to complete gem dependency resolution during development.
This is only relevant for paperclip developers. Please see: 
https://github.com/thoughtbot/paperclip/issues/1256 and thanks to
@nkondratyev
