### PR TITLE
Added exception handling to paperclip:refresh:thumbnails rake task.

### DIFF
--- a/lib/tasks/paperclip.rake
+++ b/lib/tasks/paperclip.rake
@@ -18,7 +18,7 @@ module Paperclip
     end
 
     def self.log_error(error)
-      puts error
+      $stderr.puts error
     end
   end
 end

--- a/test/rake_test.rb
+++ b/test/rake_test.rb
@@ -53,7 +53,6 @@ class RakeTest < Test::Unit::TestCase
         end
         ::Rake::Task['paperclip:refresh:thumbnails'].execute
       end
-
     end
 
     context "when there is an error in reprocess!" do
@@ -91,7 +90,14 @@ class RakeTest < Test::Unit::TestCase
         end
         ::Rake::Task['paperclip:refresh:thumbnails'].execute
       end
+    end
+  end
 
+  context "Paperclip::Task.log_error method" do
+    should "print its argument to STDERR" do
+      msg = 'Some Message'
+      $stderr.expects(:puts).with(msg)
+      Paperclip::Task.log_error(msg)
     end
   end
 end


### PR DESCRIPTION
Addresses part 2 of https://github.com/thoughtbot/paperclip/issues/760, catching all exceptions coming out of reprocess! and printing them to STDOUT (the same way model errors are handled).
