### PR TITLE
Enforce agnosticism towards ActiveRecord; use ActiveModel

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -37,7 +37,7 @@ module Paperclip
     attr_accessor :post_processing
 
     # Creates an Attachment object. +name+ is the name of the attachment,
-    # +instance+ is the ActiveRecord object instance it's attached to, and
+    # +instance+ is the model object instance it's attached to, and
     # +options+ is the same as the hash passed to +has_attached_file+.
     #
     # Options include:

--- a/lib/paperclip/validators/attachment_content_type_validator.rb
+++ b/lib/paperclip/validators/attachment_content_type_validator.rb
@@ -53,7 +53,7 @@ module Paperclip
     end
 
     module HelperMethods
-      # Places ActiveRecord-style validations on the content type of the file
+      # Places ActiveModel validations on the content type of the file
       # assigned. The possible options are:
       # * +content_type+: Allowed content types.  Can be a single content type
       #   or an array.  Each type can be a String or a Regexp. It should be

--- a/lib/paperclip/validators/attachment_presence_validator.rb
+++ b/lib/paperclip/validators/attachment_presence_validator.rb
@@ -13,7 +13,7 @@ module Paperclip
     end
 
     module HelperMethods
-      # Places ActiveRecord-style validations on the presence of a file.
+      # Places ActiveModel validations on the presence of a file.
       # Options:
       # * +if+: A lambda or name of an instance method. Validation will only
       #   be run if this lambda or method returns true.

--- a/lib/paperclip/validators/attachment_size_validator.rb
+++ b/lib/paperclip/validators/attachment_size_validator.rb
@@ -88,7 +88,7 @@ module Paperclip
     end
 
     module HelperMethods
-      # Places ActiveRecord-style validations on the size of the file assigned. The
+      # Places ActiveModel validations on the size of the file assigned. The
       # possible options are:
       # * +in+: a Range of bytes (i.e. +1..1.megabyte+),
       # * +less_than+: equivalent to :in => 0..options[:less_than]

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -25,12 +25,12 @@ Gem::Specification.new do |s|
   s.requirements << "ImageMagick"
   s.required_ruby_version = ">= 1.9.2"
 
-  s.add_dependency('activerecord', '>= 3.0.0')
   s.add_dependency('activemodel', '>= 3.0.0')
   s.add_dependency('activesupport', '>= 3.0.0')
   s.add_dependency('cocaine', '~> 0.5.0')
   s.add_dependency('mime-types')
 
+  s.add_development_dependency('activerecord', '>= 3.0.0')
   s.add_development_dependency('shoulda')
   s.add_development_dependency('appraisal')
   s.add_development_dependency('mocha')


### PR DESCRIPTION
Paperclip is already agnostic towards ActiveRecord, i.e. it checks that AR is defined before including AR-specific code.

This commit does two things to enforce this agnosticism:
- Remove AR as a production gem dependency, make it a dev (test) dependency instead.
- Change comments to reflect AR vs. AM where appropriate

Lastly, although I have **not** included it in this PR, I would urge that Mongoid support (i.e. the `mongoid-paperclip` gem) be merged into the core of Paperclip. It is straightforward to do since Mongoid uses ActiveModel. I'd be glad to do this work if its acceptable to thoughtbot team.
