### PR TITLE
changed to look for older versions of active support and active record s...

### DIFF
--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
 
   s.requirements << "ImageMagick"
 
-  s.add_dependency('activerecord', '>= 2.3.0')
-  s.add_dependency('activesupport', '>= 2.3.2')
+  s.add_dependency('activerecord', '~> 2.3.0')
+  s.add_dependency('activesupport', '~> 2.3.2')
   s.add_dependency('cocaine', '~> 0.3.0')
   s.add_dependency('mime-types')
 


### PR DESCRIPTION
...o as to maintain ruby 1.8.7 compatibility

Small change to gemspec which forces older version of activesupport(latest ActiveSupport 4.0 does not support ruby 1.8.7)
