### PR TITLE
activesupport ruby 1.8.7 fix (v2.7.x)

### DIFF
--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
 
   s.requirements << "ImageMagick"
 
-  s.add_dependency('activerecord', '>= 2.3.0')
-  s.add_dependency('activesupport', '>= 2.3.2')
+  s.add_dependency('activerecord', '< 4.0.0')
+  s.add_dependency('activesupport', '< 4.0.0')
   s.add_dependency('cocaine', '~> 0.3.0')
   s.add_dependency('mime-types')
 


### PR DESCRIPTION
activesupport (4.0.0) has dropped support for Ruby 1.8.7, so we need activesupport < 4.0.0 in the old branch.
