### PR TITLE
Overriding AWS::Core::LogFormatter to make sure it return a UTF-8 string

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -99,14 +99,14 @@ module Paperclip
           raise e
         end unless defined?(AWS::Core)
 
-        # Overriding AWS::Core::LogFormatter to make sure it return a UTF-8 string
-        if AWS::VERSION >= "1.3.9"
+	# Overriding log formatter to make sure it return a UTF-8 string
+        if defined?(AWS::Core::LogFormatter)
           AWS::Core::LogFormatter.class_eval do
             def summarize_hash(hash)
               hash.map { |key, value| ":#{key}=>#{summarize_value(value)}".force_encoding('UTF-8') }.sort.join(',')
             end
           end
-        else
+        elsif defined?(AWS::Core::ClientLogging)
           AWS::Core::ClientLogging.class_eval do
             def sanitize_hash(hash)
               hash.map { |key, value| "#{sanitize_value(key)}=>#{sanitize_value(value)}".force_encoding('UTF-8') }.sort.join(',')


### PR DESCRIPTION
Please add this commit in order to paperclip works properly with S3 on rails-4 branch.
