### PR TITLE
Revert Paperclip::Storage::Filesystem#flush_writes

### DIFF
--- a/lib/paperclip/storage/filesystem.rb
+++ b/lib/paperclip/storage/filesystem.rb
@@ -36,9 +36,13 @@ module Paperclip
       def flush_writes #:nodoc:
         @queued_for_write.each do |style_name, file|
           FileUtils.mkdir_p(File.dirname(path(style_name)))
-          File.open(path(style_name), "wb") do |new_file|
-            while chunk = file.read(16 * 1024)
-              new_file.write(chunk)
+          begin
+            FileUtils.mv(file.path, path(style_name))
+          rescue SystemCallError
+            File.open(path(style_name), "wb") do |new_file|
+              while chunk = file.read(16 * 1024)
+                new_file.write(chunk)
+              end
             end
           end
           unless @options[:override_file_permissions] == false


### PR DESCRIPTION
This commit makes this method move by default instead of copying, which 
should make it perform significantly better with large files. It falls back
to the old semantics if the mv fails.
