### PR TITLE
Expose the target of the uplodated_file_adapter and reconstruct it if it disappears during model validation.

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -377,7 +377,9 @@ module Paperclip
     end
 
     def valid_assignment? #:nodoc:
+      dont_forget_about_me = @queued_for_write[:original].target
       if instance.valid?
+        @queued_for_write[:original] = UploadedFileAdapter.new(dont_forget_about_me) if @queued_for_write[:original].nil?
         true
       else
         instance.errors.none? do |attr, message|

--- a/lib/paperclip/io_adapters/uploaded_file_adapter.rb
+++ b/lib/paperclip/io_adapters/uploaded_file_adapter.rb
@@ -11,6 +11,10 @@ module Paperclip
       end
     end
 
+    def target
+      @target
+    end
+
     class << self
       attr_accessor :content_type_detector
     end


### PR DESCRIPTION
We were experiencing a bug and this resolved our issue.
