### PR TITLE
Check for files to be closed using ObjectSpace

### DIFF
--- a/test/attachment_test.rb
+++ b/test/attachment_test.rb
@@ -38,8 +38,6 @@ class AttachmentTest < Test::Unit::TestCase
 
     # :small avatar should be 42px wide (processed original), not 50px (preprocessed original)
     assert_equal `identify -format "%w" "#{dummy.avatar.path(:small)}"`.strip, "42"
-
-    file.close
   end
 
   should "not delete styles that don't get reprocessed" do
@@ -280,8 +278,6 @@ class AttachmentTest < Test::Unit::TestCase
       @dummy.avatar = @file
     end
 
-    teardown { @file.close }
-
     should "make sure that they are interpolated correctly" do
       assert_equal "1024.omg/1024-bbq/1024what/000/001/024.wtf", @dummy.avatar.path
     end
@@ -515,8 +511,6 @@ class AttachmentTest < Test::Unit::TestCase
       @dummyB = Dummy.new(:other => 'b')
       @dummyB.avatar = @file
     end
-
-    teardown { @file.close }
 
     should "return correct path" do
       assert_equal "path/a.png", @dummyA.avatar.path
@@ -980,7 +974,6 @@ class AttachmentTest < Test::Unit::TestCase
     end
 
     teardown do
-      @file.close
       Paperclip::Attachment.default_options.merge!(@old_defaults)
     end
 
@@ -1009,7 +1002,6 @@ class AttachmentTest < Test::Unit::TestCase
     end
 
     teardown do
-      @file.close
       Paperclip::Attachment.default_options.merge!(@old_defaults)
     end
 
@@ -1216,8 +1208,6 @@ class AttachmentTest < Test::Unit::TestCase
       @file = File.new(fixture_file("5k.png"), 'rb')
     end
 
-    teardown { @file.close }
-
     should "not error when assigned an attachment" do
       assert_nothing_raised { @dummy.avatar = @file }
     end
@@ -1370,8 +1360,6 @@ class AttachmentTest < Test::Unit::TestCase
       @path = @attachment.path
     end
 
-    teardown { @file.close }
-
     should "not delete the files from storage when attachment is destroyed" do
       @attachment.destroy
       assert_file_exists(@path)
@@ -1399,8 +1387,6 @@ class AttachmentTest < Test::Unit::TestCase
       @attachment = @dummy.avatar
       @path = @attachment.path
     end
-
-    teardown { @file.close }
 
     should "not be deleted when the model fails to destroy" do
       @dummy.stubs(:destroy).raises(Exception)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -37,6 +37,14 @@ class Test::Unit::TestCase
       Rails.stubs(:const_defined?).with(:Railtie).returns(false)
     end
   end
+
+  def teardown
+    ObjectSpace.each_object File do |file|
+      if !file.closed? && file.path !~ /debug.log$/
+        file.close
+      end
+    end
+  end
 end
 
 $LOAD_PATH << File.join(ROOT, 'lib')

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -13,8 +13,6 @@ class IntegrationTest < Test::Unit::TestCase
       end
     end
 
-    teardown { @file.close }
-
     should "not exceed the open file limit" do
        assert_nothing_raised do
          dummies = Dummy.find(:all)
@@ -31,8 +29,6 @@ class IntegrationTest < Test::Unit::TestCase
       @dummy.avatar = @file
       assert @dummy.save
     end
-
-    teardown { @file.close }
 
     should "create its thumbnails properly" do
       assert_match /\b50x50\b/, `identify "#{@dummy.avatar.path(:thumb)}"`
@@ -90,8 +86,6 @@ class IntegrationTest < Test::Unit::TestCase
 
     end
 
-    teardown { @file.close }
-
     should "not create the thumbnails upon saving when post-processing is disabled" do
       @dummy.avatar.post_processing = false
       @dummy.avatar = @file
@@ -122,8 +116,6 @@ class IntegrationTest < Test::Unit::TestCase
       assert @dummy.save
       @dummy.avatar.post_processing = true
     end
-
-    teardown { @file.close }
 
     should "allow us to create all thumbnails in one go" do
       assert_file_not_exists(@thumb_small_path)
@@ -159,8 +151,6 @@ class IntegrationTest < Test::Unit::TestCase
     should "report the file size of the processed file and not the original" do
       assert_not_equal File.size(@file.path), @dummy.avatar.size
     end
-
-    teardown { @file.close }
   end
 
   context "A model with attachments scoped under an id" do
@@ -172,8 +162,6 @@ class IntegrationTest < Test::Unit::TestCase
       @file = File.new(fixture_file("5k.png"), 'rb')
       @dummy.avatar = @file
     end
-
-    teardown { @file.close }
 
     context "when saved" do
       setup do
@@ -218,7 +206,6 @@ class IntegrationTest < Test::Unit::TestCase
 
       teardown do
         File.umask @umask
-        @file.close
       end
 
       should "respect the current umask" do
@@ -235,10 +222,6 @@ class IntegrationTest < Test::Unit::TestCase
         rebuild_model :override_file_permissions => perms
         @dummy = Dummy.new
         @file  = File.new(fixture_file("5k.png"), 'rb')
-      end
-
-      teardown do
-        @file.close
       end
 
       should "respect the current perms" do
@@ -274,8 +257,6 @@ class IntegrationTest < Test::Unit::TestCase
       assert @dummy.valid?, @dummy.errors.full_messages.join(", ")
       assert @dummy.save
     end
-
-    teardown { [@file, @bad_file].each(&:close) }
 
     should "write and delete its files" do
       [["434x66", :original],
@@ -370,8 +351,6 @@ class IntegrationTest < Test::Unit::TestCase
         @dummy2.save
       end
 
-      teardown { @file2.close }
-
       should "work when assigned a file" do
         assert_not_equal `identify -format "%wx%h" "#{@dummy.avatar.path(:original)}"`,
                          `identify -format "%wx%h" "#{@dummy2.avatar.path(:original)}"`
@@ -397,8 +376,6 @@ class IntegrationTest < Test::Unit::TestCase
       @dummy.avatar = @file
     end
 
-    teardown { @file.close }
-
     should "should not error when saving" do
       @dummy.save!
     end
@@ -415,10 +392,6 @@ class IntegrationTest < Test::Unit::TestCase
 
       @file = File.new(fixture_file("5k.png"), 'rb')
       @dummy = Dummy.create! :avatar => @file
-    end
-
-    teardown do
-      @file.close
     end
 
     should "be accessible" do
@@ -491,12 +464,6 @@ class IntegrationTest < Test::Unit::TestCase
         @dummy.save!
 
         @files_on_s3 = s3_files_for(@dummy.avatar)
-      end
-
-      teardown do
-        @file.close
-        @bad_file.close
-        @files_on_s3.values.each(&:close) if @files_on_s3
       end
 
       context 'assigning itself to a new model' do
@@ -629,8 +596,6 @@ class IntegrationTest < Test::Unit::TestCase
       rebuild_model
       @file = File.new(fixture_file("5k.png"), 'rb')
     end
-
-    teardown { @file.close }
 
     should "succeed when original attachment is a file" do
       original = Dummy.new

--- a/test/io_adapters/attachment_adapter_test.rb
+++ b/test/io_adapters/attachment_adapter_test.rb
@@ -17,10 +17,6 @@ class AttachmentAdapterTest < Test::Unit::TestCase
       @subject = Paperclip.io_adapters.for(@attachment)
     end
 
-    teardown do
-      @file.close
-    end
-
     should "get the right filename" do
       assert_equal "5k.png", @subject.original_filename
     end
@@ -68,10 +64,6 @@ class AttachmentAdapterTest < Test::Unit::TestCase
       @subject = Paperclip.io_adapters.for(@attachment)
     end
 
-    teardown do
-      @file.close
-    end
-
     should "not generate paths that include restricted characters" do
       assert_no_match /:/, @subject.path
     end
@@ -93,11 +85,6 @@ class AttachmentAdapterTest < Test::Unit::TestCase
 
       @attachment.save
       @subject = Paperclip.io_adapters.for(@attachment.styles[:thumb])
-    end
-
-    teardown do
-      @file.close
-      @thumb.close
     end
 
     should "get the original filename" do

--- a/test/io_adapters/file_adapter_test.rb
+++ b/test/io_adapters/file_adapter_test.rb
@@ -9,8 +9,6 @@ class FileAdapterTest < Test::Unit::TestCase
         @subject = Paperclip.io_adapters.for(@file)
       end
 
-      teardown { @file.close }
-
       should "get the right filename" do
         assert_equal "5k.png", @subject.original_filename
       end
@@ -92,8 +90,6 @@ class FileAdapterTest < Test::Unit::TestCase
         @subject = Paperclip.io_adapters.for(@file)
       end
 
-      teardown { @file.close }
-
       should "not generate filenames that include restricted characters" do
         assert_equal 'image_restricted.gif', @subject.original_filename
       end
@@ -108,8 +104,6 @@ class FileAdapterTest < Test::Unit::TestCase
         @file = Tempfile.new("file_adapter_test")
         @subject = Paperclip.io_adapters.for(@file)
       end
-
-      teardown { @file.close }
 
       should "provide correct mime-type" do
         assert_match %r{.*/x-empty}, @subject.content_type

--- a/test/meta_class_test.rb
+++ b/test/meta_class_test.rb
@@ -7,8 +7,6 @@ class MetaClassTest < Test::Unit::TestCase
       @file = File.new(fixture_file("5k.png"), 'rb')
     end
 
-    teardown { @file.close }
-
     should "be able to use Paperclip like a normal class" do
       reset_class("Dummy")
       @dummy = Dummy.new
@@ -16,7 +14,7 @@ class MetaClassTest < Test::Unit::TestCase
       assert_nothing_raised do
         rebuild_meta_class_of(@dummy)
       end
-    end    
+    end
 
     should "work like any other instance" do
       reset_class("Dummy")

--- a/test/paperclip_test.rb
+++ b/test/paperclip_test.rb
@@ -75,8 +75,6 @@ class PaperclipTest < Test::Unit::TestCase
       @expected = [d1, d3]
     end
 
-    teardown { @file.close }
-
     should "yield every instance of a model that has an attachment" do
       actual = []
       Paperclip.each_instance_with_attachment("Dummy", "avatar") do |instance|
@@ -112,8 +110,6 @@ class PaperclipTest < Test::Unit::TestCase
       rebuild_model :path => "tmp/:class/omg/:style.:extension"
       @file = File.new(fixture_file("5k.png"), 'rb')
     end
-
-    teardown { @file.close }
 
     should "not error when trying to also create a 'blah' attachment" do
       assert_nothing_raised do

--- a/test/storage/filesystem_test.rb
+++ b/test/storage/filesystem_test.rb
@@ -11,8 +11,6 @@ class FileSystemTest < Test::Unit::TestCase
         @dummy.avatar = @file
       end
 
-      teardown { @file.close }
-
       should "allow file assignment" do
         assert @dummy.save
       end
@@ -47,7 +45,6 @@ class FileSystemTest < Test::Unit::TestCase
         @dummy.avatar.copy_to_local_file(:original, tempfile.path)
         tempfile.rewind
         assert_equal @file.read, tempfile.read
-        tempfile.close
       end
     end
 
@@ -60,8 +57,6 @@ class FileSystemTest < Test::Unit::TestCase
         @dummy.avatar = @file
         @dummy.save
       end
-
-      teardown { @file.close }
 
       should "store the file" do
         assert_file_exists(@dummy.avatar.path)

--- a/test/storage/fog_test.rb
+++ b/test/storage/fog_test.rb
@@ -17,8 +17,6 @@ class FogTest < Test::Unit::TestCase
         @dummy.avatar = @file
       end
 
-      teardown { @file.close }
-
       should "have the proper information loading credentials from a file" do
         assert_equal @dummy.avatar.fog_credentials[:provider], 'AWS'
       end
@@ -35,8 +33,6 @@ class FogTest < Test::Unit::TestCase
         @dummy = Dummy.new
         @dummy.avatar = @file
       end
-
-      teardown { @file.close }
 
       should "have the proper information loading credentials from a file" do
         assert_equal @dummy.avatar.fog_credentials[:provider], 'AWS'
@@ -59,8 +55,6 @@ class FogTest < Test::Unit::TestCase
         @dummy.avatar = @file
       end
 
-      teardown { @file.close }
-
       should "be able to interpolate the path without blowing up" do
         assert_equal File.expand_path(File.join(File.dirname(__FILE__), "../../tmp/public/avatars/5k.png")),
                      @dummy.avatar.path
@@ -82,8 +76,6 @@ class FogTest < Test::Unit::TestCase
         @dummy.id = 1
         @dummy.avatar = @file
       end
-
-      teardown { @file.close }
 
       should "have correct path and url from interpolated defaults" do
         assert_equal "dummies/avatars/000/000/001/original/5k.png", @dummy.avatar.path
@@ -149,7 +141,6 @@ class FogTest < Test::Unit::TestCase
       end
 
       teardown do
-        @file.close
         directory = @connection.directories.new(:key => @fog_directory)
         directory.files.each {|file| file.destroy}
         directory.destroy
@@ -178,7 +169,6 @@ class FogTest < Test::Unit::TestCase
         tempfile.rewind
         assert_equal @connection.directories.get(@fog_directory).files.get(@dummy.avatar.path).body,
                      tempfile.read
-        tempfile.close
       end
 
       should "pass the content type to the Fog::Storage::AWS::Files instance" do
@@ -442,7 +432,6 @@ class FogTest < Test::Unit::TestCase
     end
 
     teardown do
-      @file.close
       Fog.mock!
     end
 

--- a/test/storage/s3_live_test.rb
+++ b/test/storage/s3_live_test.rb
@@ -34,8 +34,6 @@ unless ENV["S3_BUCKET"].blank?
         @attachment2.assign(@attachment)
         @attachment2.save
       end
-
-      teardown { [@s3_credentials, @file].each(&:close) }
     end
 
     context "Generating an expiring url on a nonexistant attachment" do
@@ -68,8 +66,6 @@ unless ENV["S3_BUCKET"].blank?
         @dummy = Dummy.new
       end
 
-      teardown { @s3_credentials.close }
-
       should "be extended by the S3 module" do
         assert Dummy.new.avatar.is_a?(Paperclip::Storage::S3)
       end
@@ -81,7 +77,6 @@ unless ENV["S3_BUCKET"].blank?
         end
 
         teardown do
-          @file.close
           @dummy.destroy
         end
 
@@ -111,8 +106,6 @@ unless ENV["S3_BUCKET"].blank?
         @dummy.avatar = @file
         @dummy.save
       end
-
-      teardown { @s3_credentials.close }
 
       should "return a replaced version for path" do
         assert_match /.+\/spaced_file\.png/, @dummy.avatar.path
@@ -151,8 +144,6 @@ unless ENV["S3_BUCKET"].blank?
         @dummy = Dummy.new
       end
 
-      teardown { @s3_credentials.close }
-
       context "when assigned" do
         setup do
           @file = File.new(fixture_file('5k.png'), 'rb')
@@ -160,7 +151,6 @@ unless ENV["S3_BUCKET"].blank?
         end
 
         teardown do
-          @file.close
           @dummy.destroy
         end
 

--- a/test/storage/s3_test.rb
+++ b/test/storage/s3_test.rb
@@ -324,8 +324,6 @@ class S3Test < Test::Unit::TestCase
       @dummy.save
     end
 
-    teardown { @file.close }
-
     should "succeed" do
       assert_equal @dummy.counter, 7
     end
@@ -663,8 +661,6 @@ class S3Test < Test::Unit::TestCase
         @dummy.avatar = @file
       end
 
-      teardown { @file.close }
-
       should "not get a bucket to get a URL" do
         @dummy.avatar.expects(:s3).never
         @dummy.avatar.expects(:s3_bucket).never
@@ -831,8 +827,6 @@ class S3Test < Test::Unit::TestCase
         @dummy.avatar = @file
       end
 
-      teardown { @file.close }
-
       context "and saved" do
         setup do
           object = stub
@@ -869,8 +863,6 @@ class S3Test < Test::Unit::TestCase
         @dummy = Dummy.new
         @dummy.avatar = @file
       end
-
-      teardown { @file.close }
 
       context "and saved" do
         setup do
@@ -909,8 +901,6 @@ class S3Test < Test::Unit::TestCase
         @dummy.avatar = @file
       end
 
-      teardown { @file.close }
-
       context "and saved" do
         setup do
           object = stub
@@ -947,8 +937,6 @@ class S3Test < Test::Unit::TestCase
         @dummy = Dummy.new
         @dummy.avatar = @file
       end
-
-      teardown { @file.close }
 
       context "and saved" do
         setup do
@@ -988,8 +976,6 @@ class S3Test < Test::Unit::TestCase
           @dummy.avatar = @file
         end
 
-        teardown { @file.close }
-
         context "and saved" do
           setup do
             object = stub
@@ -1027,8 +1013,6 @@ class S3Test < Test::Unit::TestCase
         @dummy.avatar = @file
       end
 
-      teardown { @file.close }
-
       context "and saved" do
         setup do
           object = stub
@@ -1065,8 +1049,6 @@ class S3Test < Test::Unit::TestCase
         @dummy = Dummy.new
         @dummy.avatar = @file
       end
-
-      teardown { @file.close }
 
       context "and saved" do
         setup do
@@ -1150,8 +1132,6 @@ class S3Test < Test::Unit::TestCase
           @dummy.avatar = @file
         end
 
-        teardown { @file.close }
-
         context "and saved" do
           setup do
             object = stub
@@ -1187,8 +1167,6 @@ class S3Test < Test::Unit::TestCase
           @dummy = Dummy.new
           @dummy.avatar = @file
         end
-
-        teardown { @file.close }
 
         context "and saved" do
           setup do
@@ -1231,8 +1209,6 @@ class S3Test < Test::Unit::TestCase
           @dummy = Dummy.new
           @dummy.avatar = @file
         end
-
-        teardown { @file.close }
 
         context "and saved" do
           setup do
@@ -1280,8 +1256,6 @@ class S3Test < Test::Unit::TestCase
           @dummy.avatar = @file
         end
 
-        teardown { @file.close }
-
         context "and saved" do
           setup do
             @dummy.save
@@ -1323,8 +1297,6 @@ class S3Test < Test::Unit::TestCase
         @dummy.stubs(:name => 'Custom Avatar Name.png')
         @dummy.avatar = @file
       end
-
-      teardown { @file.close }
 
       context "and saved" do
         setup do

--- a/test/thumbnail_test.rb
+++ b/test/thumbnail_test.rb
@@ -7,8 +7,6 @@ class ThumbnailTest < Test::Unit::TestCase
       @tempfile = Paperclip::Tempfile.new(["file", ".jpg"])
     end
 
-    teardown { @tempfile.close }
-
     should "have its path contain a real extension" do
       assert_equal ".jpg", File.extname(@tempfile.path)
     end
@@ -23,8 +21,6 @@ class ThumbnailTest < Test::Unit::TestCase
       @tempfile = Paperclip::Tempfile.new("file")
     end
 
-    teardown { @tempfile.close }
-
     should "not have an extension if not given one" do
       assert_equal "", File.extname(@tempfile.path)
     end
@@ -38,8 +34,6 @@ class ThumbnailTest < Test::Unit::TestCase
     setup do
       @file = File.new(fixture_file("5k.png"), 'rb')
     end
-
-    teardown { @file.close }
 
     [["600x600>", "434x66"],
      ["400x400>", "400x61"],
@@ -321,8 +315,6 @@ class ThumbnailTest < Test::Unit::TestCase
       @file = File.new(fixture_file("twopage.pdf"), 'rb')
     end
 
-    teardown { @file.close }
-
     should "start with two pages with dimensions 612x792" do
       cmd = %Q[identify -format "%wx%h" "#{@file.path}"]
       assert_equal "612x792"*2, `#{cmd}`.chomp
@@ -353,8 +345,6 @@ class ThumbnailTest < Test::Unit::TestCase
     setup do
       @file = File.new(fixture_file("animated.gif"), 'rb')
     end
-
-    teardown { @file.close }
 
     should "start with 12 frames with size 100x100" do
       cmd = %Q[identify -format "%wx%h" "#{@file.path}"]


### PR DESCRIPTION
This will end all the problem we have with too many open files error.

The real change is in https://github.com/thoughtbot/paperclip/blob/44da76c021b8f1f25fc552ee049a51d2a7326c58/test/helper.rb. The rest of the commit is to remove all the `file.close` that I added to mitigate the error ...
