### PR TITLE
Feature: now the "url" option can be a closure or anything respond to "call"

### DIFF
--- a/lib/paperclip/url_generator.rb
+++ b/lib/paperclip/url_generator.rb
@@ -32,7 +32,11 @@ module Paperclip
       if @attachment.original_filename.nil?
         default_url
       else
-        @attachment_options[:url]
+        if @attachment_options[:url].respond_to?(:call)
+          @attachment_options[:url].call(@attachment)
+        else
+          @attachment_options[:url]
+        end
       end
     end
 

--- a/test/url_generator_test.rb
+++ b/test/url_generator_test.rb
@@ -184,4 +184,17 @@ class UrlGeneratorTest < Test::Unit::TestCase
     assert mock_interpolator.has_interpolated_pattern?(expected),
       "expected the interpolator to be passed #{expected.inspect} but it wasn't"
   end
+
+  should "execute the URL lambda if a closure is provided" do
+    mock_attachment = MockAttachment.new(:original_filename => 'exists')
+    mock_interpolator = MockInterpolator.new
+    url = lambda {|attachment| "the #{attachment.class.name} url" }
+    options = { :interpolator => mock_interpolator, :url => url}
+
+    url_generator = Paperclip::UrlGenerator.new(mock_attachment, options)
+    url_generator.for(:style_name, {})
+
+    assert mock_interpolator.has_interpolated_pattern?("the MockAttachment url"),
+      %{expected the interpolator to be passed "the MockAttachment url", but it wasn't}
+  end
 end


### PR DESCRIPTION
some of the options, like "default_url", "styles", could take a closure as the value, and evaluate the closure at runtime will make the paperclip options really flexible, while "url" is an exception, the pull request is trying to make "url" configurable like the other options like "default_url" and "styles"
