### PR TITLE
Fixes validate_attachment_presence matcher, #1296

### DIFF
--- a/lib/paperclip/matchers/validate_attachment_presence_matcher.rb
+++ b/lib/paperclip/matchers/validate_attachment_presence_matcher.rb
@@ -46,7 +46,11 @@ module Paperclip
           @file = StringIO.new(".")
           @subject.send(@attachment_name).assign(@file)
           @subject.valid?
-          @subject.errors[:"#{@attachment_name}"].blank?
+          expected_message = [
+            @attachment_name.to_s.titleize,
+            I18n.t(:blank, scope: [:errors, :messages])
+          ].join(' ')
+          @subject.errors.full_messages.exclude?(expected_message)
         end
       end
     end

--- a/test/matchers/validate_attachment_presence_matcher_test.rb
+++ b/test/matchers/validate_attachment_presence_matcher_test.rb
@@ -23,6 +23,28 @@ class ValidateAttachmentPresenceMatcherTest < Test::Unit::TestCase
       should_accept_dummy_class
     end
 
+    context "given an instance with other attachment validations" do
+      setup do
+        reset_table("dummies") do |d|
+          d.string :avatar_file_name
+          d.string :avatar_content_type
+        end
+
+        @dummy_class.class_eval do
+          validates_attachment_presence :avatar
+          validates_attachment_content_type :avatar, :content_type => 'image/gif'
+        end
+
+        @dummy = @dummy_class.new
+        @matcher = self.class.validate_attachment_presence(:avatar)
+      end
+
+      should "it should validate properly" do
+        @dummy.avatar = File.new fixture_file('5k.png')
+        assert_accepts @matcher, @dummy
+      end
+    end
+
     context "using an :if to control the validation" do
       setup do
         @dummy_class.class_eval do


### PR DESCRIPTION
Copying attribute validation failures up to the root object breaks the 
validate_attachment_presence_matcher when other paperclip validations have
failed.  This fixes this bug.
