### PR TITLE
Ensure :rails_env interpolation is downcased

### DIFF
--- a/lib/paperclip/interpolations.rb
+++ b/lib/paperclip/interpolations.rb
@@ -76,7 +76,7 @@ module Paperclip
 
     # Returns the Rails.env constant.
     def rails_env attachment, style_name
-      Rails.env
+      Rails.env.downcase
     end
 
     # Returns the underscored, pluralized version of the class name.


### PR DESCRIPTION
I've been experiencing this very rare (about 0.05%) bug where Rails.env would return 'Production' vs 'production' at the most random times. 

This is relevant to paperclip, because I use :rails_env in my S3 upload path, and paperclip would sometimes upload to the folder 'Production'. Therefore the URL that paperclip would build in the future would be incorrect, since the photo is actually in a 'Production' folder.

Here is my app caught in the act:

Paperclip building the paths using 'Production'
![visual](https://f.cloud.github.com/assets/1760501/932273/c5464758-003d-11e3-9a3d-1f945ef04d5d.png)
![source](https://f.cloud.github.com/assets/1760501/932279/ed8ae52a-003d-11e3-9723-12f4f6f5164f.png)

Refreshing a moment later:
![visual](https://f.cloud.github.com/assets/1760501/932292/0331fb66-003e-11e3-8483-6becd331b99b.png)
![source](https://f.cloud.github.com/assets/1760501/932294/081be04c-003e-11e3-974b-6378717e4dc5.png)

I realize this isn't a paperclip problem, and this pull request is from way left field.
I just think it would in the best interest of paperclip, to ensure that this freak problem does not happen to others.
