### PR TITLE
Fix #1292: Set content_type errors correctly on base

### DIFF
--- a/lib/paperclip/validators/attachment_content_type_validator.rb
+++ b/lib/paperclip/validators/attachment_content_type_validator.rb
@@ -17,7 +17,9 @@ module Paperclip
         validate_blacklist(record, attribute, value)
 
         if record.errors.include? attribute
-          record.errors.add base_attribute, record.errors[attribute]
+          record.errors[attribute].each do |error|
+            record.errors.add base_attribute, error
+          end
         end
       end
 

--- a/test/validators/attachment_content_type_validator_test.rb
+++ b/test/validators/attachment_content_type_validator_test.rb
@@ -61,6 +61,11 @@ class AttachmentContentTypeValidatorTest < Test::Unit::TestCase
       assert @dummy.errors[:avatar].present?,
         "Error not added to base attribute"
     end
+
+    should "add error to base object as a string" do
+      assert_kind_of String, @dummy.errors[:avatar].first,
+        "Error added to base attribute as something other than a String"
+    end
   end
 
   context "with a successful validation" do

--- a/test/validators/attachment_size_validator_test.rb
+++ b/test/validators/attachment_size_validator_test.rb
@@ -45,6 +45,11 @@ class AttachmentSizeValidatorTest < Test::Unit::TestCase
           "Error not added to base attribute"
       end
 
+      should "add error to base object as a string" do
+        assert_kind_of String, @dummy.errors[:avatar].first,
+          "Error added to base attribute as something other than a String"
+      end
+
       if options[:message]
         should "return a correct error message" do
           assert_includes @dummy.errors[:avatar_file_size], options[:message]


### PR DESCRIPTION
Content Type errors were incorrectly being set as an array on the base
attribute rather than being set individually as strings.
