### PR TITLE
Use :swallow_stderr instead of not thread safe silence_stream(STDERR)

### DIFF
--- a/lib/paperclip/geometry_detector_factory.rb
+++ b/lib/paperclip/geometry_detector_factory.rb
@@ -14,9 +14,14 @@ module Paperclip
 
     def geometry_string
       begin
-        silence_stream(STDERR) do
-          Paperclip.run("identify", "-format '%wx%h,%[exif:orientation]' :file", :file => "#{path}[0]")
-        end
+        Paperclip.run(
+          "identify",
+          "-format '%wx%h,%[exif:orientation]' :file", {
+            :file => "#{path}[0]"
+          }, {
+            :swallow_stderr => true
+          }
+        )
       rescue Cocaine::ExitStatusError
         ""
       rescue Cocaine::CommandNotFoundError => e


### PR DESCRIPTION
This should fix the thread safety issues reported at https://github.com/jruby/jruby/issues/965.
