### PR TITLE
Lambdas not being passed to Paperclip validators

### DIFF
--- a/lib/paperclip/validators.rb
+++ b/lib/paperclip/validators.rb
@@ -37,6 +37,8 @@ module Paperclip
               validator_options = options.delete(validator_kind)
               validator_options = {} if validator_options == true
               local_options = attributes + [validator_options]
+              conditional_options = options.slice(:if, :unless)
+              local_options.last.merge!(conditional_options)
               send(:"validates_attachment_#{validator_kind}", *local_options)
             end
           end

--- a/test/validators_test.rb
+++ b/test/validators_test.rb
@@ -29,4 +29,33 @@ class ValidatorsTest < Test::Unit::TestCase
       assert_raise(RuntimeError){ dummy.valid? }
     end
   end
+
+  context "using the helper with a conditional" do
+    setup do
+      Dummy.validates_attachment :avatar, :presence => true,
+                                 :content_type => { :content_type => "image/jpeg" },
+                                 :size => { :in => 0..10.kilobytes },
+                                 :if => :title_present?
+    end
+
+    should "validate the attachment if title is present" do
+      Dummy.class_eval do
+        def title_present?
+          true
+        end
+      end
+      dummy = Dummy.new(:avatar => File.new(fixture_file("12k.png")))
+      assert_equal [:avatar_content_type, :avatar, :avatar_file_size], dummy.errors.keys
+    end
+
+    should "not validate attachment if tile is not present" do
+      Dummy.class_eval do
+        def title_present?
+          false
+        end
+      end
+      dummy = Dummy.new(:avatar => File.new(fixture_file("12k.png")))
+      assert_equal [], dummy.errors.keys
+    end
+  end
 end


### PR DESCRIPTION
In the 3.5 update, the validators were no longer getting the `if/unless` clauses passed down to the validation methods.  Wrote a failing spec for the situation and code to explicitly find the options and pass them through.
