### PR TITLE
Prevent Errno::EFILENAMETOOLONG when creating tempfile

### DIFF
--- a/lib/paperclip/tempfile_factory.rb
+++ b/lib/paperclip/tempfile_factory.rb
@@ -1,8 +1,6 @@
 module Paperclip
   class TempfileFactory
 
-    ILLEGAL_FILENAME_CHARACTERS = /^~/
-
     def generate(name)
       @name = name
       file = Tempfile.new([basename, extension])
@@ -15,7 +13,7 @@ module Paperclip
     end
 
     def basename
-      File.basename(@name, extension).gsub(ILLEGAL_FILENAME_CHARACTERS, '_')
+      Digest::MD5.hexdigest(File.basename(@name, extension))
     end
   end
 end

--- a/test/tempfile_factory_test.rb
+++ b/test/tempfile_factory_test.rb
@@ -10,4 +10,8 @@ class Paperclip::TempfileFactoryTest < Test::Unit::TestCase
   should "be able to generate a tempfile with the right name with a tilde at the end" do
     file = subject.generate("omg.png~")
   end
+  should "be able to generate a tempfile from a file with a really long name" do
+    filename = "#{"longfilename" * 100}.txt"
+    file = subject.generate(filename)
+  end
 end


### PR DESCRIPTION
Use Digest::MD5.hexdigest to change the name of the tempfile being generated.  This should also remove the need to check for illegal filename characters.
