### PR TITLE
Quick change to make it possible to ignore the :geometry option when defining styles

### DIFF
--- a/lib/paperclip/thumbnail.rb
+++ b/lib/paperclip/thumbnail.rb
@@ -28,7 +28,7 @@ module Paperclip
     def initialize(file, options = {}, attachment = nil)
       super
 
-      geometry             = options[:geometry] # this is not an option
+      geometry             = options[:geometry].to_s # this is not an option
       @file                = file
       @crop                = geometry[-1,1] == '#'
       @target_geometry     = (options[:string_geometry_parser] || Geometry).parse(geometry)


### PR DESCRIPTION
Hey, I've made this little change because I found it frustrating that I couldn't make Paperclip avoid resizing my thumbnail by itself in order to resize it myself using `:convert_options`: I had to make a thumbnail of a picture which is just a cropped version of it, without any resizing. 

After some trial and error I realized that it didn't look like it was possible unless I specified an empty string for geometry (which, using the old format, would end up making my styles look like `{ thumb: ["", :png] }`, which is kind of ugly.  
I figured out that I could pass my styles as a hash by looking at the code, but not passing a geometry still gave me an error (because line 33 in `thumbnail.rb`, `@crop = geometry[-1,1] == '#'` won't work if geometry is not a string). 

To solve that, I added a call to `to_s` where the geometry is fetched from the options. This will make it so that if it's `nil`, it'll just be turned into an empty string, with which Paperclip happily chugs along and doesn't resize the picture. 

This is the use case:

``` ruby
class WorkPicture < ActiveRecord::Base
  CROP_OPTIONS = "-crop 360x222+0+0"
  has_attached_file    :picture, styles:          { big:   { geometry: "945x584#", format: :png },
                                                    thumb: { format: :png, convert_options: CROP_OPTIONS } }, # Notice the absence of `geometry: "..."` here
                                 url:             "/pictures/:hash.:extension",
                                 hash_secret:     ENV["PAPERCLIP_SECRET_KEY"]
end
```

---

I haven't been able to test this change (and I'm sorry for that) because I couldn't get the test suite to pass at all on my machine for some weird reason, but it would be great if you could run a quick test on it for me and let me know if there are any issues.

To "validate" my change, I still tried pointing Paperclip in my app's gemfile to my local repository and trying to add a picture using my model without the geometry definition, and the error was gone. It's probably not enough to be 100% sure that it's a good change, but I tried my best and I'm hoping that it's good enough for you to accept it.

Thanks!

**Commit message:**

> This should make it possible to avoid passing a :geometry in the style
> definition (when passing it as a hash), thus making Paperclip avoid resizing the
> image. This is helpful when you want to perform your own custom
> resizing/cropping using :convert_options rather than the default options offered
> by Paperclip itself.

**EDIT:** crap, I just realized I accidentally made this change on master. I hope that's not a problem for you.
