### PR TITLE
Duplicate error messages being shown and lack of unit option in which to display size

### DIFF
--- a/lib/paperclip/validators/attachment_size_validator.rb
+++ b/lib/paperclip/validators/attachment_size_validator.rb
@@ -13,7 +13,6 @@ module Paperclip
       end
 
       def validate_each(record, attr_name, value)
-        base_attr_name = attr_name
         attr_name = "#{attr_name}_file_size".to_sym
         value = record.send(:read_attribute_for_validation, attr_name)
 
@@ -24,13 +23,11 @@ module Paperclip
 
             unless value.send(CHECKS[option], option_value)
               error_message_key = options[:in] ? :in_between : option
-              [ attr_name, base_attr_name ].each do |error_attr_name|
-                record.errors.add(error_attr_name, error_message_key, filtered_options(value).merge(
-                  :min => min_value_in_human_size(record),
-                  :max => max_value_in_human_size(record),
-                  :count => human_size(option_value, options[:unit])
-                ))
-              end
+              record.errors.add(attr_name, error_message_key, filtered_options(value).merge(
+                :min => min_value_in_human_size(record),
+                :max => max_value_in_human_size(record),
+                :count => human_size(option_value, options[:unit])
+              ))
             end
           end
         end

--- a/test/validators/attachment_size_validator_test.rb
+++ b/test/validators/attachment_size_validator_test.rb
@@ -40,13 +40,8 @@ class AttachmentSizeValidatorTest < Test::Unit::TestCase
           "Unexpected error message on :avatar_file_size"
       end
 
-      should "add error to the base dummy object" do
-        assert @dummy.errors[:avatar].present?,
-          "Error not added to base attribute"
-      end
-
-      should "add error to base object as a string" do
-        assert_kind_of String, @dummy.errors[:avatar].first,
+      should "add error to dummy object as a string" do
+        assert_kind_of String, @dummy.errors[:avatar_file_size].first,
           "Error added to base attribute as something other than a String"
       end
 


### PR DESCRIPTION
### FIX No 1:

Added a unit option to `validates_attachment_size`. It will be helpful to make the size errors more readable.

Example:

```
validates_attachment_size :attachment, :less_than => 10.megabytes
```

If we upload a file greater than 10 MB, then it will add an error message like `Attachment file size must be less than 10485760 bytes`. As you can see that the size is not very readable to the user. User has to convert it to MB or GB to understand the size limit. So after this fix you can pass a unit option to `validates_attachment_size` validation.

Example after Fix:

```
validates_attachment_size :attachment, :less_than => 10.megabytes, :unit => :mb
```

Not the user will get message something like this `Attachment file size must be less than 10 MB`
### Fix No 2:

This fix can be better explained in code so I'm commenting the issue in this PR. Here is the link for the comment.
https://github.com/thoughtbot/paperclip/pull/1357/files#r6825945
