### PR TITLE
Prevent file deletion on transaction rollback

### DIFF
--- a/lib/paperclip/has_attached_file.rb
+++ b/lib/paperclip/has_attached_file.rb
@@ -81,7 +81,7 @@ module Paperclip
       name = @name
       @klass.send(:after_save) { send(name).send(:save) }
       @klass.send(:before_destroy) { send(name).send(:queue_all_for_delete) }
-      @klass.send(:after_destroy) { send(name).send(:flush_deletes) }
+      @klass.send(:after_commit, :on => :destroy) { send(name).send(:flush_deletes) }
     end
 
     def add_paperclip_callbacks

--- a/test/attachment_test.rb
+++ b/test/attachment_test.rb
@@ -1419,6 +1419,15 @@ class AttachmentTest < Test::Unit::TestCase
       @dummy.destroy
       assert_file_not_exists(@path)
     end
+
+    should "not be deleted when transaction rollbacks after model is destroyed" do
+      ActiveRecord::Base.transaction do
+        @dummy.destroy
+        raise ActiveRecord::Rollback
+      end
+
+      assert_file_exists(@path)
+    end
   end
 
 end

--- a/test/has_attached_file_test.rb
+++ b/test/has_attached_file_test.rb
@@ -35,8 +35,8 @@ class HasAttachedFileTest < Test::Unit::TestCase
       assert_adding_attachment('avatar').defines_callback('before_destroy')
     end
 
-    should 'define an after_destroy callback' do
-      assert_adding_attachment('avatar').defines_callback('after_destroy')
+    should 'define an after_commit callback' do
+      assert_adding_attachment('avatar').defines_callback('after_commit')
     end
 
     should 'define the Paperclip-specific callbacks' do
@@ -117,6 +117,7 @@ class HasAttachedFileTest < Test::Unit::TestCase
            after_save: nil,
            before_destroy: nil,
            after_destroy: nil,
+           after_commit: nil,
            define_paperclip_callbacks: nil,
            extend: nil,
            name: 'Billy')


### PR DESCRIPTION
Changed `after_destroy` callback to `after_commit :on => :destroy` in `Paperclip::HasAttachedFile`.
This will prevent attachment deletion when transaction rollbacks after model is destroyed.

Example before fix:

``` ruby
File.exists?(image.attachment.path) # => true
ActiveRecord::Base.transaction do
  image.destroy
  raise ActiveRecord::Rollback
end
File.exists?(image.attachment.path) # => false
```

Example after fix:

``` ruby
File.exists?(image.attachment.path) # => true
ActiveRecord::Base.transaction do
  image.destroy
  raise ActiveRecord::Rollback
end
File.exists?(image.attachment.path) # => true
```
