### PR TITLE
Revert platform block syntax introduced into Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-platform :jruby do
-  gem 'jruby-openssl'
-  gem 'activerecord-jdbcsqlite3-adapter'
-end
-
-platform :ruby do
-  gem 'pry'
-  gem 'pry-debugger'
-end
+gem 'jruby-openssl', :platform => :jruby
+gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
+gem 'pry', :platform => :ruby
+gem 'pry-debugger', :platform => :ruby


### PR DESCRIPTION
1d8982325f introduced the platform block syntax to the Gemfile, but that is not supported by the latest stable Appraisal release (0.5.2).  This reverts the syntax change, but not the other changes that commit made to the Gemfile.
