### PR TITLE
Make AttachmentRegistry.definitions_for include attachments for parent classes

### DIFF
--- a/lib/paperclip/attachment_registry.rb
+++ b/lib/paperclip/attachment_registry.rb
@@ -51,7 +51,13 @@ module Paperclip
     end
 
     def definitions_for(klass)
-      @attachments[klass]
+      (klass.ancestors - klass.included_modules).inject({}) do |definitions, klass|
+        if @attachments[klass]
+          definitions.reverse_merge! @attachments[klass]
+        end
+
+        definitions
+      end
     end
   end
 end

--- a/test/attachment_registry_test.rb
+++ b/test/attachment_registry_test.rb
@@ -62,6 +62,21 @@ class AttachmentRegistryTest < Test::Unit::TestCase
 
       assert_equal expected_definitions, definitions
     end
+
+    should 'include attachments defined in parent class' do
+      expected_definitions = {
+        avatar: { yo: 'greeting' },
+        greeter: { ciao: 'greeting' }
+      }
+      foo = Class.new
+      bar = Class.new(foo)
+      Paperclip::AttachmentRegistry.register(foo, :avatar, { yo: 'greeting' })
+      Paperclip::AttachmentRegistry.register(bar, :greeter, { ciao: 'greeting' })
+
+      definitions = Paperclip::AttachmentRegistry.definitions_for(bar)
+
+      assert_equal expected_definitions, definitions
+    end
   end
 
   context '.clear' do


### PR DESCRIPTION
Given this scenario:

``` ruby
class Foo
  has_attached_file :image
end

class Bar < Foo
end
```

`Bar#attachment_definitions` should return the `image` attachment definition defined on `Bar`'s parent class, `Foo`, but it currently returns `nil`.  This commit returns the attachments registered for the given class, as well as all of its parents, instead.  This also supports the situation where attachments are defined on both the parent and child classes, and supports any number of levels of inheritance.  

This also makes a subtle change to `AttachmentRegistry.definitions_for`:  When no attachments are defined, it now returns an empty Hash instead of `nil`.  Nothing within paperclip relied on that behavior, and I believe that makes more sense anyway. If anyone feels that will break something, I'm happy to restore the old behavior, though. 
