### PR TITLE
Delegate binmode and binmode? in AbstractAdapter

### DIFF
--- a/lib/paperclip/io_adapters/abstract_adapter.rb
+++ b/lib/paperclip/io_adapters/abstract_adapter.rb
@@ -5,7 +5,7 @@ module Paperclip
     OS_RESTRICTED_CHARACTERS = %r{[/:]}
 
     attr_reader :content_type, :original_filename, :size
-    delegate :close, :closed?, :eof?, :path, :rewind, :unlink, :to => :@tempfile
+    delegate :binmode, :binmode?, :close, :closed?, :eof?, :path, :rewind, :unlink, :to => :@tempfile
 
     def fingerprint
       @fingerprint ||= Digest::MD5.file(path).to_s

--- a/test/io_adapters/abstract_adapter_test.rb
+++ b/test/io_adapters/abstract_adapter_test.rb
@@ -32,7 +32,7 @@ class AbstractAdapterTest < Test::Unit::TestCase
       @adapter.tempfile = stub("Tempfile")
     end
 
-    [:close, :closed?, :eof?, :path, :rewind, :unlink].each do |method|
+    [:binmode, :binmode?, :close, :closed?, :eof?, :path, :rewind, :unlink].each do |method|
       should "delegate #{method} to @tempfile" do
         @adapter.tempfile.stubs(method)
         @adapter.public_send(method)


### PR DESCRIPTION
AbstractAdapter wasn't delegating `binmode` or `binmode?` to the
underlying @tempfile object. `binmode` is useful for cases where the
Adapter object gets handed on to another library expecting an `IO`
object holding image data. We ran into this with Prawn and people using
`prawnto` in conjunction with Paperclip. Prawn wants to ensure the `IO`
is in binmode for embedding the image data.

I had a look and this change doesn't seem to require documentation changes.
