### PR TITLE
fixup for s3_server_side_encryption option

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -134,7 +134,7 @@ module Paperclip
             @s3_server_side_encryption = false
           end
           if @s3_server_side_encryption
-            @s3_server_side_encryption = @options[:s3_server_side_encryption].to_s.upcase
+            @s3_server_side_encryption = @options[:s3_server_side_encryption]
           end
 
           unless @options[:url].to_s.match(/^:s3.*url$/) || @options[:url] == ":asset_host"

--- a/test/storage/s3_test.rb
+++ b/test/storage/s3_test.rb
@@ -1036,7 +1036,7 @@ class S3Test < Test::Unit::TestCase
           object.expects(:write).with(anything,
                                       :content_type => "image/png",
                                       :acl => :public_read,
-                                      :server_side_encryption => 'AES256')
+                                      :server_side_encryption => :aes256)
           @dummy.save
         end
 


### PR DESCRIPTION
Per [S3 documentation](http://docs.aws.amazon.com/AmazonS3/latest/dev/SSEUsingRubySDK.html), the `server_side_encryption` option value should be `:aes256`, not `AES256`.

This PR fixes this option, so that

```
has_attached_file :file, s3_permissions: :private, s3_server_side_encryption: :aes256
```

results in server side encryption being used for storage of the S3 objects, which currently is not the case with the above attachment configuration. I confirmed this by using this commit and the above configuration, and verifying that the S3 console shows the file is stored with SSE.
