### PR TITLE
Add nokogiri as a regular dependency

### DIFF
--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activesupport', '>= 3.0.0')
   s.add_dependency('cocaine', '~> 0.5.3')
   s.add_dependency('mime-types')
+  s.add_dependency('nokogiri')
 
   s.add_development_dependency('activerecord', '>= 3.0.0')
   s.add_development_dependency('shoulda')
@@ -40,7 +41,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('sqlite3', '~> 1.3.4')
   s.add_development_dependency('cucumber', '~> 1.2.1')
   s.add_development_dependency('aruba')
-  s.add_development_dependency('nokogiri')
   # Ruby version < 1.9.3 can't install capybara > 2.0.3.
   s.add_development_dependency('capybara', '= 2.0.3')
   s.add_development_dependency('bundler')


### PR DESCRIPTION
This is a very minor change, but some rake tasks seem to depend on nokogiri and if you use them in an production environment you will get an error unless you require nokogiri elsewhere.
