### PR TITLE
Adding Default Format for styles

### DIFF
--- a/lib/paperclip/style.rb
+++ b/lib/paperclip/style.rb
@@ -29,7 +29,7 @@ module Paperclip
         @geometry, @format = [definition, nil].flatten[0..1]
         @other_args = {}
       end
-      @format  = nil if @format.blank?
+      @format = default_format if @format.blank?
     end
 
     # retrieves from the attachment the processors defined in the has_attached_file call
@@ -97,6 +97,12 @@ module Paperclip
       else
         @other_args[key] = value
       end
+    end
+
+    # defaults to default format (nil by default)
+    def default_format
+      base = attachment.options[:default_format]
+      base.respond_to?(:call) ? base.call(attachment, name) : base
     end
 
   end

--- a/test/style_test.rb
+++ b/test/style_test.rb
@@ -210,4 +210,42 @@ class StyleTest < Test::Unit::TestCase
       assert_equal "-do_extra_stuff", @attachment.styles[:large].processor_options[:source_file_options]
     end
   end
+
+  context "A style rule supplied with default format" do
+     setup do
+       @attachment = attachment :default_format => :png,
+                                :styles => {
+                                  :asstring => "300x300#",
+                                  :aslist => ["300x300#", :jpg],
+                                  :ashash => {
+                                    :geometry => "300x300#",
+                                    :convert_options => "-do_stuff"
+                                  }
+                                }
+     end
+
+     should "have the right number of styles" do
+       assert_kind_of Hash, @attachment.styles
+       assert_equal 3, @attachment.styles.size
+     end
+
+     should "have styles as Style objects" do
+       [:aslist, :ashash, :aslist].each do |s|
+         assert_kind_of Paperclip::Style, @attachment.styles[s]
+       end
+     end
+
+     should "have the right geometries" do
+       [:aslist, :ashash, :aslist].each do |s|
+         assert_equal @attachment.styles[s].geometry, "300x300#"
+       end
+     end
+
+     should "have the right formats" do
+       assert_equal @attachment.styles[:aslist].format,    :jpg
+       assert_equal @attachment.styles[:ashash].format,    :png
+       assert_equal @attachment.styles[:asstring].format,  :png
+     end
+
+   end
 end


### PR DESCRIPTION
Allows a lambda to be passed to decide what format a style should be processed as.  This is really handy for when all your images are jpgs but you want a particular style to be an animated gif.

Cheers to @pelegr which is where this [code originated](https://github.com/pelegr/paperclip). 
