### PR TITLE
Destroy callback: add fallback for ORMs which do not support transactions

### DIFF
--- a/lib/paperclip/has_attached_file.rb
+++ b/lib/paperclip/has_attached_file.rb
@@ -81,7 +81,11 @@ module Paperclip
       name = @name
       @klass.send(:after_save) { send(name).send(:save) }
       @klass.send(:before_destroy) { send(name).send(:queue_all_for_delete) }
-      @klass.send(:after_commit, :on => :destroy) { send(name).send(:flush_deletes) }
+      if @klass.respond_to?(:after_commit)
+        @klass.send(:after_commit, :on => :destroy) { send(name).send(:flush_deletes) }
+      else
+        @klass.send(:after_destroy) { send(name).send(:flush_deletes) }
+      end
     end
 
     def add_paperclip_callbacks


### PR DESCRIPTION
Refer to comments on https://github.com/thoughtbot/paperclip/commit/a01677f58762394c2915eb512fe2f69aec6fbcf5