### PR TITLE
Memoize result of identify command

### DIFF
--- a/lib/paperclip/thumbnail.rb
+++ b/lib/paperclip/thumbnail.rb
@@ -109,7 +109,10 @@ module Paperclip
 
     # Return true if ImageMagick's +identify+ returns an animated format
     def identified_as_animated?
-      ANIMATED_FORMATS.include? identify("-format %m :file", :file => "#{@file.path}[0]").to_s.downcase.strip
+      if @identified_as_animated.nil?
+        @identified_as_animated = ANIMATED_FORMATS.include? identify("-format %m :file", :file => "#{@file.path}[0]").to_s.downcase.strip
+      end
+      @identified_as_animated
     rescue Cocaine::ExitStatusError => e
       raise Paperclip::Error, "There was an error running `identify` for #{@basename}" if @whiny
     rescue Cocaine::CommandNotFoundError => e


### PR DESCRIPTION
Thumbnail#identified_as_animated? method makes a call to ImageMagick and it is invoked 3 times inside Thumbnail. This looks in the logs like this:

```
2014-01-28 21:30:26 [INFO ] Command :: identify -format %m '/tmp/9fdb62f932adf55af2c0e09e5586196420140128-16848-13ev7mr.jpeg[0]' (pid:16848)
2014-01-28 21:30:26 [INFO ] Command :: identify -format %m '/tmp/9fdb62f932adf55af2c0e09e5586196420140128-16848-13ev7mr.jpeg[0]' (pid:16848)
2014-01-28 21:30:26 [INFO ] Command :: identify -format %m '/tmp/9fdb62f932adf55af2c0e09e5586196420140128-16848-13ev7mr.jpeg[0]' (pid:16848)
```

Such external call means forking the whole Ruby process and I think that it should be avoided due to performance reasons. This pull request simply memoizes the value returned by the first call.
