### PR TITLE
Validate media type spoofing only when attachment changed.

### DIFF
--- a/lib/paperclip/has_attached_file.rb
+++ b/lib/paperclip/has_attached_file.rb
@@ -79,7 +79,8 @@ module Paperclip
     end
 
     def add_required_validations
-      @klass.validates_media_type_spoof_detection @name
+      name = @name
+      @klass.validates_media_type_spoof_detection name, :if => ->{ send(name).dirty? }
     end
 
     def add_active_record_callbacks

--- a/test/validators/media_type_spoof_detection_validator_test.rb
+++ b/test/validators/media_type_spoof_detection_validator_test.rb
@@ -9,4 +9,19 @@ class MediaTypeSpoofDetectionValidatorTest < Test::Unit::TestCase
   should "be on the attachment without being explicitly added" do
     assert Dummy.validators_on(:avatar).any?{ |validator| validator.kind == :media_type_spoof_detection }
   end
+
+  should "run when attachment is dirty" do
+    # Make avatar dirty
+    file = File.new(fixture_file("5k.png"), "rb")
+    @dummy.avatar.assign(file)
+
+    detector = mock("detector", :spoofed? => false)
+    Paperclip::MediaTypeSpoofDetector.expects(:using).returns(detector)
+    @dummy.valid?
+  end
+
+  should "not run when attachment is not dirty" do
+    Paperclip::MediaTypeSpoofDetector.expects(:using).never
+    @dummy.valid?
+  end
 end


### PR DESCRIPTION
It resulted with downloading attachment (i.e. from S3) on each
instance validation even when attachment didn't change at all.
