### PR TITLE
Fixes long bundler resolution times when there is no pre-existing Gemfile.lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,10 @@ gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
 
 gem 'pry', :platform => :ruby
 gem 'pry-byebug', :platform => :ruby
+
+# Hinting at development dependencies
+# Prevents bundler from taking a long-time to resolve
+group :development, :test do
+  gem 'mime-types', '~> 1.16'
+  gem 'builder', '~> 3.1.4'
+end


### PR DESCRIPTION
This should fix #1382.

Bundler is falling into a long-running dependency lookup trap when trying to resolve mime-types and builder versions that work with the other dependencies. It will eventually finish, but I gave up after about 15 minutes of allowing it to run on my machine.

I would have liked to add the hinting to the gemspec. However you can't have both a development and runtime dependency with the same name defined.
## Repro Steps

```
paperclip $ rm Gemfile.lock; bundle
Fetching gem metadata from https://rubygems.org/......
Fetching additional metadata from https://rubygems.org/..
Resolving dependencies.................................. # Will take an exceptionally long time...
```
