### PR TITLE
change --mime-type to --mime for more flexibility

### DIFF
--- a/lib/paperclip/media_type_spoof_detector.rb
+++ b/lib/paperclip/media_type_spoof_detector.rb
@@ -52,7 +52,7 @@ module Paperclip
 
     def type_from_file_command
       begin
-        Paperclip.run("file", "-b --mime-type :file", :file => @file.path)
+        Paperclip.run("file", "-b --mime :file", :file => @file.path)
       rescue Cocaine::CommandLineError
         ""
       end


### PR DESCRIPTION
This is for the same problem they were having here: #581 
The error is: file: unrecognized option `--mime-type' on centos
