### PR TITLE
Update rspec matcher protocol for rspec3.0

### DIFF
--- a/lib/paperclip/matchers/have_attached_file_matcher.rb
+++ b/lib/paperclip/matchers/have_attached_file_matcher.rb
@@ -27,7 +27,7 @@ module Paperclip
           "Should have an attachment named #{@attachment_name}"
         end
 
-        def negative_failure_message
+        def failure_message_when_negated
           "Should not have an attachment named #{@attachment_name}"
         end
 

--- a/lib/paperclip/matchers/validate_attachment_presence_matcher.rb
+++ b/lib/paperclip/matchers/validate_attachment_presence_matcher.rb
@@ -26,7 +26,7 @@ module Paperclip
           "Attachment #{@attachment_name} should be required"
         end
 
-        def negative_failure_message
+        def failure_message_when_negated
           "Attachment #{@attachment_name} should not be required"
         end
 

--- a/lib/paperclip/matchers/validate_attachment_size_matcher.rb
+++ b/lib/paperclip/matchers/validate_attachment_size_matcher.rb
@@ -45,7 +45,7 @@ module Paperclip
           "Attachment #{@attachment_name} must be between #{@low} and #{@high} bytes"
         end
 
-        def negative_failure_message
+        def failure_message_when_negated
           "Attachment #{@attachment_name} cannot be between #{@low} and #{@high} bytes"
         end
 


### PR DESCRIPTION
When I run rspec with `Paperclip::Shoulda::Matchers`, 

I could see the error like below. 

```
Paperclip::Shoulda::Matchers::HaveAttachedFileMatcher implements a legacy RSpec matcher
protocol. For the current protocol you should expose the failure messages
via the `failure_message` and `failure_message_when_negated` methods.
```

In RSpec3.0, failure messages methods in matchers are updated  to `failure_message` and `failure_message_negated`

So I changed methods in matchers. 
