### PR TITLE
Fix exception that is raised if after_commit callback hooks are absent

### DIFF
--- a/lib/paperclip/has_attached_file.rb
+++ b/lib/paperclip/has_attached_file.rb
@@ -91,7 +91,9 @@ module Paperclip
       @klass.send(:after_save) { send(name).send(:save) }
       @klass.send(:before_destroy) { send(name).send(:queue_all_for_delete) }
       if @klass.respond_to?(:after_commit)
-        @klass.send(:after_commit, :on => :destroy) { send(name).send(:flush_deletes) }
+        @klass.send(:after_commit, on: :destroy) do
+          send(name).send(:flush_deletes)
+        end
       else
         @klass.send(:after_destroy) { send(name).send(:flush_deletes) }
       end

--- a/lib/paperclip/has_attached_file.rb
+++ b/lib/paperclip/has_attached_file.rb
@@ -90,7 +90,11 @@ module Paperclip
       name = @name
       @klass.send(:after_save) { send(name).send(:save) }
       @klass.send(:before_destroy) { send(name).send(:queue_all_for_delete) }
-      @klass.send(:after_commit, :on => :destroy) { send(name).send(:flush_deletes) }
+      if @klass.respond_to?(:after_commit)
+        @klass.send(:after_commit, :on => :destroy) { send(name).send(:flush_deletes) }
+      else
+        @klass.send(:after_destroy) { send(name).send(:flush_deletes) }
+      end
     end
 
     def add_paperclip_callbacks

--- a/spec/paperclip/has_attached_file_spec.rb
+++ b/spec/paperclip/has_attached_file_spec.rb
@@ -38,12 +38,13 @@ describe Paperclip::HasAttachedFile do
       assert_adding_attachment('avatar').defines_callback('after_commit')
     end
 
-    it 'defines an after_commit callback if the class allows after_commit callbacks' do
-      assert_adding_attachment('avatar').defines_callback('after_commit')
-    end
-
-    it 'defines an after_destroy callback if the class does not allow after_commit callbacks' do
-      assert_adding_attachment('avatar', :unstub_methods => [:after_commit]).defines_callback('after_destroy')
+    context 'when the class does not allow after_commit callbacks' do
+      it 'defines an after_destroy callback' do
+        assert_adding_attachment(
+          'avatar',
+          unstub_methods: [:after_commit]
+        ).defines_callback('after_destroy')
+      end
     end
 
     it 'defines the Paperclip-specific callbacks' do

--- a/spec/paperclip/has_attached_file_spec.rb
+++ b/spec/paperclip/has_attached_file_spec.rb
@@ -38,6 +38,14 @@ describe Paperclip::HasAttachedFile do
       assert_adding_attachment('avatar').defines_callback('after_commit')
     end
 
+    it 'defines an after_commit callback if the class allows after_commit callbacks' do
+      assert_adding_attachment('avatar').defines_callback('after_commit')
+    end
+
+    it 'defines an after_destroy callback if the class does not allow after_commit callbacks' do
+      assert_adding_attachment('avatar', :unstub_methods => [:after_commit]).defines_callback('after_destroy')
+    end
+
     it 'defines the Paperclip-specific callbacks' do
       assert_adding_attachment('avatar').defines_callback('define_paperclip_callbacks')
     end
@@ -53,20 +61,26 @@ describe Paperclip::HasAttachedFile do
 
   private
 
-  def assert_adding_attachment(attachment_name)
-    AttachmentAdder.new(attachment_name)
+  def assert_adding_attachment(attachment_name, options={})
+    AttachmentAdder.new(attachment_name, options)
   end
 
   class AttachmentAdder
     include Mocha::API
     include RSpec::Matchers
 
-    def initialize(attachment_name)
+    def initialize(attachment_name, options = {})
       @attachment_name = attachment_name
+      @stubbed_class = stub_class
+      if options.present?
+        options[:unstub_methods].each do |method|
+          @stubbed_class.unstub(method)
+        end
+      end
     end
 
     def defines_method(method_name)
-      a_class = stub_class
+      a_class = @stubbed_class
 
       Paperclip::HasAttachedFile.define_on(a_class, @attachment_name, {})
 
@@ -74,7 +88,7 @@ describe Paperclip::HasAttachedFile do
     end
 
     def defines_class_method(method_name)
-      a_class = stub_class
+      a_class = @stubbed_class
       a_class.class.stubs(:define_method)
 
       Paperclip::HasAttachedFile.define_on(a_class, @attachment_name, {})
@@ -83,7 +97,7 @@ describe Paperclip::HasAttachedFile do
     end
 
     def defines_validation
-      a_class = stub_class
+      a_class = @stubbed_class
 
       Paperclip::HasAttachedFile.define_on(a_class, @attachment_name, {})
 
@@ -91,7 +105,7 @@ describe Paperclip::HasAttachedFile do
     end
 
     def registers_attachment
-      a_class = stub_class
+      a_class = @stubbed_class
       Paperclip::AttachmentRegistry.stubs(:register)
 
       Paperclip::HasAttachedFile.define_on(a_class, @attachment_name, {size: 1})
@@ -100,7 +114,7 @@ describe Paperclip::HasAttachedFile do
     end
 
     def defines_callback(callback_name)
-      a_class = stub_class
+      a_class = @stubbed_class
 
       Paperclip::HasAttachedFile.define_on(a_class, @attachment_name, {})
 
@@ -132,6 +146,7 @@ describe Paperclip::HasAttachedFile do
            after_save: nil,
            before_destroy: nil,
            after_commit: nil,
+           after_destroy: nil,
            define_paperclip_callbacks: nil,
            extend: nil,
            name: 'Billy',


### PR DESCRIPTION
This is the same issue that is fixed by https://github.com/thoughtbot/paperclip/pull/1425 but because we needed it asap, I added tests for this.