### PR TITLE
Improving AttachmentSizeValidator#human_size method

### DIFF
--- a/lib/paperclip/validators/attachment_size_validator.rb
+++ b/lib/paperclip/validators/attachment_size_validator.rb
@@ -71,7 +71,13 @@ module Paperclip
       end
 
       def human_size(size)
-        ActiveSupport::NumberHelper.number_to_human_size(size)
+        if defined?(ActiveRecord::NumberHelper) # Rails 4.0+
+          ActiveSupport::NumberHelper.number_to_human_size(size)
+        else
+          storage_units_format = I18n.translate(:'number.human.storage_units.format', :locale => options[:locale], :raise => true)
+          unit = I18n.translate(:'number.human.storage_units.units.byte', :locale => options[:locale], :count => size.to_i, :raise => true)
+          storage_units_format.gsub(/%n/, size.to_i.to_s).gsub(/%u/, unit).html_safe
+        end
       end
 
       def min_value_in_human_size(record)

--- a/spec/paperclip/validators/attachment_size_validator_spec.rb
+++ b/spec/paperclip/validators/attachment_size_validator_spec.rb
@@ -12,6 +12,14 @@ describe Paperclip::Validators::AttachmentSizeValidator do
     ))
   end
 
+  def self.storage_units
+    if defined?(ActiveRecord::NumberHelper) # Rails 4.0+
+      { 5120 => '5 KB',       10240 => '10 KB' }
+    else
+      { 5120 => '5120 Bytes', 10240 => '10240 Bytes' }
+    end
+  end
+
   def self.should_allow_attachment_file_size(size)
     context "when the attachment size is #{size}" do
       it "adds error to dummy object" do
@@ -151,7 +159,7 @@ describe Paperclip::Validators::AttachmentSizeValidator do
       end
 
       should_not_allow_attachment_file_size 11.kilobytes,
-        message: "is invalid. (Between 5 KB and 10 KB please.)"
+        message: "is invalid. (Between #{storage_units[5120]} and #{storage_units[10240]} please.)"
     end
 
     context "given :less_than and :greater_than" do
@@ -162,7 +170,7 @@ describe Paperclip::Validators::AttachmentSizeValidator do
       end
 
       should_not_allow_attachment_file_size 11.kilobytes,
-        message: "is invalid. (Between 5 KB and 10 KB please.)"
+        message: "is invalid. (Between #{storage_units[5120]} and #{storage_units[10240]} please.)"
     end
   end
 
@@ -174,9 +182,9 @@ describe Paperclip::Validators::AttachmentSizeValidator do
       end
 
       should_not_allow_attachment_file_size 11.kilobytes,
-        message: "must be less than 10 KB"
+        message: "must be less than #{storage_units[10240]}"
       should_not_allow_attachment_file_size 4.kilobytes,
-        message: "must be greater than 5 KB"
+        message: "must be greater than #{storage_units[5120]}"
     end
 
     context "given a size range" do
@@ -185,9 +193,9 @@ describe Paperclip::Validators::AttachmentSizeValidator do
       end
 
       should_not_allow_attachment_file_size 11.kilobytes,
-        message: "must be in between 5 KB and 10 KB"
+        message: "must be in between #{storage_units[5120]} and #{storage_units[10240]}"
       should_not_allow_attachment_file_size 4.kilobytes,
-        message: "must be in between 5 KB and 10 KB"
+        message: "must be in between #{storage_units[5120]} and #{storage_units[10240]}"
     end
   end
 


### PR DESCRIPTION
It allows to have better validation messages, using friendly storage units (**kb** or **mb** instead of always use **bytes**).
