### PR TITLE
Return name of style in processor options

### DIFF
--- a/lib/paperclip/style.rb
+++ b/lib/paperclip/style.rb
@@ -71,7 +71,7 @@ module Paperclip
     # Arguments other than the standard geometry, format etc are just passed through from
     # initialization and any procs are called here, just before post-processing.
     def processor_options
-      args = {}
+      args = {:style => name}
       @other_args.each do |k,v|
         args[k] = v.respond_to?(:call) ? v.call(attachment) : v
       end

--- a/test/style_test.rb
+++ b/test/style_test.rb
@@ -31,6 +31,10 @@ class StyleTest < Test::Unit::TestCase
       assert_equal [:thumbnail], @style[:processors]
       assert_equal "100x100#", @style[:geometry]
     end
+
+    should "return the name of the style in processor options" do
+      assert_equal :foo, @style.processor_options[:style]
+    end
   end
 
   context "A style rule with properties supplied as procs" do
@@ -67,6 +71,7 @@ class StyleTest < Test::Unit::TestCase
       @attachment = attachment :path => ":basename.:extension",
                                :styles => styles
     end
+
     should "have the right number of styles" do
       assert_kind_of Hash, @attachment.styles
       assert_equal 3, @attachment.styles.size


### PR DESCRIPTION
So we know which style is being processed. We use it in our new release of Retina Rails (https://github.com/jhnvz/retina_rails/tree/2.0.0 https://github.com/jhnvz/retina_rails/pull/39).
