### PR TITLE
Use original filename in creating temp files

### DIFF
--- a/lib/paperclip/io_adapters/abstract_adapter.rb
+++ b/lib/paperclip/io_adapters/abstract_adapter.rb
@@ -34,7 +34,7 @@ module Paperclip
     private
 
     def destination
-      @destination ||= TempfileFactory.new.generate(@original_filename)
+      @destination ||= TempfileFactory.new.generate(@original_filename.to_s)
     end
 
     def copy_to_tempfile(src)

--- a/test/io_adapters/abstract_adapter_test.rb
+++ b/test/io_adapters/abstract_adapter_test.rb
@@ -57,6 +57,11 @@ class AbstractAdapterTest < Test::Unit::TestCase
     assert !TestAdapter.new.nil?
   end
 
+  should "can generate a destination filename with no original filename" do
+    @adapter = TestAdapter.new
+    assert_not_nil @adapter.send(:destination).path
+  end
+
   should 'use the original filename to generate the tempfile' do
     @adapter = TestAdapter.new
     @adapter.original_filename = "file.png"


### PR DESCRIPTION
By default, paperclip is creating temp files without extensions. This causes a problem for some processors that require a filename extension. Instead, we can seed the temp file factory with the original filename.
