### PR TITLE
Readable units

### DIFF
--- a/lib/paperclip/validators/attachment_size_validator.rb
+++ b/lib/paperclip/validators/attachment_size_validator.rb
@@ -30,8 +30,8 @@ module Paperclip
               error_message_key = options[:in] ? :in_between : option
               [ attr_name, base_attr_name ].each do |error_attr_name|
                 record.errors.add(error_attr_name, error_message_key, filtered_options(value).merge(
-                  :min => min_value_in_human_size(record),
-                  :max => max_value_in_human_size(record),
+                  :min => min_value_in_human_size(record, options[:unit]),
+                  :max => max_value_in_human_size(record, options[:unit]),
                   :count => human_size(option_value, options[:unit])
                 ))
               end
@@ -85,18 +85,18 @@ module Paperclip
         storage_units_format.gsub(/%n/, (size.to_i / unit_size).to_s).gsub(/%u/, unit).html_safe
       end
 
-      def min_value_in_human_size(record)
+      def min_value_in_human_size(record, unit = nil)
         value = options[:greater_than_or_equal_to] || options[:greater_than]
         value = value.call(record) if value.respond_to?(:call)
         value = value.min if value.respond_to?(:min)
-        human_size(value)
+        human_size(value, unit)
       end
 
-      def max_value_in_human_size(record)
+      def max_value_in_human_size(record, unit = nil)
         value = options[:less_than_or_equal_to] || options[:less_than]
         value = value.call(record) if value.respond_to?(:call)
         value = value.max if value.respond_to?(:max)
-        human_size(value)
+        human_size(value, unit)
       end
     end
 

--- a/spec/paperclip/validators/attachment_size_validator_spec.rb
+++ b/spec/paperclip/validators/attachment_size_validator_spec.rb
@@ -169,17 +169,17 @@ describe Paperclip::Validators::AttachmentSizeValidator do
   context "with :unit option" do
     context "given unit is :byte" do
       before do
-        build_validator in: (5.bytes..10.bytes), unit: :byte, locale: :en
+        build_validator in: (5.bytes..10.bytes), unit: :byte
       end
 
-      should_allow_attachment_file_size(7.kilobytes)
-      should_not_allow_attachment_file_size(4.kilobytes, message: 'must be in between 5 Bytes and 10 Bytes')
-      should_not_allow_attachment_file_size(11.kilobytes, message: 'must be in between 5 Bytes and 10 Bytes')
+      should_allow_attachment_file_size(7.bytes)
+      should_not_allow_attachment_file_size(4.bytes, message: 'must be in between 5 Bytes and 10 Bytes')
+      should_not_allow_attachment_file_size(11.bytes, message: 'must be in between 5 Bytes and 10 Bytes')
     end
 
     context "given unit is :kb" do
       before do
-        build_validator in: (5.kilobytes..10.kilobytes), unit: :kb, locale: :en
+        build_validator in: (5.kilobytes..10.kilobytes), unit: :kb
       end
 
       should_allow_attachment_file_size(7.kilobytes)
@@ -189,7 +189,7 @@ describe Paperclip::Validators::AttachmentSizeValidator do
 
     context "given unit is :mb" do
       before do
-        build_validator in: (5.megabytes..10.megabytes), unit: :mb, locale: :en
+        build_validator in: (5.megabytes..10.megabytes), unit: :mb
       end
 
       should_allow_attachment_file_size(7.megabytes)
@@ -199,7 +199,7 @@ describe Paperclip::Validators::AttachmentSizeValidator do
 
     context "given unit is :gb" do
       before do
-        build_validator in: (5.gigabytes..10.gigabytes), unit: :gb, locale: :en
+        build_validator in: (5.gigabytes..10.gigabytes), unit: :gb
       end
 
       should_allow_attachment_file_size(7.gigabytes)
@@ -209,7 +209,7 @@ describe Paperclip::Validators::AttachmentSizeValidator do
 
     context "given unit is :tb" do
       before do
-        build_validator in: (5.terabytes..10.terabytes), unit: :tb, locale: :en
+        build_validator in: (5.terabytes..10.terabytes), unit: :tb
       end
 
       should_allow_attachment_file_size(7.terabytes)
@@ -219,7 +219,7 @@ describe Paperclip::Validators::AttachmentSizeValidator do
 
     context "given unit is :invalid" do
       before do
-        build_validator in: (5.bytes..10.bytes), unit: :invalid_unit, locale: :en
+        build_validator in: (5.bytes..10.bytes), unit: :invalid_unit
       end
 
       should_allow_attachment_file_size(7.bytes)


### PR DESCRIPTION
Added a unit option to `validates_attachment_size`. It will be helpful to make the size errors more readable.

Example:

```
validates_attachment_size :attachment, :less_than => 10.megabytes
```

If we upload a file greater than 10 MB, then it will add an error message like
`Attachment file size must be less than 10485760 bytes`
As you can see that the size is not very readable to the user. User has to convert it to MB or GB to understand the size limit. So after this fix you can pass a unit option to `validates_attachment_size` validation.

Example after Fix:

```
validates_attachment_size :attachment, :less_than => 10.megabytes, :unit => :mb
```

Now the user will get message something like this
`Attachment file size must be less than 10 MB`
