### PR TITLE
Document requirement for file command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ GhostScript to be installed. On Mac OS X, you can also install that using Homebr
 
     brew install gs
 
+### `file` command
+
+The Unix [`file` command](http://en.wikipedia.org/wiki/File_(command)) is required for content type checking.
 
 Installation
 ------------


### PR DESCRIPTION
I was getting the failure "File has an extension that does not match its contents". In my case, it turns out that the `file` command was not installed by default on my Centos 6 VPS. I added a note about the requirement for this command in the Readme.
