### PR TITLE
content_type_mappings accepts now an array of mimes for one extension

### DIFF
--- a/lib/paperclip/media_type_spoof_detector.rb
+++ b/lib/paperclip/media_type_spoof_detector.rb
@@ -31,7 +31,16 @@ module Paperclip
     end
 
     def mapping_override_mismatch?
-      mapped_content_type != calculated_content_type
+
+      if mapped_content_type.kind_of?(Array)
+        mapped_content_type.each do |m|
+          true if m == calculated_content_type
+        end
+        false
+      else
+        mapped_content_type != calculated_content_type
+      end
+
     end
 
     def supplied_file_media_types


### PR DESCRIPTION
content_type_mappings accepts now an array of mimes for one extension, sometimes one file can have multiple mime-types

Paperclip.options[:content_type_mappings] = {
  :jos => ["application/jos", "text/plain"]
}
