### PR TITLE
Optionally disable inspecting EXIF for orientation

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -75,6 +75,8 @@ module Paperclip
   # * command_path: Defines the path at which to find the command line
   #   programs if they are not visible to Rails the system's search path. Defaults to
   #   nil, which uses the first executable found in the user's search path.
+  # * use_exif_orientation: Whether to inspect EXIF data to determine an
+  #   image's orientation. Defaults to true.
   def self.options
     @options ||= {
       :whiny => true,
@@ -83,7 +85,8 @@ module Paperclip
       :log => true,
       :log_command => true,
       :swallow_stderr => true,
-      :content_type_mappings => {}
+      :content_type_mappings => {},
+      :use_exif_orientation => true
     }
   end
 

--- a/lib/paperclip/geometry_detector_factory.rb
+++ b/lib/paperclip/geometry_detector_factory.rb
@@ -14,9 +14,11 @@ module Paperclip
 
     def geometry_string
       begin
+        orientation = Paperclip.options[:use_exif_orientation] ?
+          "%[exif:orientation]" : "1"
         Paperclip.run(
           "identify",
-          "-format '%wx%h,%[exif:orientation]' :file", {
+          "-format '%wx%h,#{orientation}' :file", {
             :file => "#{path}[0]"
           }, {
             :swallow_stderr => true

--- a/spec/paperclip/geometry_detector_spec.rb
+++ b/spec/paperclip/geometry_detector_spec.rb
@@ -20,5 +20,20 @@ describe Paperclip::GeometryDetector do
 
     expect(output).to eq :correct
   end
+
+  it 'avoids reading EXIF orientation if so configured' do
+    begin
+      Paperclip.options[:use_exif_orientation] = false
+      Paperclip::GeometryParser.stubs(:new).with("300x200,1").returns(stub(make: :correct))
+      file = fixture_file("rotated.jpg")
+      factory = Paperclip::GeometryDetector.new(file)
+
+      output = factory.make
+
+      expect(output).to eq :correct
+    ensure
+      Paperclip.options[:use_exif_orientation] = true
+    end
+  end
 end
 


### PR DESCRIPTION
Closes https://github.com/thoughtbot/paperclip/issues/1513.

Allows users to disable reading EXIF data for image orientation, to avoid potential DoS outlined in that issue.
