### PR TITLE
Ensure required validations accepts subclasses

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -391,8 +391,16 @@ module Paperclip
       @instance.class.validators.map(&:class)
     end
 
+    def required_validator_classes
+      Paperclip::REQUIRED_VALIDATORS + Paperclip::REQUIRED_VALIDATORS.flat_map(&:descendants)
+    end
+
+    def missing_required_validator?
+      (active_validator_classes & required_validator_classes).empty?
+    end
+
     def ensure_required_validations!
-      if (active_validator_classes & Paperclip::REQUIRED_VALIDATORS).empty?
+      if missing_required_validator?
         raise Paperclip::Errors::MissingRequiredValidatorError
       end
     end

--- a/spec/paperclip/validators_spec.rb
+++ b/spec/paperclip/validators_spec.rb
@@ -77,6 +77,28 @@ describe Paperclip::Validators do
       end
     end
 
+    it 'does not raise an error when a content_type validation exists using validates_with' do
+      Dummy.validates_with Paperclip::Validators::AttachmentContentTypeValidator, attributes: :attachment, content_type: 'images/jpeg'
+
+      assert_nothing_raised do
+        Dummy.new(avatar: File.new(fixture_file("12k.png")))
+      end
+    end
+
+    it 'does not raise an error when an inherited validator is used' do
+      class MyValidator < Paperclip::Validators::AttachmentContentTypeValidator
+        def initialize(options)
+          options[:content_type] = "images/jpeg" unless options.has_key?(:content_type)
+          super
+        end
+      end
+      Dummy.validates_with MyValidator, attributes: :attachment
+
+      assert_nothing_raised do
+        Dummy.new(avatar: File.new(fixture_file("12k.png")))
+      end
+    end
+
     it 'does not raise an error when a file_name validation exists' do
       Dummy.validates_attachment :avatar, file_name: { matches: /png$/ }
 


### PR DESCRIPTION
Allow users to create a custom validator that inherits from the acceptable paperclip validators, and will prevent an error from being raised in that case.

```
class MyValidator < Paperclip::Validators::AttachmentContentTypeValidator
end

class MyModel < ActiveRecord::Base
  has_attached_file :attachment
  validates_with MyValidator, attributes: :attachment, content_type: 'image/jpeg'
end
```
