### PR TITLE
Fix shoulda matcher have_attached_file to not clash with rspec new synta...

### DIFF
--- a/lib/paperclip/matchers.rb
+++ b/lib/paperclip/matchers.rb
@@ -1,4 +1,4 @@
-require 'paperclip/matchers/have_attached_file_matcher'
+require 'paperclip/matchers/contain_file_matcher'
 require 'paperclip/matchers/validate_attachment_presence_matcher'
 require 'paperclip/matchers/validate_attachment_content_type_matcher'
 require 'paperclip/matchers/validate_attachment_size_matcher'
@@ -21,7 +21,7 @@ module Paperclip
     #
     # Example:
     #   describe User do
-    #     it { should have_attached_file(:avatar) }
+    #     it { should contain_file(:avatar) }
     #     it { should validate_attachment_presence(:avatar) }
     #     it { should validate_attachment_content_type(:avatar).
     #                   allowing('image/png', 'image/gif').
@@ -49,7 +49,7 @@ module Paperclip
     #   require 'test_helper'
     #
     #   class UserTest < ActiveSupport::TestCase
-    #     should have_attached_file(:avatar)
+    #     should contain_file(:avatar)
     #     should validate_attachment_presence(:avatar)
     #     should validate_attachment_content_type(:avatar).
     #                  allowing('image/png', 'image/gif').

--- a/lib/paperclip/matchers/contain_file_matcher.rb
+++ b/lib/paperclip/matchers/contain_file_matcher.rb
@@ -6,13 +6,13 @@ module Paperclip
       #
       # Example:
       #   describe User do
-      #     it { should have_attached_file(:avatar) }
+      #     it { should contain_file(:avatar) }
       #   end
-      def have_attached_file name
-        HaveAttachedFileMatcher.new(name)
+      def contain_file name
+        ContainFileMatcher.new(name)
       end
 
-      class HaveAttachedFileMatcher
+      class ContainFileMatcher
         def initialize attachment_name
           @attachment_name = attachment_name
         end
@@ -24,16 +24,16 @@ module Paperclip
         end
 
         def failure_message
-          "Should have an attachment named #{@attachment_name}"
+          "Should contain an attachment named #{@attachment_name}"
         end
 
         def failure_message_when_negated
-          "Should not have an attachment named #{@attachment_name}"
+          "Should not contain an attachment named #{@attachment_name}"
         end
         alias negative_failure_message failure_message_when_negated
 
         def description
-          "have an attachment named #{@attachment_name}"
+          "contain an attachment named #{@attachment_name}"
         end
 
         protected

--- a/shoulda_macros/paperclip.rb
+++ b/shoulda_macros/paperclip.rb
@@ -13,9 +13,9 @@ module Paperclip
     # This will test whether you have defined your attachment correctly by
     # checking for all the required fields exist after the definition of the
     # attachment.
-    def should_have_attached_file name
+    def should_contain_file name
       klass   = self.name.gsub(/Test$/, '').constantize
-      matcher = have_attached_file name
+      matcher = contain_file name
       should matcher.description do
         assert_accepts(matcher, klass)
       end


### PR DESCRIPTION
It changes soulda matcher have_attached_file_matcher to contain_file_matcher because the rspec 3 displays warnings when using have in matcher name.