### PR TITLE
Fix intermittently failing spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,5 +17,4 @@ gem 'pry'
 group :development, :test do
   gem 'mime-types', '~> 1.16'
   gem 'builder', '~> 3.1.4'
-  gem 'timecop', '~> 0.7.1'
 end

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -47,4 +47,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('railties')
   s.add_development_dependency('actionmailer', '>= 3.0.0')
   s.add_development_dependency('generator_spec')
+  s.add_development_dependency('timecop')
 end


### PR DESCRIPTION
- `fog_spec.rb:328` fails intermittently due to a race condition
- Use [TimeCop](https://github.com/travisjeffery/timecop) gem to freeze time during the spec
- Extract magic number
- Break long line

![TimeCop
Poster](http://www.deconstructingmovies.com/wp-content/uploads/2014/03/timecop-poster.jpg)
