### PR TITLE
Fix mime checking when unix util "file" version <5.

### DIFF
--- a/lib/paperclip/file_command_content_type_detector.rb
+++ b/lib/paperclip/file_command_content_type_detector.rb
@@ -12,10 +12,17 @@ module Paperclip
 
     private
 
+    def major_version_of_file_command
+      output = /^file-(\d+)\./.match(Paperclip.run("file", "-v 2>&1", {}, expected_outcodes: [0,1]))
+      output && output.size > 1 ? output[1] : nil
+    end
+
     def type_from_file_command
       type = begin
+        command_version = major_version_of_file_command
+        mime_option = command_version && command_version.to_i <= 4 ? '-i' : '--mime'
         # On BSDs, `file` doesn't give a result code of 1 if the file doesn't exist.
-        Paperclip.run("file", "-b --mime :file", :file => @filename)
+        Paperclip.run("file", "-b #{mime_option} :file", :file => @filename)
       rescue Cocaine::CommandLineError => e
         Paperclip.log("Error while determining content type: #{e}")
         SENSIBLE_DEFAULT

--- a/lib/paperclip/media_type_spoof_detector.rb
+++ b/lib/paperclip/media_type_spoof_detector.rb
@@ -59,11 +59,7 @@ module Paperclip
     end
 
     def type_from_file_command
-      begin
-        Paperclip.run("file", "-b --mime :file", :file => @file.path).split(/[:;]\s+/).first
-      rescue Cocaine::CommandLineError
-        ""
-      end
+      FileCommandContentTypeDetector.new(@file.path).detect
     end
   end
 end

--- a/spec/paperclip/content_type_detector_spec.rb
+++ b/spec/paperclip/content_type_detector_spec.rb
@@ -15,7 +15,9 @@ describe Paperclip::ContentTypeDetector do
     MIME::Types.stubs(:type_for).returns([MIME::Type.new('application/mp4'), MIME::Type.new('video/mp4'), MIME::Type.new('audio/mp4')])
     Paperclip.stubs(:run).returns("video/mp4")
     @filename = "my_file.mp4"
-    assert_equal "video/mp4", Paperclip::ContentTypeDetector.new(@filename).detect
+    detector = Paperclip::ContentTypeDetector.new(@filename)
+    detector.stubs(:major_version_of_file_command).returns('5')
+    assert_equal "video/mp4", detector.detect
   end
 
   it 'finds the right type in the list via the file command' do


### PR DESCRIPTION
This is potentially relevant in #1506, but it doesn't really affect the current choices, rather, it merely ensures that the current code works even on older versions of the `file` command on unix/linux.

For versions prior to 5, the `-i` option provides the mime type. That option doesn't exist in version 5 and has been replaced with the `--mime` that Paperclip was using by default.