### PR TITLE
Attachment size validation - Fixed the number helper condition issue

### DIFF
--- a/lib/paperclip/validators/attachment_size_validator.rb
+++ b/lib/paperclip/validators/attachment_size_validator.rb
@@ -71,7 +71,7 @@ module Paperclip
       end
 
       def human_size(size)
-        if defined?(ActiveRecord::NumberHelper) # Rails 4.0+
+        if defined?(ActiveSupport::NumberHelper) # Rails 4.0+
           ActiveSupport::NumberHelper.number_to_human_size(size)
         else
           storage_units_format = I18n.translate(:'number.human.storage_units.format', :locale => options[:locale], :raise => true)


### PR DESCRIPTION
In the original code, there is support added for Rails 4.0+ to show the size validation error message in KB/MB instead of Bytes. Unfortunately it was not working because of the wrong condition.

The condition checks `ActiveRecord::NumberHelper` is defined or not. But there is no such a class `ActiveRecord::NumberHelper`. 

I've changed the condition to `ActiveSupport::NumberHelper` using which the code is humanising size on line no. 75.

Now it is working.
