### PR TITLE
 Replace drop_attached_file with remove_attachment

### DIFF
--- a/lib/generators/paperclip/templates/paperclip_migration.rb.erb
+++ b/lib/generators/paperclip/templates/paperclip_migration.rb.erb
@@ -9,7 +9,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration
 
   def self.down
 <% attachment_names.each do |attachment| -%>
-    drop_attached_file :<%= table_name %>, :<%= attachment %>
+    remove_attachment :<%= table_name %>, :<%= attachment %>
 <% end -%>
   end
 end


### PR DESCRIPTION
Hello!
In this small pull-request I replaced `drop_attached_file` method with new one in generator's template.
I could not find any tests for migration generator that I would have to change.
