### PR TITLE
Adds AttachmentSizeValidator usage example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ Example Usage:
 ```ruby
 validates :avatar, :attachment_presence => true
 validates_with AttachmentPresenceValidator, :attributes => :avatar
+validates_with AttachmentSizeValidator, :attributes => :avatar, :less_than => 1.megabytes
+
 ```
 
 Validators can also be defined using the old helper style:


### PR DESCRIPTION
Syntax is not clear from current documentation. This syntax works on my Rails 4, Paperclip 3.5.4 app. I found this syntax by guessing, but by all means if there is a cleaner syntax, please use that. Thanks for the great work!
