### PR TITLE
Add a test case for protocol-relative URL `s3_protocol`

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -26,7 +26,7 @@ module Paperclip
     #   put your bucket name in this file, instead of adding it to the code directly.
     #   This is useful when you want the same account but a different bucket for
     #   development versus production.
-    #   When using a Proc it provides a single parameter which is the attachment itself. A  
+    #   When using a Proc it provides a single parameter which is the attachment itself. A
     #   method #instance is available on the attachment which will take you back to your
     #   code. eg.
     #     class User
@@ -51,7 +51,7 @@ module Paperclip
     #     :s3_permissions => :private
     #
     # * +s3_protocol+: The protocol for the URLs generated to your S3 assets. Can be either
-    #   'http', 'https', or an empty string to generate scheme-less URLs. Defaults to 'http'
+    #   'http', 'https', or an empty string to generate protocol-relative URLs. Defaults to 'http'
     #   when your :s3_permissions are :public_read (the default), and 'https' when your
     #   :s3_permissions are anything else.
     # * +s3_headers+: A hash of headers or a Proc. You may specify a hash such as

--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -152,6 +152,22 @@ describe Paperclip::Storage::S3 do
     end
   end
 
+  context "s3_protocol: ''" do
+    before do
+      rebuild_model storage: :s3,
+        s3_credentials: {},
+        s3_protocol: '',
+        bucket: "bucket",
+        path: ":attachment/:basename:dotextension"
+      @dummy = Dummy.new
+      @dummy.avatar = stringy_file
+    end
+
+    it "returns a protocol-relative URL" do
+      assert_match %r{^//s3.amazonaws.com/bucket/avatars/data[^\.]}, @dummy.avatar.url
+    end
+  end
+
   context "s3_protocol: :https" do
     before do
       rebuild_model storage: :s3,


### PR DESCRIPTION
Just added a test example of [protocol-relative URLs](https://en.wikipedia.org/wiki/Uniform_resource_locator#Protocol-relative_URLs). As there are no examples in the documentation a test could be helpful to check the usage. 
