### PR TITLE
Add :skip_spoof_detection option

### DIFF
--- a/lib/paperclip/has_attached_file.rb
+++ b/lib/paperclip/has_attached_file.rb
@@ -80,8 +80,9 @@ module Paperclip
 
     def add_required_validations
       name = @name
+      skip_spoof_detection = @options && @options.is_a?(Hash) && @options[:skip_spoof_detection]
       @klass.validates_media_type_spoof_detection name,
-        :if => ->(instance){ instance.send(name).dirty? }
+        :if => ->(instance){ instance.send(name).dirty? && !skip_spoof_detection }
     end
 
     def add_active_record_callbacks

--- a/spec/paperclip/validators/media_type_spoof_detection_validator_spec.rb
+++ b/spec/paperclip/validators/media_type_spoof_detection_validator_spec.rb
@@ -44,4 +44,16 @@ describe Paperclip::Validators::MediaTypeSpoofDetectionValidator do
     @dummy.valid?
     assert_received(Paperclip::MediaTypeSpoofDetector, :using){|e| e.never }
   end
+
+  it "does not run when :skip_spoof_detection is set" do
+    rebuild_model skip_spoof_detection: true
+    dummy = Dummy.new
+    build_validator
+    file = File.new(fixture_file("5k.png"), "rb")
+    dummy.avatar.assign(file)
+
+    Paperclip::MediaTypeSpoofDetector.stubs(:using).never
+    dummy.valid?
+    assert_received(Paperclip::MediaTypeSpoofDetector, :using){|e| e.never }
+  end
 end


### PR DESCRIPTION
I had problems with spoof detection and it seems that in order to disable this feature monkey patching needs to be used (eg. https://github.com/thoughtbot/paperclip/issues/1429, http://stackoverflow.com/questions/22527092/paperclip-is-not-supporting-doc-file). I think that there should be a better way, so I've added :skip_spoof_detection option.

Example:

``` ruby
class User
  has_attached_file :attachment, skip_spoof_detection: true
end
```

I'm not sure if it is the best solution, but I think that there should be such feature available, because currently spoof detection is not very reliable. 
