### PR TITLE
Use stream downloads for S3 objects as suggested by aws-sdk

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -384,10 +384,11 @@ module Paperclip
 
       def copy_to_local_file(style, local_dest_path)
         log("copying #{path(style)} to local file #{local_dest_path}")
-        local_file = ::File.open(local_dest_path, 'wb')
-        file = s3_object(style)
-        local_file.write(file.read)
-        local_file.close
+        ::File.open(local_dest_path, 'wb') do |local_file|
+          s3_object(style).read do |chunk|
+            local_file.write(chunk)
+          end
+        end
       rescue AWS::Errors::Base => e
         warn("#{e} - cannot copy #{path(style)} to local file #{local_dest_path}")
         false


### PR DESCRIPTION
documentation.

They recommend sending a block to the #read method to avoid loading
large objects into memory. See the "Reading Objects" section at:
http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/S3/S3Object.html
