### PR TITLE
Download S3 files by reading in chunks, not all at once.

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -395,7 +395,9 @@ module Paperclip
         log("copying #{path(style)} to local file #{local_dest_path}")
         local_file = ::File.open(local_dest_path, 'wb')
         file = s3_object(style)
-        local_file.write(file.read)
+        file.read do |chunk|
+          local_file.write chunk
+        end
         local_file.close
       rescue AWS::Errors::Base => e
         warn("#{e} - cannot copy #{path(style)} to local file #{local_dest_path}")


### PR DESCRIPTION
This changes the downloading of objects from S3 to avoid reading the entire object into memory.

Anything which results in a reprocessing of an attachment will need to download the file from S3. In our case we're dealing with large files (video, sometimes several hundred megs), and we're using the delayed_paperclip gem to reprocess the files using delayed job. This results in the original files getting downloaded, reprocessed then uploaded back to S3. The upload gets chunked automatically by the S3 gem, but the download part doesn't ballooning up Ruby's memory usage - this is changes the download behaviour to follow the pattern recommended in the aws-sdk docs for S3Object#read
