### PR TITLE
Honor fog_credentials[:scheme] option

### DIFF
--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -14,6 +14,7 @@ module Paperclip
     #     aws_secret_access_key: '<your aws_secret_access_key>'
     #     provider: 'AWS'
     #     region: 'eu-west-1'
+    #     scheme: 'https'
     # * +fog_directory+: This is the name of the S3 bucket that will
     #   store your files.  Remember that the bucket must be unique across
     #   all of Amazon S3. If the bucket does not exist, Paperclip will
@@ -131,7 +132,7 @@ module Paperclip
           "#{dynamic_fog_host_for_style(style)}/#{path(style)}"
         else
           if fog_credentials[:provider] == 'AWS'
-            "https://#{host_name_for_directory}/#{path(style)}"
+            "#{scheme}://#{host_name_for_directory}/#{path(style)}"
           else
             directory.files.new(:key => path(style)).public_url
           end
@@ -224,6 +225,10 @@ module Paperclip
         end
 
         @directory ||= connection.directories.new(:key => dir)
+      end
+
+      def scheme
+        @scheme ||= fog_credentials[:scheme] || 'https'
       end
     end
   end

--- a/spec/paperclip/storage/fog_spec.rb
+++ b/spec/paperclip/storage/fog_spec.rb
@@ -308,6 +308,34 @@ describe Paperclip::Storage::Fog do
         end
       end
 
+      context "with scheme set" do
+        before do
+          rebuild_model(@options.merge(:fog_credentials => @credentials.merge(:scheme => 'http')))
+          @file = File.new(fixture_file('5k.png'), 'rb')
+          @dummy = Dummy.new
+          @dummy.avatar = @file
+          @dummy.save
+        end
+
+        it "honors the scheme in public url" do
+          assert_match(/^http:\/\//, @dummy.avatar.url)
+        end
+      end
+
+      context "with scheme not set" do
+        before do
+          rebuild_model(@options)
+          @file = File.new(fixture_file('5k.png'), 'rb')
+          @dummy = Dummy.new
+          @dummy.avatar = @file
+          @dummy.save
+        end
+
+        it "provides HTTPS public url" do
+          assert_match(/^https:\/\//, @dummy.avatar.url)
+        end
+      end
+
       context "with a valid bucket name for a subdomain" do
         it "provides an url in subdomain style" do
           assert_match(/^https:\/\/papercliptests.s3.amazonaws.com\/avatars\/5k.png/, @dummy.avatar.url)


### PR DESCRIPTION
So that `attachment.url` can provide an HTTP url if properly configured:

```
has_attached_file :image,
  storage: :fog,
  :fog_credentials => {
    :scheme            => 'http',
    :access_key_id     => ENV['AWS_ACCESS_KEY_ID'],
    :secret_access_key => ENV['AWS_SECRET_ACCESS_KEY']
  }
```

Default is still HTTPS, indeed.
