### PR TITLE
Uses a faster implementation for ensure_required_validations!

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -389,12 +389,8 @@ module Paperclip
       @instance.class.validators.map(&:class)
     end
 
-    def required_validator_classes
-      Paperclip::REQUIRED_VALIDATORS + Paperclip::REQUIRED_VALIDATORS.flat_map(&:descendants)
-    end
-
     def missing_required_validator?
-      (active_validator_classes & required_validator_classes).empty?
+      (active_validator_classes.flat_map(&:ancestors) & Paperclip::REQUIRED_VALIDATORS).empty?
     end
 
     def ensure_required_validations!


### PR DESCRIPTION
While updating an application to Paperclip 4.2.0, I noticed its specs where a lot slower after the upgrade. While investigating, I've found that the usage of the `descendants` method was the culprit. This PR uses an alternative implementation to avoid its usage, which brings the specs to the same running time as before.
