### PR TITLE
Make id partitioning for string similar to integer

### DIFF
--- a/lib/paperclip/interpolations.rb
+++ b/lib/paperclip/interpolations.rb
@@ -172,7 +172,7 @@ module Paperclip
       when Integer
         ("%09d" % id).scan(/\d{3}/).join("/")
       when String
-        id.scan(/.{3}/).first(3).join("/")
+        ('%9.9s' % id).tr(" ", "0").scan(/.{3}/).join("/")
       else
         nil
       end

--- a/spec/paperclip/interpolations_spec.rb
+++ b/spec/paperclip/interpolations_spec.rb
@@ -138,7 +138,14 @@ describe Paperclip::Interpolations do
     assert_equal "000/000/023", Paperclip::Interpolations.id_partition(attachment, :style)
   end
 
-  it "returns the partitioned id of the attachment when the id is a string" do
+  it "returns the partitioned id of the attachment when the id is a short string" do
+    attachment = mock
+    attachment.expects(:id).returns("fnj23")
+    attachment.expects(:instance).returns(attachment)
+    assert_equal "000/0fn/j23", Paperclip::Interpolations.id_partition(attachment, :style)
+  end
+
+  it "returns the partitioned id of the attachment when the id is a long string" do
     attachment = mock
     attachment.expects(:id).returns("32fnj23oio2f")
     attachment.expects(:instance).returns(attachment)
@@ -204,7 +211,7 @@ describe Paperclip::Interpolations do
     attachment.stubs(:original_filename).returns("one")
     assert_equal "one", Paperclip::Interpolations.filename(attachment, :style)
   end
-  
+
   it "returns the basename when the extension contains regexp special characters" do
     attachment = mock
     attachment.stubs(:styles).returns({})


### PR DESCRIPTION
String id partitioning works slightly different from Integer id partitioning

```
42 #=> '000/000/042'
ab #=> 'ab'
```

This request make them more equal

```
42 #=> '000/000/042'
ab #=> '000/000/0ab'
```
