### PR TITLE
Pass options through to the underlying adapter.

### DIFF
--- a/lib/paperclip/schema.rb
+++ b/lib/paperclip/schema.rb
@@ -22,9 +22,12 @@ module Paperclip
       def add_attachment(table_name, *attachment_names)
         raise ArgumentError, "Please specify attachment name in your add_attachment call in your migration." if attachment_names.empty?
 
+        options = attachment_names.extract_options!
+
         attachment_names.each do |attachment_name|
           COLUMNS.each_pair do |column_name, column_type|
-            add_column(table_name, "#{attachment_name}_#{column_name}", column_type)
+            column_options = options.merge(options[column_name.to_sym] || {})
+            add_column(table_name, "#{attachment_name}_#{column_name}", column_type, column_options)
           end
         end
       end
@@ -32,9 +35,12 @@ module Paperclip
       def remove_attachment(table_name, *attachment_names)
         raise ArgumentError, "Please specify attachment name in your remove_attachment call in your migration." if attachment_names.empty?
 
+        options = attachment_names.extract_options!
+
         attachment_names.each do |attachment_name|
           COLUMNS.each_pair do |column_name, column_type|
-            remove_column(table_name, "#{attachment_name}_#{column_name}")
+            column_options = options.merge(options[column_name.to_sym] || {})
+            remove_column(table_name, "#{attachment_name}_#{column_name}", column_type, column_options)
           end
         end
       end
@@ -47,9 +53,11 @@ module Paperclip
 
     module TableDefinition
       def attachment(*attachment_names)
+        options = attachment_names.extract_options!
         attachment_names.each do |attachment_name|
           COLUMNS.each_pair do |column_name, column_type|
-            column("#{attachment_name}_#{column_name}", column_type)
+            column_options = options.merge(options[column_name.to_sym] || {})
+            column("#{attachment_name}_#{column_name}", column_type, column_options)
           end
         end
       end

--- a/spec/paperclip/schema_spec.rb
+++ b/spec/paperclip/schema_spec.rb
@@ -58,6 +58,27 @@ describe Paperclip::Schema do
         expect(columns).to include(['avatar_updated_at', :datetime])
       end
     end
+
+    context "using #attachment with options" do
+      before do
+        Dummy.connection.create_table :dummies, force: true do |t|
+          t.attachment :avatar, default: '1', file_name: { default: 'default' }
+        end
+      end
+
+      it "sets defaults on columns" do
+        defaults_columns = ["avatar_file_name", "avatar_content_type", "avatar_file_size"]
+        columns = Dummy.columns.select { |e| defaults_columns.include? e.name }
+
+        columns.each do |column|
+          if column.name == 'avatar_file_name'
+            expect(column.default).to eq('default')
+          else
+            expect(column.default.to_i).to eq(1)
+          end
+        end
+      end
+    end
   end
 
   context "within schema statement" do
@@ -81,6 +102,25 @@ describe Paperclip::Schema do
         end
       end
 
+      context "with single attachment and options" do
+        before do
+          Dummy.connection.add_attachment :dummies, :avatar, default: '1', file_name: { default: 'default' }
+        end
+
+        it "sets defaults on columns" do
+          defaults_columns = ["avatar_file_name", "avatar_content_type", "avatar_file_size"]
+          columns = Dummy.columns.select { |e| defaults_columns.include? e.name }
+
+          columns.each do |column|
+            if column.name == 'avatar_file_name'
+              expect(column.default).to eq('default')
+            else
+              expect(column.default.to_i).to eq(1)
+            end
+          end
+        end
+      end
+
       context "with multiple attachments" do
         before do
           Dummy.connection.add_attachment :dummies, :avatar, :photo
@@ -97,6 +137,25 @@ describe Paperclip::Schema do
           expect(columns).to include(['photo_content_type', :string])
           expect(columns).to include(['photo_file_size', :integer])
           expect(columns).to include(['photo_updated_at', :datetime])
+        end
+      end
+
+      context "with multiple attachments and options" do
+        before do
+          Dummy.connection.add_attachment :dummies, :avatar, :photo, default: '1', file_name: { default: 'default' }
+        end
+
+        it "sets defaults on columns" do
+          defaults_columns = ["avatar_file_name", "avatar_content_type", "avatar_file_size", "photo_file_name", "photo_content_type", "photo_file_size"]
+          columns = Dummy.columns.select { |e| defaults_columns.include? e.name }
+
+          columns.each do |column|
+            if column.name == 'avatar_file_name' || column.name == 'photo_file_name'
+              expect(column.default).to eq('default')
+            else
+              expect(column.default.to_i).to eq(1)
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Column-specific options can be specified by using its name,
for example:

```
t.attachment :avatar, created_at: { index: true }
```

I tried using `index` in the tests, but it seems like the SQLite adapter was ignoring it.
