### PR TITLE
Paperclip Broken Attachment finder

### DIFF
--- a/lib/tasks/paperclip.rake
+++ b/lib/tasks/paperclip.rake
@@ -108,4 +108,20 @@ namespace :paperclip do
       end
     end
   end
+
+ desc "find missing attachments. Useful to know which attachments are broken"
+  task :find_broken_attachments => :environment do
+    klass = Paperclip::Task.obtain_class
+    names = Paperclip::Task.obtain_attachments(klass)
+    names.each do |name|
+      Paperclip.each_instance_with_attachment(klass, name) do |instance|
+        attachment = instance.send(name)
+        if attachment.exists?
+          print "."
+        else
+          Paperclip::Task.log_error("#{instance.class}##{attachment.name}, #{instance.id}, #{attachment.url}")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
t will scan ALL attachments in rails application & check to if they do really exists on storage location.
if the file is not found, it will log as error on STDERR.

The way you want to run this rake task is:

```sh
$ rake broken_links_check 2> path/to/file
```

The code might need some cleanup, will do that but want to see if you guys think its a good idea?