### PR TITLE
Adding -r option to file command

### DIFF
--- a/lib/paperclip/file_command_content_type_detector.rb
+++ b/lib/paperclip/file_command_content_type_detector.rb
@@ -15,7 +15,7 @@ module Paperclip
     def type_from_file_command
       type = begin
         # On BSDs, `file` doesn't give a result code of 1 if the file doesn't exist.
-        Paperclip.run("file", "-b --mime :file", :file => @filename)
+        Paperclip.run("file", "-b -r --mime :file", :file => @filename)
       rescue Cocaine::CommandLineError => e
         Paperclip.log("Error while determining content type: #{e}")
         SENSIBLE_DEFAULT

--- a/lib/paperclip/media_type_spoof_detector.rb
+++ b/lib/paperclip/media_type_spoof_detector.rb
@@ -60,7 +60,7 @@ module Paperclip
 
     def type_from_file_command
       begin
-        Paperclip.run("file", "-b --mime :file", :file => @file.path).split(/[:;]\s+/).first
+        Paperclip.run("file", "-b -r --mime :file", :file => @file.path).split(/[:;]\s+/).first
       rescue Cocaine::CommandLineError
         ""
       end


### PR DESCRIPTION
Adding `-r, --raw` option: Don't translate unprintable characters to \ooo.	
Normally file translates unprintable	characters to their octal representation.

without `-r` option, the file command some times return file type with `\00` like characters.

For example: 
On CentOS 5 and file command version 4.17
Test the mime type for a aiff audio file.

```
 file -b --mime mono_normalized.aiff
 audio/x-aiff\011
```

with `-r` option:

```
 file -b --mime mono_normalized.aiff
 audio/x-aiff
```
