### PR TITLE
Readme For Windows Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,7 @@ If you're using Windows 7+ as a development environment, you may need to install
 
 To manually install, you should perform the following:
 
-    1. Download the `file` installer from [this URL](http://gnuwin32.sourceforge.net/packages/file.htm)
-    2. Install
+> **Download & install `file` from [this URL](http://gnuwin32.sourceforge.net/packages/file.htm)**
 
 To test, you can use the following:
 ![untitled](https://cloud.githubusercontent.com/assets/1104431/4524452/a1f8cce4-4d44-11e4-872e-17adb96f79c9.png)


### PR DESCRIPTION
Windows users don't have any real way to see a solid fix for the infamous "spoofing" error - `Validation failed: Upload file has an extension that does not match its contents.`

Having fixed this ourselves, I provided more in-depth information for your users. This _should_ help anyone developing on Windows. I also tidied up the ReadMe in general (adding breaker lines to denote sections etc)

BTW here is a pic of me & friend your Stockholm office:
![thoughtbot](https://cloud.githubusercontent.com/assets/1104431/4530754/dc9b8f1e-4d83-11e4-8d84-50857eebfddd.JPG)
