### PR TITLE
add support for Proc in S3 storage for s3_options

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -136,6 +136,8 @@ module Paperclip
 
         base.instance_eval do
           @s3_options     = @options[:s3_options]     || {}
+          @s3_options     = @options[:s3_options].call(self) if @options[:s3_options].respond_to?(:call)
+          
           @s3_permissions = set_permissions(@options[:s3_permissions])
           @s3_protocol    = @options[:s3_protocol]    ||
             Proc.new do |style, attachment|


### PR DESCRIPTION
Hello,

I add this support to use different S3 endpoints if buckets need it.

Thanks for adding it in the main gem.

Cheers
Migoo
