### PR TITLE
Use Travis container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ rvm:
 install:
   - "travis_retry bundle install"
 
-before_script: "sudo ntpdate -ub ntp.ubuntu.com pool.ntp.org; true"
 script: "bundle exec rake clean spec cucumber"
 
 gemfile:
@@ -21,3 +20,5 @@ matrix:
   allow_failures:
     - rvm: jruby-19mode
     - rvm: rbx-2
+
+sudo: false


### PR DESCRIPTION
The container infrastructure (beta) has many advantages:
* More memory
* More CPU
* builds start much faster.
* builds run much faster (usually)

However, `sudo` cannot be used when running in this environment (which is
enabled with the `sudo: false` configuration.

The existing travis configuration had a `sudo` command that was added some time ago without much explanation. It's hoped that this is no longer necessary and that this PR will build okay without it...