### PR TITLE
Add `length` alias for `size` method in AbstractAdapter

### DIFF
--- a/lib/paperclip/io_adapters/abstract_adapter.rb
+++ b/lib/paperclip/io_adapters/abstract_adapter.rb
@@ -6,6 +6,7 @@ module Paperclip
 
     attr_reader :content_type, :original_filename, :size
     delegate :binmode, :binmode?, :close, :close!, :closed?, :eof?, :path, :rewind, :unlink, :to => :@tempfile
+    alias :length :size
 
     def fingerprint
       @fingerprint ||= Digest::MD5.file(path).to_s

--- a/spec/paperclip/io_adapters/stringio_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/stringio_adapter_spec.rb
@@ -20,6 +20,10 @@ describe Paperclip::StringioAdapter do
       assert_equal 6, @subject.size
     end
 
+    it "returns the length of the data" do
+      assert_equal 6, @subject.length
+    end
+
     it "generates an MD5 hash of the contents" do
       assert_equal Digest::MD5.hexdigest(@contents), @subject.fingerprint
     end


### PR DESCRIPTION
The reason behind this I'm trying to use `StringioAdapter` inside the `ActionMailer`, and it fails because `length` used in one of the `mail` gem:
https://github.com/mikel/mail/blob/master/lib/mail/message.rb#L1997

Also you can see that normally `size` has `length` alias, for example in a `StringIO` class:
http://ruby-doc.org/stdlib-1.9.3/libdoc/stringio/rdoc/StringIO.html#method-i-length

Let me know, if this change requires test case, I will add it.