### PR TITLE
Add the ability to deep_merge! Attachment definitions

### DIFF
--- a/lib/paperclip/attachment_registry.rb
+++ b/lib/paperclip/attachment_registry.rb
@@ -52,7 +52,7 @@ module Paperclip
 
     def definitions_for(klass)
       klass.ancestors.each_with_object({}) do |ancestor, inherited_definitions|
-        inherited_definitions.merge! @attachments[ancestor]
+        inherited_definitions.deep_merge! @attachments[ancestor]
       end
     end
   end

--- a/spec/paperclip/attachment_registry_spec.rb
+++ b/spec/paperclip/attachment_registry_spec.rb
@@ -54,12 +54,16 @@ describe 'Attachment Registry' do
         greeter: { ciao: 'greeting' }
       }
       foo = Class.new
-      Paperclip::AttachmentRegistry.register(foo,
-                                             :avatar,
-                                             { yo: 'greeting' })
-      Paperclip::AttachmentRegistry.register(foo,
-                                             :greeter,
-                                             { ciao: 'greeting' })
+      Paperclip::AttachmentRegistry.register(
+        foo,
+        :avatar,
+        { yo: 'greeting' }
+      )
+      Paperclip::AttachmentRegistry.register(
+        foo,
+        :greeter,
+        { ciao: 'greeting' }
+      )
 
       definitions = Paperclip::AttachmentRegistry.definitions_for(foo)
 
@@ -70,9 +74,11 @@ describe 'Attachment Registry' do
       expected_definitions = { avatar: { yo: 'greeting' } }
       foo = Class.new
       bar = Class.new(foo)
-      Paperclip::AttachmentRegistry.register(foo,
-                                             :avatar,
-                                             expected_definitions[:avatar])
+      Paperclip::AttachmentRegistry.register(
+        foo,
+        :avatar,
+        expected_definitions[:avatar]
+      )
 
       definitions = Paperclip::AttachmentRegistry.definitions_for(bar)
 
@@ -90,12 +96,16 @@ describe 'Attachment Registry' do
       }
       foo = Class.new
       bar = Class.new(foo)
-      Paperclip::AttachmentRegistry.register(foo,
-                                             :avatar,
-                                             foo_definitions[:avatar])
-      Paperclip::AttachmentRegistry.register(bar,
-                                             :avatar,
-                                             bar_definitions[:avatar])
+      Paperclip::AttachmentRegistry.register(
+        foo,
+        :avatar,
+        foo_definitions[:avatar]
+      )
+      Paperclip::AttachmentRegistry.register(
+        bar,
+        :avatar,
+        bar_definitions[:avatar]
+      )
 
       definitions = Paperclip::AttachmentRegistry.definitions_for(bar)
 

--- a/spec/paperclip/attachment_registry_spec.rb
+++ b/spec/paperclip/attachment_registry_spec.rb
@@ -31,8 +31,8 @@ describe 'Attachment Registry' do
     it 'calls the block with the class, attachment name, and options' do
       foo = Class.new
       expected_accumulations = [
-        [foo, :avatar, { yo: 'greeting' }],
-        [foo, :greeter, { ciao: 'greeting' }]
+        [foo, :avatar, { yo: "greeting" }],
+        [foo, :greeter, { ciao: "greeting" }]
       ]
       expected_accumulations.each do |args|
         Paperclip::AttachmentRegistry.register(*args)
@@ -50,19 +50,19 @@ describe 'Attachment Registry' do
   context '.definitions_for' do
     it 'produces the attachment name and options' do
       expected_definitions = {
-        avatar: { yo: 'greeting' },
-        greeter: { ciao: 'greeting' }
+        avatar: { yo: "greeting" },
+        greeter: { ciao: "greeting" }
       }
       foo = Class.new
       Paperclip::AttachmentRegistry.register(
         foo,
         :avatar,
-        { yo: 'greeting' }
+        yo: "greeting"
       )
       Paperclip::AttachmentRegistry.register(
         foo,
         :greeter,
-        { ciao: 'greeting' }
+        ciao: "greeting"
       )
 
       definitions = Paperclip::AttachmentRegistry.definitions_for(foo)
@@ -71,7 +71,7 @@ describe 'Attachment Registry' do
     end
 
     it 'produces defintions for subclasses' do
-      expected_definitions = { avatar: { yo: 'greeting' } }
+      expected_definitions = { avatar: { yo: "greeting" } }
       foo = Class.new
       bar = Class.new(foo)
       Paperclip::AttachmentRegistry.register(
@@ -86,12 +86,12 @@ describe 'Attachment Registry' do
     end
 
     it 'produces defintions for subclasses but deep merging them' do
-      foo_definitions = { avatar: { yo: 'greeting' } }
-      bar_definitions = { avatar: { ciao: 'greeting' } }
+      foo_definitions = { avatar: { yo: "greeting" } }
+      bar_definitions = { avatar: { ciao: "greeting" } }
       expected_definitions = {
         avatar: {
-          yo: 'greeting',
-          ciao: 'greeting'
+          yo: "greeting",
+          ciao: "greeting"
         }
       }
       foo = Class.new
@@ -118,7 +118,7 @@ describe 'Attachment Registry' do
       foo = Class.new
       Paperclip::AttachmentRegistry.register(foo,
                                              :greeter,
-                                             { ciao: 'greeting' })
+                                             { ciao: "greeting" })
 
       Paperclip::AttachmentRegistry.clear
 

--- a/spec/paperclip/attachment_registry_spec.rb
+++ b/spec/paperclip/attachment_registry_spec.rb
@@ -64,11 +64,30 @@ describe 'Attachment Registry' do
 
     it "produces defintions for subclasses" do
       expected_definitions = { avatar: { yo: 'greeting' } }
-      Foo = Class.new
-      Bar = Class.new(Foo)
-      Paperclip::AttachmentRegistry.register(Foo, :avatar, expected_definitions[:avatar])
+      foo = Class.new
+      bar = Class.new(foo)
+      Paperclip::AttachmentRegistry.register(foo, :avatar, expected_definitions[:avatar])
 
-      definitions = Paperclip::AttachmentRegistry.definitions_for(Bar)
+      definitions = Paperclip::AttachmentRegistry.definitions_for(bar)
+
+      assert_equal expected_definitions, definitions
+    end
+
+    it "produces defintions for subclasses but deep merging them" do
+      foo_definitions = { avatar: { yo: 'greeting' } }
+      bar_definitions = { avatar: { ciao: 'greeting' } }
+      expected_definitions = {
+        avatar: {
+          yo: 'greeting',
+          ciao: 'greeting'
+         }
+      }
+      foo = Class.new
+      bar = Class.new(foo)
+      Paperclip::AttachmentRegistry.register(foo, :avatar, foo_definitions[:avatar])
+      Paperclip::AttachmentRegistry.register(bar, :avatar, bar_definitions[:avatar])
+
+      definitions = Paperclip::AttachmentRegistry.definitions_for(bar)
 
       assert_equal expected_definitions, definitions
     end

--- a/spec/paperclip/attachment_registry_spec.rb
+++ b/spec/paperclip/attachment_registry_spec.rb
@@ -1,19 +1,19 @@
-require 'spec_helper'
+require "spec_helper"
 
-describe 'Attachment Registry' do
+describe "Attachment Registry" do
   before do
     Paperclip::AttachmentRegistry.clear
   end
 
-  context '.names_for' do
-    it 'includes attachment names for the given class' do
+  context ".names_for" do
+    it "includes attachment names for the given class" do
       foo = Class.new
       Paperclip::AttachmentRegistry.register(foo, :avatar, {})
 
       assert_equal [:avatar], Paperclip::AttachmentRegistry.names_for(foo)
     end
 
-    it 'does not include attachment names for other classes' do
+    it "does not include attachment names for other classes" do
       foo = Class.new
       bar = Class.new
       Paperclip::AttachmentRegistry.register(foo, :avatar, {})
@@ -22,13 +22,13 @@ describe 'Attachment Registry' do
       assert_equal [:lover], Paperclip::AttachmentRegistry.names_for(bar)
     end
 
-    it 'produces the empty array for a missing key' do
+    it "produces the empty array for a missing key" do
       assert_empty Paperclip::AttachmentRegistry.names_for(Class.new)
     end
   end
 
-  context '.each_definition' do
-    it 'calls the block with the class, attachment name, and options' do
+  context ".each_definition" do
+    it "calls the block with the class, attachment name, and options" do
       foo = Class.new
       expected_accumulations = [
         [foo, :avatar, { yo: "greeting" }],
@@ -47,8 +47,8 @@ describe 'Attachment Registry' do
     end
   end
 
-  context '.definitions_for' do
-    it 'produces the attachment name and options' do
+  context ".definitions_for" do
+    it "produces the attachment name and options" do
       expected_definitions = {
         avatar: { yo: "greeting" },
         greeter: { ciao: "greeting" }
@@ -70,7 +70,7 @@ describe 'Attachment Registry' do
       assert_equal expected_definitions, definitions
     end
 
-    it 'produces defintions for subclasses' do
+    it "produces defintions for subclasses" do
       expected_definitions = { avatar: { yo: "greeting" } }
       foo = Class.new
       bar = Class.new(foo)
@@ -85,7 +85,7 @@ describe 'Attachment Registry' do
       assert_equal expected_definitions, definitions
     end
 
-    it 'produces defintions for subclasses but deep merging them' do
+    it "produces defintions for subclasses but deep merging them" do
       foo_definitions = { avatar: { yo: "greeting" } }
       bar_definitions = { avatar: { ciao: "greeting" } }
       expected_definitions = {
@@ -113,8 +113,8 @@ describe 'Attachment Registry' do
     end
   end
 
-  context '.clear' do
-    it 'removes all of the existing attachment definitions' do
+  context ".clear" do
+    it "removes all of the existing attachment definitions" do
       foo = Class.new
       Paperclip::AttachmentRegistry.register(
         foo,

--- a/spec/paperclip/attachment_registry_spec.rb
+++ b/spec/paperclip/attachment_registry_spec.rb
@@ -116,9 +116,11 @@ describe 'Attachment Registry' do
   context '.clear' do
     it 'removes all of the existing attachment definitions' do
       foo = Class.new
-      Paperclip::AttachmentRegistry.register(foo,
-                                             :greeter,
-                                             { ciao: "greeting" })
+      Paperclip::AttachmentRegistry.register(
+        foo,
+        :greeter,
+        ciao: "greeting"
+      )
 
       Paperclip::AttachmentRegistry.clear
 

--- a/spec/paperclip/attachment_registry_spec.rb
+++ b/spec/paperclip/attachment_registry_spec.rb
@@ -54,38 +54,48 @@ describe 'Attachment Registry' do
         greeter: { ciao: 'greeting' }
       }
       foo = Class.new
-      Paperclip::AttachmentRegistry.register(foo, :avatar, { yo: 'greeting' })
-      Paperclip::AttachmentRegistry.register(foo, :greeter, { ciao: 'greeting' })
+      Paperclip::AttachmentRegistry.register(foo,
+                                             :avatar,
+                                             { yo: 'greeting' })
+      Paperclip::AttachmentRegistry.register(foo,
+                                             :greeter,
+                                             { ciao: 'greeting' })
 
       definitions = Paperclip::AttachmentRegistry.definitions_for(foo)
 
       assert_equal expected_definitions, definitions
     end
 
-    it "produces defintions for subclasses" do
+    it 'produces defintions for subclasses' do
       expected_definitions = { avatar: { yo: 'greeting' } }
       foo = Class.new
       bar = Class.new(foo)
-      Paperclip::AttachmentRegistry.register(foo, :avatar, expected_definitions[:avatar])
+      Paperclip::AttachmentRegistry.register(foo,
+                                             :avatar,
+                                             expected_definitions[:avatar])
 
       definitions = Paperclip::AttachmentRegistry.definitions_for(bar)
 
       assert_equal expected_definitions, definitions
     end
 
-    it "produces defintions for subclasses but deep merging them" do
+    it 'produces defintions for subclasses but deep merging them' do
       foo_definitions = { avatar: { yo: 'greeting' } }
       bar_definitions = { avatar: { ciao: 'greeting' } }
       expected_definitions = {
         avatar: {
           yo: 'greeting',
           ciao: 'greeting'
-         }
+        }
       }
       foo = Class.new
       bar = Class.new(foo)
-      Paperclip::AttachmentRegistry.register(foo, :avatar, foo_definitions[:avatar])
-      Paperclip::AttachmentRegistry.register(bar, :avatar, bar_definitions[:avatar])
+      Paperclip::AttachmentRegistry.register(foo,
+                                             :avatar,
+                                             foo_definitions[:avatar])
+      Paperclip::AttachmentRegistry.register(bar,
+                                             :avatar,
+                                             bar_definitions[:avatar])
 
       definitions = Paperclip::AttachmentRegistry.definitions_for(bar)
 
@@ -96,7 +106,9 @@ describe 'Attachment Registry' do
   context '.clear' do
     it 'removes all of the existing attachment definitions' do
       foo = Class.new
-      Paperclip::AttachmentRegistry.register(foo, :greeter, { ciao: 'greeting' })
+      Paperclip::AttachmentRegistry.register(foo,
+                                             :greeter,
+                                             { ciao: 'greeting' })
 
       Paperclip::AttachmentRegistry.clear
 


### PR DESCRIPTION
Instead of just merging them.

This pull request is intended to try to "improve" the feature that was included in the #1331 and also mentioned in #1330 and #1373 in regards to the [attachement_definition](https://github.com/thoughtbot/paperclip/blob/master/lib/paperclip/has_attached_file.rb#L103) method and the call to the [definitions_for] (https://github.com/thoughtbot/paperclip/blob/master/lib/paperclip/attachment_registry.rb#L53) method that merge together the all the ancestors definitions.

#### Why this change? 
Because if there are different definitions for the same attachment name, with the **merge!** method the ancestor ones override the actual ones, I included the test to showcase this.

I make use of the **deep_merge!** method that I know that it's Rails specific, but checking the dependencies of paperclip and reading the [CONTRIBUTING.md](https://github.com/thoughtbot/paperclip/blob/master/CONTRIBUTING.md) (that said _Use Rails idioms and helpers_) file I thought that maybe is better to use a Rails method and write some ruby helper for the deep merging feature, please let me know if you prefer another approach for this.

Thanks and let me know if there is anything that I missed.
