### PR TITLE
Updated the `build missing styles` Capistrano task

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,7 +795,11 @@ namespace :deploy do
   desc "build missing paperclip styles"
   task :build_missing_paperclip_styles do
     on roles(:app) do
-      execute "cd #{current_path}; RAILS_ENV=production bundle exec rake paperclip:refresh:missing_styles"
+      within release_path do
+        with rails_env: fetch(:rails_env) do
+          execute :rake, "paperclip:refresh:missing_styles"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The task (as specified in the current form) did not work for me (on Rails 4.2.0 and Capistrano 3.3.5 with rbenv). I changed the task so that it uses the same standards as Capistrano's own tasks.

This now works for my setup.