### PR TITLE
RubyForge isn't a thing anymore

### DIFF
--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.description       = "Easy upload management for ActiveRecord"
   s.license           = "MIT"
 
-  s.rubyforge_project = "paperclip"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
Remove RubyForge project name from gemspec