### PR TITLE
Allows multiple content types for spoof detector

### DIFF
--- a/lib/paperclip/media_type_spoof_detector.rb
+++ b/lib/paperclip/media_type_spoof_detector.rb
@@ -31,7 +31,7 @@ module Paperclip
     end
 
     def mapping_override_mismatch?
-      mapped_content_type != calculated_content_type
+      ! Array(mapped_content_type).include?(calculated_content_type)
     end
 
     def supplied_file_media_types

--- a/lib/paperclip/media_type_spoof_detector.rb
+++ b/lib/paperclip/media_type_spoof_detector.rb
@@ -31,7 +31,7 @@ module Paperclip
     end
 
     def mapping_override_mismatch?
-      ! Array(mapped_content_type).include?(calculated_content_type)
+      !Array(mapped_content_type).include?(calculated_content_type)
     end
 
     def supplied_file_media_types

--- a/spec/paperclip/media_type_spoof_detector_spec.rb
+++ b/spec/paperclip/media_type_spoof_detector_spec.rb
@@ -43,4 +43,14 @@ describe Paperclip::MediaTypeSpoofDetector do
       Paperclip.options[:content_type_mappings] = {}
     end
   end
+
+  it 'doest allow array as :content_type_mappings' do
+    begin
+      Paperclip.options[:content_type_mappings] = { html: [ "binary", "text/html" ] }
+      file = File.open(fixture_file("empty.html"))
+      assert ! Paperclip::MediaTypeSpoofDetector.using(file, "empty.html").spoofed?
+    ensure
+      Paperclip.options[:content_type_mappings] = {}
+    end
+  end
 end

--- a/spec/paperclip/media_type_spoof_detector_spec.rb
+++ b/spec/paperclip/media_type_spoof_detector_spec.rb
@@ -44,11 +44,14 @@ describe Paperclip::MediaTypeSpoofDetector do
     end
   end
 
-  it 'doest allow array as :content_type_mappings' do
+  it "does allow array as :content_type_mappings" do
     begin
-      Paperclip.options[:content_type_mappings] = { html: [ "binary", "text/html" ] }
+      Paperclip.options[:content_type_mappings] = {
+        html: [ "binary", "text/html" ]
+      }
       file = File.open(fixture_file("empty.html"))
-      assert ! Paperclip::MediaTypeSpoofDetector.using(file, "empty.html").spoofed?
+      assert !Paperclip::MediaTypeSpoofDetector
+        .using(file, "empty.html").spoofed?
     ensure
       Paperclip.options[:content_type_mappings] = {}
     end

--- a/spec/paperclip/media_type_spoof_detector_spec.rb
+++ b/spec/paperclip/media_type_spoof_detector_spec.rb
@@ -47,11 +47,12 @@ describe Paperclip::MediaTypeSpoofDetector do
   it "does allow array as :content_type_mappings" do
     begin
       Paperclip.options[:content_type_mappings] = {
-        html: [ "binary", "text/html" ]
+        html: ["binary", "text/html"]
       }
       file = File.open(fixture_file("empty.html"))
-      assert !Paperclip::MediaTypeSpoofDetector
-        .using(file, "empty.html").spoofed?
+      spoofed = Paperclip::MediaTypeSpoofDetector.
+        using(file, "empty.html").spoofed?
+      assert !spoofed
     ensure
       Paperclip.options[:content_type_mappings] = {}
     end

--- a/spec/paperclip/media_type_spoof_detector_spec.rb
+++ b/spec/paperclip/media_type_spoof_detector_spec.rb
@@ -44,14 +44,14 @@ describe Paperclip::MediaTypeSpoofDetector do
     end
   end
 
-  it "does allow array as :content_type_mappings" do
+  it 'does allow array as :content_type_mappings' do
     begin
       Paperclip.options[:content_type_mappings] = {
-        html: ["binary", "text/html"]
+        html: ['binary', 'text/html']
       }
-      file = File.open(fixture_file("empty.html"))
-      spoofed = Paperclip::MediaTypeSpoofDetector.
-        using(file, "empty.html").spoofed?
+      file = File.open(fixture_file('empty.html'))
+      spoofed = Paperclip::MediaTypeSpoofDetector
+                .using(file, 'empty.html').spoofed?
       assert !spoofed
     ensure
       Paperclip.options[:content_type_mappings] = {}


### PR DESCRIPTION
Hi everybody

I had some issue ( https://github.com/thoughtbot/paperclip/issues/1809 ) with `file` command having different results in different machines.
The solution I found is to allow an array for `content_type_mapping`, like this 

    Paperclip.options[:content_type_mappings][:blend] = [ "application/octet-stream", "binary" ]

I created a new test. All other tests passed.