### PR TITLE
remove useless condition

### DIFF
--- a/lib/paperclip/glue.rb
+++ b/lib/paperclip/glue.rb
@@ -8,7 +8,7 @@ module Paperclip
       base.extend ClassMethods
       base.send :include, Callbacks
       base.send :include, Validators
-      base.send :include, Schema if defined? ActiveRecord
+      base.send :include, Schema
 
       locale_path = Dir.glob(File.dirname(__FILE__) + "/locales/*.{rb,yml}")
       I18n.load_path += locale_path unless I18n.load_path.include?(locale_path)


### PR DESCRIPTION
It's useless because there is the same conditional in https://github.com/thoughtbot/paperclip/blob/master/lib/paperclip/railtie.rb#L25, and if ActiveRecord is not defined, Glue will not run.