### PR TITLE
Remove useless statement

### DIFF
--- a/lib/paperclip/thumbnail.rb
+++ b/lib/paperclip/thumbnail.rb
@@ -29,7 +29,6 @@ module Paperclip
       super
 
       geometry             = options[:geometry].to_s
-      @file                = file
       @crop                = geometry[-1,1] == '#'
       @target_geometry     = options.fetch(:string_geometry_parser, Geometry).parse(geometry)
       @current_geometry    = options.fetch(:file_geometry_parser, Geometry).from_file(@file)


### PR DESCRIPTION
this statement useless, because it's exits in the initialize method of `Thumbnail`'s parent – `Processor`: https://github.com/thoughtbot/paperclip/blob/master/lib/paperclip/processor.rb#L24