### PR TITLE
register active record reflections

### DIFF
--- a/lib/paperclip/has_attached_file.rb
+++ b/lib/paperclip/has_attached_file.rb
@@ -17,6 +17,7 @@ module Paperclip
       define_query
       register_new_attachment
       add_active_record_callbacks
+      add_reflections
       add_paperclip_callbacks
       add_required_validations
     end
@@ -91,6 +92,14 @@ module Paperclip
       @klass.send(:after_save) { send(name).send(:save) }
       @klass.send(:before_destroy) { send(name).send(:queue_all_for_delete) }
       @klass.send(:after_commit, :on => :destroy) { send(name).send(:flush_deletes) }
+    end
+
+    def add_reflections
+      return unless @klass.respond_to?(:_reflections)
+      @klass._reflections.merge!(
+        @name.to_s => ActiveRecord::Reflection::HasOneReflection.new(
+          :photo, nil, { class: @klass.name }, @klass)
+      )
     end
 
     def add_paperclip_callbacks

--- a/spec/paperclip/has_attached_file_spec.rb
+++ b/spec/paperclip/has_attached_file_spec.rb
@@ -49,6 +49,10 @@ describe Paperclip::HasAttachedFile do
     it 'does define a media_type check if told to' do
       assert_adding_attachment('avatar').sets_up_media_type_check_validation
     end
+
+    it 'registers the activerecord reflections' do
+      assert_adding_attachment('avatar').registers_reflections
+    end
   end
 
   private
@@ -123,6 +127,15 @@ describe Paperclip::HasAttachedFile do
       expect(a_class).to have_received(:validates_media_type_spoof_detection)
     end
 
+    def registers_reflections
+      a_class = stub_class
+
+      Paperclip::HasAttachedFile.define_on(a_class,
+        @attachment_name, { validate_media_type: false })
+
+      expect(a_class._reflections.keys.include?(@attachment_name))
+    end
+
     private
 
     def stub_class
@@ -135,7 +148,9 @@ describe Paperclip::HasAttachedFile do
            define_paperclip_callbacks: nil,
            extend: nil,
            name: 'Billy',
-           validates_media_type_spoof_detection: nil
+           validates_media_type_spoof_detection: nil,
+           pluralize_table_names: true,
+           :"_reflections" => {}
           )
     end
   end


### PR DESCRIPTION
when creating associations, active_record registers reflections on the associations... paperclip is creating an association but not registering it as a reflection