### PR TITLE
Fix for Errno::ENAMETOOLONG in Thumbnails

### DIFF
--- a/lib/paperclip/thumbnail.rb
+++ b/lib/paperclip/thumbnail.rb
@@ -63,8 +63,8 @@ module Paperclip
     # that contains the new image.
     def make
       src = @file
-      dst = Tempfile.new([@basename, @format ? ".#{@format}" : ''])
-      dst.binmode
+      filename = [@basename, @format ? ".#{@format}" : ""].join
+      dst = TempfileFactory.new.generate(filename)
 
       begin
         parameters = []

--- a/spec/paperclip/tempfile_factory_spec.rb
+++ b/spec/paperclip/tempfile_factory_spec.rb
@@ -26,4 +26,8 @@ describe Paperclip::TempfileFactory do
    file = subject.generate
    assert File.exist?(file.path)
   end
+
+  it "does not throw Errno::ENAMETOOLONG when it has a really long name" do
+    expect { subject.generate("o" * 255) }.to_not raise_error
+  end
 end

--- a/spec/paperclip/thumbnail_spec.rb
+++ b/spec/paperclip/thumbnail_spec.rb
@@ -481,4 +481,20 @@ describe Paperclip::Thumbnail do
       end
     end
   end
+
+  context "with a really long file name" do
+    before do
+      tempfile = Tempfile.new("f")
+      tempfile_additional_chars = tempfile.path.split("/")[-1].length + 15
+      image_file = File.new(fixture_file("5k.png"), "rb")
+      @file = Tempfile.new("f" * (255 - tempfile_additional_chars))
+      @file.write(image_file.read)
+      @file.rewind
+    end
+
+    it "does not throw Errno::ENAMETOOLONG" do
+      thumb = Paperclip::Thumbnail.new(@file, geometry: "50x50", format: :gif)
+      expect { thumb.make }.to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
* also includes a test for TempfileFactory to be sure it does not revert to similar behavior