### PR TITLE
Adding new option :relative to :url S3 storage

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -157,7 +157,7 @@ module Paperclip
             @s3_server_side_encryption = @options[:s3_server_side_encryption]
           end
 
-          unless @options[:url].to_s.match(/\A:s3.*url\Z/) || @options[:url] == ":asset_host"
+          unless @options[:url].to_s.match(/\A:s3.*url\Z/) || @options[:url] == ":asset_host" || @options[:url] == ":relative"
             @options[:path] = path_option.gsub(/:url/, @options[:url]).gsub(/\A:rails_root\/public\/system/, '')
             @options[:url]  = ":s3_path_url"
           end
@@ -175,6 +175,9 @@ module Paperclip
         Paperclip.interpolates(:s3_domain_url) do |attachment, style|
           "#{attachment.s3_protocol(style, true)}//#{attachment.bucket_name}.#{attachment.s3_host_name}/#{attachment.path(style).gsub(%r{\A/}, "")}"
         end unless Paperclip::Interpolations.respond_to? :s3_domain_url
+        Paperclip.interpolates(:relative) do |attachment, style|
+          "/#{attachment.path(style).gsub(%r{\A/}, "")}"
+        end unless Paperclip::Interpolations.respond_to? :relative
         Paperclip.interpolates(:asset_host) do |attachment, style|
           "#{attachment.path(style).gsub(%r{\A/}, "")}"
         end unless Paperclip::Interpolations.respond_to? :asset_host

--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -176,7 +176,7 @@ module Paperclip
           "#{attachment.s3_protocol(style, true)}//#{attachment.bucket_name}.#{attachment.s3_host_name}/#{attachment.path(style).gsub(%r{\A/}, "")}"
         end unless Paperclip::Interpolations.respond_to? :s3_domain_url
         Paperclip.interpolates(:relative) do |attachment, style|
-          "/#{attachment.path(style).gsub(%r{\A/}, "")}"
+          "/#{attachment.path(style).gsub(%r{\A/}, '')}"
         end unless Paperclip::Interpolations.respond_to? :relative
         Paperclip.interpolates(:asset_host) do |attachment, style|
           "#{attachment.path(style).gsub(%r{\A/}, '')}"

--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -179,7 +179,7 @@ module Paperclip
           "/#{attachment.path(style).gsub(%r{\A/}, "")}"
         end unless Paperclip::Interpolations.respond_to? :relative
         Paperclip.interpolates(:asset_host) do |attachment, style|
-          "#{attachment.path(style).gsub(%r{\A/}, "")}"
+          "#{attachment.path(style).gsub(%r{\A/}, '')}"
         end unless Paperclip::Interpolations.respond_to? :asset_host
       end
 

--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -176,10 +176,10 @@ module Paperclip
           "#{attachment.s3_protocol(style, true)}//#{attachment.bucket_name}.#{attachment.s3_host_name}/#{attachment.path(style).gsub(%r{\A/}, "")}"
         end unless Paperclip::Interpolations.respond_to? :s3_domain_url
         Paperclip.interpolates(:relative) do |attachment, style|
-          "/#{attachment.path(style).gsub(%r{\A/}, '')}"
+          "/#{attachment.path(style).gsub(%r{\A/}, "")}"
         end unless Paperclip::Interpolations.respond_to? :relative
         Paperclip.interpolates(:asset_host) do |attachment, style|
-          "#{attachment.path(style).gsub(%r{\A/}, '')}"
+          "#{attachment.path(style).gsub(%r{\A/}, "")}"
         end unless Paperclip::Interpolations.respond_to? :asset_host
       end
 

--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -176,10 +176,10 @@ module Paperclip
           "#{attachment.s3_protocol(style, true)}//#{attachment.bucket_name}.#{attachment.s3_host_name}/#{attachment.path(style).gsub(%r{\A/}, "")}"
         end unless Paperclip::Interpolations.respond_to? :s3_domain_url
         Paperclip.interpolates(:relative) do |attachment, style|
-          "/#{attachment.path(style).gsub(%r{\A/}, "")}"
+          "/#{attachment.path(style).gsub(%r{\A/}, '')}"
         end unless Paperclip::Interpolations.respond_to? :relative
         Paperclip.interpolates(:asset_host) do |attachment, style|
-          "#{attachment.path(style).gsub(%r{\A/}, "")}"
+          "#{attachment.path(style).gsub(%r{\A/}, '')}"
         end unless Paperclip::Interpolations.respond_to? :asset_host
       end
 

--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -477,6 +477,23 @@ describe Paperclip::Storage::S3 do
 
   end
 
+  context "generating a url with url set to :relative" do
+    before do
+      rebuild_model storage: :s3,
+        s3_credentials: {},
+        bucket: "bucket",
+        path: ":attachment/:basename:dotextension",
+        url: ":relative"
+      @dummy = Dummy.new
+      @dummy.avatar = stringy_file
+    end
+
+    it "returns a relative URL for Rails to calculate assets host BUT without assets pipeline" do
+      assert_match %r{\/avatars/data[^\.]}, @dummy.avatar.url
+    end
+
+  end
+
   context "Generating a secure url with an expiration" do
     before do
       @build_model_with_options = lambda {|options|

--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -480,18 +480,17 @@ describe Paperclip::Storage::S3 do
   context "generating a url with url set to :relative" do
     before do
       rebuild_model storage: :s3,
-        s3_credentials: {},
-        bucket: "bucket",
-        path: ":attachment/:basename:dotextension",
-        url: ":relative"
+                    s3_credentials: {},
+                    bucket: "bucket",
+                    path: ":attachment/:basename:dotextension",
+                    url: ":relative"
       @dummy = Dummy.new
       @dummy.avatar = stringy_file
     end
 
-    it "returns a relative URL for Rails to calculate assets host BUT without assets pipeline" do
+    it "returns a relative URL for assets host without using assets pipeline" do
       assert_match %r{\/avatars/data[^\.]}, @dummy.avatar.url
     end
-
   end
 
   context "Generating a secure url with an expiration" do

--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -480,10 +480,10 @@ describe Paperclip::Storage::S3 do
   context "generating a url with url set to :relative" do
     before do
       rebuild_model storage: :s3,
-                    s3_credentials: {},
-                    bucket: "bucket",
-                    path: ":attachment/:basename:dotextension",
-                    url: ":relative"
+        s3_credentials: {},
+        bucket: "bucket",
+        path: ":attachment/:basename:dotextension",
+        url: ":relative"
       @dummy = Dummy.new
       @dummy.avatar = stringy_file
     end


### PR DESCRIPTION
I'm following this issue #1829 

**Usecase:**
I want to still rely on ActionController::Base.asset_host to manage my absolute URL but the current option _:asset_host_ append rails asset pipeline path (/assets) which is not valid in this scenario.

Thanks.
