### PR TITLE
Use Updated Version of `aws-sdk` in Docs [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ You may also choose to store your files using Amazon's S3 service. To do so, inc
 the `aws-sdk` gem in your Gemfile:
 
 ```ruby
-gem 'aws-sdk', '~> 1.5.7'
+gem 'aws-sdk', '~> 1.6'
 ```
 
 And then you can specify using S3 from `has_attached_file`.

--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -4,7 +4,7 @@ module Paperclip
     # distribution. You can find out more about it at http://aws.amazon.com/s3
     #
     # To use Paperclip with S3, include the +aws-sdk+ gem in your Gemfile:
-    #   gem 'aws-sdk'
+    #   gem 'aws-sdk', '~> 1.6'
     # There are a few S3-specific options for has_attached_file:
     # * +s3_credentials+: Takes a path, a File, a Hash or a Proc. The path (or File) must point
     #   to a YAML file containing the +access_key_id+ and +secret_access_key+ that Amazon


### PR DESCRIPTION
The `aws-sdk` development dependency was updated to `~> 1.6` in #1816
to resolve issues with the creation of 0-byte files on S3 (see #1729).
However, there is no runtime dependency on `aws-sdk`, and the
documentation still suggests that users install an earlier version of
`aws-sdk` that produces the problems in the referenced issue.

This commit updates the docs to recommend the use of `aws-sdk` `~> 1.6`
with Paperclip.