### PR TITLE
allow overriding of io adapters

### DIFF
--- a/lib/paperclip/io_adapters/registry.rb
+++ b/lib/paperclip/io_adapters/registry.rb
@@ -9,7 +9,7 @@ module Paperclip
     end
 
     def register(handler_class, &block)
-      @registered_handlers << [block, handler_class]
+      @registered_handlers.unshift([block, handler_class])
     end
 
     def handler_for(target)

--- a/spec/paperclip/io_adapters/registry_spec.rb
+++ b/spec/paperclip/io_adapters/registry_spec.rb
@@ -15,6 +15,19 @@ describe Paperclip::AttachmentRegistry do
     end
   end
 
+  context "register" do
+    it "allows overriding" do
+      class OriginalAdapter; def initialize(_);end; end
+      class NewAdapter; def initialize(_);end; end
+
+      @subject = Paperclip::AdapterRegistry.new
+      @subject.register(OriginalAdapter) { |_| t == "string" }
+      @subject.register(NewAdapter) { |_| t == "string" }
+
+      assert_equal NewAdapter, @subject.handler_for("string")
+    end
+  end
+
   context "registered?" do
     before do
       class AdapterTest


### PR DESCRIPTION
when registering io adpaters, put them in the beginning of the array.
this will allow you to override existing adapters if needed.
