### PR TITLE
allow sublcasses to override definitions

### DIFF
--- a/lib/paperclip/attachment_registry.rb
+++ b/lib/paperclip/attachment_registry.rb
@@ -51,7 +51,7 @@ module Paperclip
     end
 
     def definitions_for(klass)
-      klass.ancestors.each_with_object({}) do |ancestor, inherited_definitions|
+      klass.ancestors.reverse.each_with_object({}) do |ancestor, inherited_definitions|
         inherited_definitions.deep_merge! @attachments[ancestor]
       end
     end

--- a/lib/paperclip/attachment_registry.rb
+++ b/lib/paperclip/attachment_registry.rb
@@ -51,7 +51,8 @@ module Paperclip
     end
 
     def definitions_for(klass)
-      klass.ancestors.reverse.each_with_object({}) do |ancestor, inherited_definitions|
+      parent_classes = klass.ancestors.reverse
+      parent_classes.each_with_object({}) do |ancestor, inherited_definitions|
         inherited_definitions.deep_merge! @attachments[ancestor]
       end
     end

--- a/spec/paperclip/attachment_registry_spec.rb
+++ b/spec/paperclip/attachment_registry_spec.rb
@@ -111,6 +111,34 @@ describe 'Attachment Registry' do
 
       assert_equal expected_definitions, definitions
     end
+
+    it 'allows subclasses to override attachment defitions' do
+      foo_definitions = { avatar: { yo: "greeting" } }
+      bar_definitions = { avatar: { yo: "hello" } }
+
+      expected_definitions = {
+        avatar: {
+          yo: "hello"
+        }
+      }
+
+      foo = Class.new
+      bar = Class.new(foo)
+      Paperclip::AttachmentRegistry.register(
+        foo,
+        :avatar,
+        foo_definitions[:avatar]
+      )
+      Paperclip::AttachmentRegistry.register(
+        bar,
+        :avatar,
+        bar_definitions[:avatar]
+      )
+
+      definitions = Paperclip::AttachmentRegistry.definitions_for(bar)
+
+      assert_equal expected_definitions, definitions
+    end
   end
 
   context '.clear' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'active_support/core_ext'
 require 'mocha/api'
 require 'bourne'
 require 'ostruct'
+require 'pathname'
 
 ROOT = Pathname(File.expand_path(File.join(File.dirname(__FILE__), '..')))
 


### PR DESCRIPTION
It seems like when redefining attachment definitions in STI classes, only the styles from the parent class are being picked up. 

```rb
class Photo < ActiveRecord::Base
  has_attached_file :data, styles: { small: "70x70#" }
# ...


class UserPhoto < Photo
  has_attachment_file :data, styles: { small: "100x100>" }
# ...
```

Expectation:

```rb
UserPhoto.attachment_definitions[:data][:styles] == { small: "100x100>" }
```

Reality: 

```rb
UserPhoto.attachment_definitions[:data][:styles] == { small:  "70x70#" }
```

That seems like a strange behavior, and it definitely didn't do that in earlier versions of paperclip (like 3.4.0, where we're upgrading from).

This PR addresses this issue, let us know what you think.

cc-ing @mgerrior who found and fixed the issue