### PR TITLE
Added pre_convert_options to the thumbnail processor

### DIFF
--- a/lib/paperclip/thumbnail.rb
+++ b/lib/paperclip/thumbnail.rb
@@ -2,8 +2,9 @@ module Paperclip
   # Handles thumbnailing images that are uploaded.
   class Thumbnail < Processor
 
-    attr_accessor :current_geometry, :target_geometry, :format, :whiny, :convert_options,
-                  :source_file_options, :animated, :auto_orient, :pre_convert_options
+    attr_accessor :current_geometry, :target_geometry, :format, :whiny,
+                  :convert_options, :source_file_options, :animated,
+                  :auto_orient, :pre_convert_options
 
     # List of formats that we need to preserve animation
     ANIMATED_FORMATS = %w(gif)

--- a/lib/paperclip/thumbnail.rb
+++ b/lib/paperclip/thumbnail.rb
@@ -3,7 +3,7 @@ module Paperclip
   class Thumbnail < Processor
 
     attr_accessor :current_geometry, :target_geometry, :format, :whiny, :convert_options,
-                  :source_file_options, :animated, :auto_orient
+                  :source_file_options, :animated, :auto_orient, :pre_convert_options
 
     # List of formats that we need to preserve animation
     ANIMATED_FORMATS = %w(gif)
@@ -70,6 +70,7 @@ module Paperclip
         parameters = []
         parameters << source_file_options
         parameters << ":source"
+        parameters << pre_convert_options
         parameters << transformation_command
         parameters << convert_options
         parameters << ":dest"

--- a/lib/paperclip/thumbnail.rb
+++ b/lib/paperclip/thumbnail.rb
@@ -2,9 +2,9 @@ module Paperclip
   # Handles thumbnailing images that are uploaded.
   class Thumbnail < Processor
 
-    attr_accessor :current_geometry, :target_geometry, :format, :whiny,
-                  :convert_options, :source_file_options, :animated,
-                  :auto_orient, :pre_convert_options
+    attr_accessor :animated, :auto_orient, :convert_options, :current_geometry,
+                  :format, :pre_convert_options, :source_file_options,
+                  :target_geometry, :whiny
 
     # List of formats that we need to preserve animation
     ANIMATED_FORMATS = %w(gif)


### PR DESCRIPTION
This will allow developers to add options before transformations. For example, it's necessary to resample an image before resizing it.

See https://github.com/thoughtbot/paperclip/issues/1864
Also, see https://github.com/thoughtbot/paperclip/issues/179 and https://github.com/thoughtbot/paperclip/issues/1085