### PR TITLE
Add single and double quotes to restricted characters for an attachment

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -14,7 +14,7 @@ module Paperclip
         :default_style         => :original,
         :default_url           => "/:attachment/:style/missing.png",
         :escape_url            => true,
-        :restricted_characters => /[&$+,\/:;=?@<>\[\]\{\}\|\\\^~%# ]/,
+        :restricted_characters => /[&$+,\/:;=?@<>\[\]\{\}\|\\\^~%#'" ]/,
         :filename_cleaner      => nil,
         :hash_data             => ":class/:attachment/:id/:style/:updated_at",
         :hash_digest           => "SHA1",


### PR DESCRIPTION
Single and doubles quotes in the attachment file name can lead to issues when the url of the attachment is in a single or double quotes string.