### PR TITLE
Use scheme for fog expiring url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We love pull requests. Here's a quick guide:
 1. Fork the repo.
 
 2. Run the tests. We only take pull requests with passing tests, and it's great
-to know that you have a clean slate: `bundle && rake`
+to know that you have a clean slate: `bundle && bundle exec rake`
 
 3. Add a test for your change. Only refactoring and documentation changes
 require no new tests. If you are adding functionality or fixing a bug, we need

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ task :all do |t|
   if ENV['BUNDLE_GEMFILE']
     exec('rake spec cucumber')
   else
-    exec("rm gemfiles/*.lock")
+    exec("rm -f gemfiles/*.lock")
     Rake::Task["appraisal:gemfiles"].execute
     Rake::Task["appraisal:install"].execute
     exec('rake appraisal')

--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -141,8 +141,9 @@ module Paperclip
 
       def expiring_url(time = (Time.now + 3600), style_name = default_style)
         time = convert_time(time)
-        if path(style_name) && directory.files.respond_to?(:get_http_url)
-          expiring_url = directory.files.get_http_url(path(style_name), time)
+        http_url_method = "get_#{scheme}_url"
+        if path(style_name) && directory.files.respond_to?(http_url_method)
+          expiring_url = directory.files.public_send(http_url_method, path(style_name), time)
 
           if @options[:fog_host]
             expiring_url.gsub!(/#{host_name_for_directory}/, dynamic_fog_host_for_style(style_name))

--- a/spec/paperclip/storage/fog_spec.rb
+++ b/spec/paperclip/storage/fog_spec.rb
@@ -320,6 +320,9 @@ describe Paperclip::Storage::Fog do
         it "honors the scheme in public url" do
           assert_match(/^http:\/\//, @dummy.avatar.url)
         end
+        it "honors the scheme in expiring url" do
+          assert_match(/^http:\/\//, @dummy.avatar.expiring_url)
+        end
       end
 
       context "with scheme not set" do
@@ -334,6 +337,9 @@ describe Paperclip::Storage::Fog do
         it "provides HTTPS public url" do
           assert_match(/^https:\/\//, @dummy.avatar.url)
         end
+        it "provides HTTPS expiring url" do
+          assert_match(/^https:\/\//, @dummy.avatar.expiring_url)
+        end
       end
 
       context "with a valid bucket name for a subdomain" do
@@ -344,7 +350,7 @@ describe Paperclip::Storage::Fog do
         end
 
         it "provides an url that expires in subdomain style" do
-          assert_match(/^http:\/\/papercliptests.s3.amazonaws.com\/avatars\/5k.png.+Expires=.+$/, @dummy.avatar.expiring_url)
+          assert_match(/^https:\/\/papercliptests.s3.amazonaws.com\/avatars\/5k.png.+Expires=.+$/, @dummy.avatar.expiring_url)
         end
       end
 
@@ -392,7 +398,7 @@ describe Paperclip::Storage::Fog do
         end
 
         it "provides a url that expires in folder style" do
-          assert_match(/^http:\/\/s3.amazonaws.com\/this_is_invalid\/avatars\/5k.png.+Expires=.+$/, @dummy.avatar.expiring_url)
+          assert_match(/^https:\/\/s3.amazonaws.com\/this_is_invalid\/avatars\/5k.png.+Expires=.+$/, @dummy.avatar.expiring_url)
         end
 
       end


### PR DESCRIPTION
Honor the configured scheme for fog expiring URLs. In order to be consistent with public URLs, this also changes the default behavior for expiring URLs to use the https scheme rather than http.

Also included are a couple of minor changes due to issues I noticed trying to get the test suite running.