### PR TITLE
V4.2.2 fix spoof detector

### DIFF
--- a/lib/paperclip/media_type_spoof_detector.rb
+++ b/lib/paperclip/media_type_spoof_detector.rb
@@ -12,7 +12,7 @@ module Paperclip
 
     def spoofed?
       if has_name? && has_extension? && media_type_mismatch? && mapping_override_mismatch?
-        Paperclip.log("Content Type Spoof: Filename #{File.basename(@name)} (#{supplied_content_type} from Headers, #{content_types_from_name} from Extension), content type discovered from file command: #{calculated_content_type}. See documentation to allow this combination.")
+        Paperclip.log("Content Type Spoof: Filename #{File.basename(@name)} (#{supplied_content_type} from Headers, #{content_types_from_name} from Extension), content type discovered from file command: #{calculated_content_types.join(', ')}. See documentation to allow this combination.")
         true
       else
         false

--- a/lib/paperclip/media_type_spoof_detector.rb
+++ b/lib/paperclip/media_type_spoof_detector.rb
@@ -62,19 +62,21 @@ module Paperclip
       @media_types_from_name ||= content_types_from_name.collect(&:media_type)
     end
 
-    def calculated_content_type
-      @calculated_content_type ||= type_from_file_command.chomp
+    def calculated_content_types
+      @calculated_content_types ||= types_from_file_command.collect{|t| t.chomp}.uniq
     end
 
     def calculated_media_type
       @calculated_media_type ||= calculated_content_type.split("/").first
     end
 
-    def type_from_file_command
+    def types_from_file_command
       begin
-        Paperclip.run("file", "-b --mime :file", :file => @file.path).split(/[:;]\s+/).first
+        first = Paperclip.run("file", "-b --mime :file", :file => @file.path).split(/[:;]\s+/).first
+        second = Paperclip.run("file", "-b --mime -k :file", :file => @file.path).split(/[:;]\s+/).first
+        return [first, second]
       rescue Cocaine::CommandLineError
-        ""
+        []
       end
     end
 

--- a/lib/paperclip/media_type_spoof_detector.rb
+++ b/lib/paperclip/media_type_spoof_detector.rb
@@ -38,11 +38,11 @@ module Paperclip
     end
 
     def calculated_type_mismatch?
-      !media_types_from_name.include?(calculated_media_type)
+      media_types_from_name.none? {|media_type| calculated_media_types.include? media_type}
     end
 
     def mapping_override_mismatch?
-      mapped_content_type != calculated_content_type
+      !calculated_content_types.include? mapped_content_type
     end
 
 
@@ -66,8 +66,8 @@ module Paperclip
       @calculated_content_types ||= types_from_file_command.collect{|t| t.chomp}.uniq
     end
 
-    def calculated_media_type
-      @calculated_media_type ||= calculated_content_type.split("/").first
+    def calculated_media_types
+      @calculated_media_types ||= calculated_content_types.collect{|t| t.split("/").first}.uniq
     end
 
     def types_from_file_command


### PR DESCRIPTION
Instead of assuming that the file command will always return exactly one mime type, this can handle 2 results if file returns them. It will still break when file finds 3+ mime type matches because file will not return the 3rd or following mime types (due to a big in libmagic). Still, this should greatly reduce the likelyhood for issue #1696 
