### PR TITLE
If Rails is defined but Rails::Railtie is not, don't try to load the Railtie

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -69,7 +69,7 @@ require 'mimemagic/overlay'
 require 'logger'
 require 'cocaine'
 
-require 'paperclip/railtie' if defined?(Rails)
+require 'paperclip/railtie' if defined?(Rails::Railtie)
 
 # The base module that gets included in ActiveRecord::Base. See the
 # documentation for Paperclip::ClassMethods for more useful information.


### PR DESCRIPTION
See https://github.com/rails/rails/pull/18196 and https://github.com/rails/rails-html-sanitizer/issues/26 for a discussion of why this is necessary.

Not sure why this is failing on travis but it doesn't look like it's because of this change.