### PR TITLE
Regression fix: original file could be unlinked in post_process_style

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -522,7 +522,7 @@ module Paperclip
 
         @queued_for_write[name] = style.processors.inject(@queued_for_write[:original]) do |file, processor|
           file = Paperclip.processor(processor).make(file, style.processor_options, self)
-          intermediate_files << file
+          intermediate_files << file unless file == @queued_for_write[:original]
           file
         end
 

--- a/spec/paperclip/attachment_spec.rb
+++ b/spec/paperclip/attachment_spec.rb
@@ -699,9 +699,6 @@ describe Paperclip::Attachment do
 
     context "when assigned" do
       it "calls #make on all specified processors" do
-        Paperclip::Thumbnail.stubs(:make).with(any_parameters).returns(@file)
-        Paperclip::Test.stubs(:make).with(any_parameters).returns(@file)
-
         @dummy.avatar = @file
 
         expect(Paperclip::Thumbnail).to have_received(:make)
@@ -716,7 +713,6 @@ describe Paperclip::Attachment do
           convert_options: "",
           source_file_options: ""
         })
-        Paperclip::Thumbnail.stubs(:make).returns(@file)
 
         @dummy.avatar = @file
 
@@ -724,11 +720,35 @@ describe Paperclip::Attachment do
       end
 
       it "calls #make with attachment passed as third argument" do
-        Paperclip::Test.expects(:make).returns(@file)
-
         @dummy.avatar = @file
 
         expect(Paperclip::Test).to have_received(:make).with(anything, anything, @dummy.avatar)
+      end
+
+      it "calls #make and unlinks intermediary files afterward" do
+        @dummy.avatar.expects(:unlink_files).with([@file, @file])
+
+        @dummy.avatar = @file
+      end
+    end
+  end
+
+  context "An attachment with a processor that returns original file" do
+    before do
+      class Paperclip::Test < Paperclip::Processor
+        def make; @file; end
+      end
+      rebuild_model processors: [:test], styles: { once: "100x100" }
+      @file = StringIO.new("...")
+      @file.stubs(:close)
+      @dummy = Dummy.new
+    end
+
+    context "when assigned" do
+      it "#calls #make and doesn't unlink the original file" do
+        @dummy.avatar.expects(:unlink_files).with([])
+
+        @dummy.avatar = @file
       end
     end
   end


### PR DESCRIPTION
https://github.com/thoughtbot/paperclip/commit/87cebf991ac49bb3f655e1e7d834c203217583dd added an `intermediate_files` local var in `Paperclip::Attachment#post_process_style` to collect temp files and then ensure they get unlinked at the end of `post_process_style()`.

But in this scenario [when a processor just returns `@file`]:

``` ruby
class Paperclip::Foo
  def make
    # ... do something with the file ...
    @file
  end
end

has_attached_file :image, {
  processors: [:foo],
  styles: {
    full: "200x200",
    thumb: "100x100"
  }
}
```

1) `post_process_style` is run for the `:full` style 
  * `Paperclip::Foo.make` is run on `:full`
  * the original file (aka `queued_for_write[:original]`) gets added to `intermediate_files`
  * when finished, files in `intermediate_files` are unlinked, including the original file

2) `post_process_style` is run for the `:thumb` style
  * `Paperclip::Foo.make` is run on `:thumb`  :bomb: :boom: `make` fails because the original file that was passed to it has been unlinked

NB I tried to write a spec for this, but it proved a little difficult. Hopefully this change makes enough sense when seen?

Thanks :sunrise: 
