### PR TITLE
Fix a nil error in failure_message of content type validation matcher

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ master:
 
 * README adjustments for Ruby beginners (add links, elucidate model in Quick Start)
 * Bugfix: Now it's possible to save images from URLs with special characters [#1932]
+* Fix a nil error in content type validation matcher [#1910]
 
 5.0.0.beta2 (2015-04-01):
 

--- a/lib/paperclip/matchers/validate_attachment_content_type_matcher.rb
+++ b/lib/paperclip/matchers/validate_attachment_content_type_matcher.rb
@@ -40,9 +40,9 @@ module Paperclip
 
         def failure_message
           "#{expected_attachment}\n".tap do |message|
-            message << accepted_types_and_failures
+            message << accepted_types_and_failures.to_s
             message << "\n\n" if @allowed_types.present? && @rejected_types.present?
-            message << rejected_types_and_failures
+            message << rejected_types_and_failures.to_s
           end
         end
 
@@ -55,7 +55,7 @@ module Paperclip
         def accepted_types_and_failures
           if @allowed_types.present?
             "Accept content types: #{@allowed_types.join(", ")}\n".tap do |message|
-              if @missing_allowed_types.any?
+              if @missing_allowed_types.present?
                 message << "  #{@missing_allowed_types.join(", ")} were rejected."
               else
                 message << "  All were accepted successfully."
@@ -66,7 +66,7 @@ module Paperclip
         def rejected_types_and_failures
           if @rejected_types.present?
             "Reject content types: #{@rejected_types.join(", ")}\n".tap do |message|
-              if @missing_rejected_types.any?
+              if @missing_rejected_types.present?
                 message << "  #{@missing_rejected_types.join(", ")} were accepted."
               else
                 message << "  All were rejected successfully."

--- a/spec/paperclip/matchers/validate_attachment_content_type_matcher_spec.rb
+++ b/spec/paperclip/matchers/validate_attachment_content_type_matcher_spec.rb
@@ -17,22 +17,26 @@ describe Paperclip::Shoulda::Matchers::ValidateAttachmentContentTypeMatcher do
 
   it "rejects a class with no validation" do
     expect(matcher).to_not accept(Dummy)
+    expect { matcher.failure_message }.to_not raise_error
   end
 
   it 'rejects a class when the validation fails' do
     Dummy.validates_attachment_content_type :avatar, content_type: %r{audio/.*}
     expect(matcher).to_not accept(Dummy)
+    expect { matcher.failure_message }.to_not raise_error
   end
 
   it "accepts a class with a matching validation" do
     Dummy.validates_attachment_content_type :avatar, content_type: %r{image/.*}
     expect(matcher).to accept(Dummy)
+    expect { matcher.failure_message }.to_not raise_error
   end
 
   it "accepts a class with other validations but matching types" do
     Dummy.validates_presence_of :title
     Dummy.validates_attachment_content_type :avatar, content_type: %r{image/.*}
     expect(matcher).to accept(Dummy)
+    expect { matcher.failure_message }.to_not raise_error
   end
 
   it "accepts a class that matches and a matcher that only specifies 'allowing'" do
@@ -40,6 +44,7 @@ describe Paperclip::Shoulda::Matchers::ValidateAttachmentContentTypeMatcher do
     matcher = plain_matcher.allowing(%w(image/png image/jpeg))
 
     expect(matcher).to accept(Dummy)
+    expect { matcher.failure_message }.to_not raise_error
   end
 
   it "rejects a class that does not match and a matcher that only specifies 'allowing'" do
@@ -47,6 +52,7 @@ describe Paperclip::Shoulda::Matchers::ValidateAttachmentContentTypeMatcher do
     matcher = plain_matcher.allowing(%w(image/png image/jpeg))
 
     expect(matcher).to_not accept(Dummy)
+    expect { matcher.failure_message }.to_not raise_error
   end
 
   it "accepts a class that matches and a matcher that only specifies 'rejecting'" do
@@ -54,6 +60,7 @@ describe Paperclip::Shoulda::Matchers::ValidateAttachmentContentTypeMatcher do
     matcher = plain_matcher.rejecting(%w(audio/mp3 application/octet-stream))
 
     expect(matcher).to accept(Dummy)
+    expect { matcher.failure_message }.to_not raise_error
   end
 
   it "rejects a class that does not match and a matcher that only specifies 'rejecting'" do
@@ -61,6 +68,7 @@ describe Paperclip::Shoulda::Matchers::ValidateAttachmentContentTypeMatcher do
     matcher = plain_matcher.rejecting(%w(audio/mp3 application/octet-stream))
 
     expect(matcher).to_not accept(Dummy)
+    expect { matcher.failure_message }.to_not raise_error
   end
 
   context "using an :if to control the validation" do
@@ -75,12 +83,14 @@ describe Paperclip::Shoulda::Matchers::ValidateAttachmentContentTypeMatcher do
       dummy = Dummy.new
       dummy.go = true
       expect(matcher).to accept(dummy)
+      expect { matcher.failure_message }.to_not raise_error
     end
 
     it "does not run the validation if the control is false" do
       dummy = Dummy.new
       dummy.go = false
       expect(matcher).to_not accept(dummy)
+      expect { matcher.failure_message }.to_not raise_error
     end
   end
 


### PR DESCRIPTION
When a matcher uses both `allowing` and `rejecting`, and validation fails, `@missing_rejected_types` might still be `nil`. The validation itself works as intended, but calling `failure_message` raises due to `@missing_rejected_types.any?`.

Presumably, this fixes #1334. Possibly also #1476.

---

I haven't added any tests for this fix yet. Any suggestions on what tests we would want? The minimal case would be:
```
expect{ matcher.failure_message }.not_to raise_error
```
But that feels dumb. On the other hand, testing the failure message string for some specific pattern feels like overkill. Ideas?