### PR TITLE
add override_path_permissions option

### DIFF
--- a/lib/paperclip/storage/filesystem.rb
+++ b/lib/paperclip/storage/filesystem.rb
@@ -35,7 +35,21 @@ module Paperclip
 
       def flush_writes #:nodoc:
         @queued_for_write.each do |style_name, file|
+          unless @options[:override_path_permissions] == false
+            dir  = File.dirname(path(style_name))
+            dirs = []
+            while not Dir.exists? dir
+              dirs << dir
+              dir = File.dirname(dir)
+            end
+          end
           FileUtils.mkdir_p(File.dirname(path(style_name)))
+          unless @options[:override_path_permissions] == false
+            resolved_chmod = @options[:override_path_permissions] || (0777 &~ File.umask)
+            dirs.each do |d|
+              FileUtils.chmod( resolved_chmod, d )
+            end
+          end
           begin
             FileUtils.mv(file.path, path(style_name))
           rescue SystemCallError


### PR DESCRIPTION
There's an `override_file_permissions` option to change the permissions of the file created, but not option to set the permissions of the path that is created. This prevents, for example, from a process running under a different user from deleting the file.

Used chmod only on newly created directories for similar functionality to override_file_permissions ( as opposed to the mode option in mkdir_p, which can not override the umask ).

Could potentially refactor to use the mode option but behaviour would vary depending on the active umask, which may not be desirable.

As a sidenote: tests will not pass on a shared directory within a VM due to inability to set permissions on directories.

[fixes #1865]
