### PR TITLE
[ci skip] Add Ubuntu install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ If you are dealing with pdf uploads or running the test suite, you'll also need
 to install GhostScript. On Mac OS X, you can also install that using Homebrew:
 
     brew install gs
+    
+If you're on Ubuntu, you'll want to run the following with apt-get:
+
+    sudo apt-get install imagemagick -y
 
 ### `file`
 


### PR DESCRIPTION
ImageMagick has a Ubuntu Launchpad package available to install and ready to use. This will help Ubuntu users to find the correct version of ImageMagick right of the box. :+1: 