### PR TITLE
Saving images from url with special characters #1921

### DIFF
--- a/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
+++ b/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
@@ -4,7 +4,7 @@ module Paperclip
     REGEXP = /\Ahttps?:\/\//
 
     def initialize(target)
-      super(URI(target))
+      super(URI(URI.escape(target)))
     end
 
   end

--- a/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
@@ -99,7 +99,7 @@ describe Paperclip::HttpUrlProxyAdapter do
   end
 
   context "a url with special characters in the filename" do
-    it "returns a file name" do
+    it "returns a encoded filename" do
       Paperclip::HttpUrlProxyAdapter.any_instance.stubs(:download_content).
         returns(StringIO.new("x"))
       url = "https://github.com/thoughtbot/paperclip-öäü字´½♥Ø²È.png"

--- a/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
@@ -98,4 +98,15 @@ describe Paperclip::HttpUrlProxyAdapter do
     end
   end
 
+  context "a url with special characters in the filename" do
+    before do
+      Paperclip::HttpUrlProxyAdapter.any_instance.stubs(:download_content).returns(StringIO.new("x"))
+      @url = "https://github.com/thoughtbot/paperclip-öäü字´½♥Ø²È.png"
+      @subject = Paperclip.io_adapters.for(@url)
+    end
+
+    it "returns a file name" do
+      assert_equal "paperclip-%C3%B6%C3%A4%C3%BC%E5%AD%97%C2%B4%C2%BD%E2%99%A5%C3%98%C2%B2%C3%88.png", @subject.original_filename
+    end
+  end
 end

--- a/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
@@ -101,11 +101,11 @@ describe Paperclip::HttpUrlProxyAdapter do
   context "a url with special characters in the filename" do
     it "returns a file name" do
       Paperclip::HttpUrlProxyAdapter.any_instance.stubs(:download_content).
-          returns(StringIO.new("x"))
+        returns(StringIO.new("x"))
       url = "https://github.com/thoughtbot/paperclip-öäü字´½♥Ø²È.png"
       subject = Paperclip.io_adapters.for(url)
-      filename = 'paperclip-%C3%B6%C3%A4%C3%BC%E5%AD%97%C2%B4%C2%BD%E2%99%A5'\
-                 '%C3%98%C2%B2%C3%88.png'
+      filename = "paperclip-%C3%B6%C3%A4%C3%BC%E5%AD%97%C2%B4%C2%BD%E2%99%A5"\
+        "%C3%98%C2%B2%C3%88.png"
 
       assert_equal filename, subject.original_filename
     end

--- a/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
@@ -99,14 +99,15 @@ describe Paperclip::HttpUrlProxyAdapter do
   end
 
   context "a url with special characters in the filename" do
-    before do
-      Paperclip::HttpUrlProxyAdapter.any_instance.stubs(:download_content).returns(StringIO.new("x"))
-      @url = "https://github.com/thoughtbot/paperclip-öäü字´½♥Ø²È.png"
-      @subject = Paperclip.io_adapters.for(@url)
-    end
-
     it "returns a file name" do
-      assert_equal "paperclip-%C3%B6%C3%A4%C3%BC%E5%AD%97%C2%B4%C2%BD%E2%99%A5%C3%98%C2%B2%C3%88.png", @subject.original_filename
+      Paperclip::HttpUrlProxyAdapter.any_instance.stubs(:download_content).
+          returns(StringIO.new("x"))
+      url = "https://github.com/thoughtbot/paperclip-öäü字´½♥Ø²È.png"
+      subject = Paperclip.io_adapters.for(url)
+      filename = 'paperclip-%C3%B6%C3%A4%C3%BC%E5%AD%97%C2%B4%C2%BD%E2%99%A5'\
+                 '%C3%98%C2%B2%C3%88.png'
+
+      assert_equal filename, subject.original_filename
     end
   end
 end


### PR DESCRIPTION
#1921 Now it is possible to save images from url with special characters like http://www.foo/öäü.jpg 