### PR TITLE
Interpolate URLs using a string rather than a regex

### DIFF
--- a/lib/paperclip/interpolations.rb
+++ b/lib/paperclip/interpolations.rb
@@ -30,7 +30,7 @@ module Paperclip
     def self.interpolate pattern, *args
       pattern = args.first.instance.send(pattern) if pattern.kind_of? Symbol
       all.reverse.inject(pattern) do |result, tag|
-        result.gsub(/:#{tag}/) do |match|
+        result.gsub(":#{tag}") do |match|
           send( tag, *args )
         end
       end

--- a/spec/paperclip/interpolations_spec.rb
+++ b/spec/paperclip/interpolations_spec.rb
@@ -249,4 +249,13 @@ describe Paperclip::Interpolations do
     value = Paperclip::Interpolations.interpolate(":notreal/:id/:attachment", :attachment, :style)
     assert_equal ":notreal/1234/attachments", value
   end
+
+  it "handles question marks" do
+    Paperclip.interpolates :foo? do
+      "bar"
+    end
+    Paperclip::Interpolations.expects(:fool).never
+    value = Paperclip::Interpolations.interpolate(":fo/:foo?")
+    assert_equal ":fo/bar", value
+  end
 end

--- a/spec/paperclip/interpolations_spec.rb
+++ b/spec/paperclip/interpolations_spec.rb
@@ -204,7 +204,7 @@ describe Paperclip::Interpolations do
     attachment.stubs(:original_filename).returns("one")
     assert_equal "one", Paperclip::Interpolations.filename(attachment, :style)
   end
-  
+
   it "returns the basename when the extension contains regexp special characters" do
     attachment = mock
     attachment.stubs(:styles).returns({})
@@ -254,7 +254,6 @@ describe Paperclip::Interpolations do
     Paperclip.interpolates :foo? do
       "bar"
     end
-    Paperclip::Interpolations.expects(:fool).never
     value = Paperclip::Interpolations.interpolate(":fo/:foo?")
     assert_equal ":fo/bar", value
   end


### PR DESCRIPTION
Several other users have had problems with the speed of `Paperclip::Interpolations.interpolate` or with `model.attachment.url` (#557, #909). `gsub` with a string is significantly faster than `gsub` with a regex, and changing to a string also prevents users from creating interpolations with ? wildcards in them.

See:
```
irb(main):001:0> require 'benchmark'
=> true
irb(main):002:0> puts Benchmark.measure{100_000.times{":foo/:bar".gsub(/:#{:bar}/, 'BAR')}}
  2.290000   0.030000   2.320000 (  2.425150)
=> nil
irb(main):003:0> puts Benchmark.measure{100_000.times{":foo/:bar".gsub(":#{:bar}", 'BAR')}}
  0.860000   0.010000   0.870000 (  1.001322)
=> nil
```