### PR TITLE
Change remove column call to properly respect method signature for Rails 3 vs Rails 4

### DIFF
--- a/lib/paperclip/schema.rb
+++ b/lib/paperclip/schema.rb
@@ -40,7 +40,11 @@ module Paperclip
         attachment_names.each do |attachment_name|
           COLUMNS.each_pair do |column_name, column_type|
             column_options = options.merge(options[column_name.to_sym] || {})
-            remove_column(table_name, "#{attachment_name}_#{column_name}", column_type, column_options)
+            if ActiveRecord::VERSION::MAJOR >= 4
+              remove_column(table_name, "#{attachment_name}_#{column_name}", column_type, column_options)
+            else
+              remove_column(table_name, "#{attachment_name}_#{column_name}")
+            end
           end
         end
       end


### PR DESCRIPTION
This is a fix for issue #1946.

No test included. Was unsure how to properly test Rails version specific behavior. Happy to add a test with some guidance.