### PR TITLE
avoids comparing [] (from filename media-type guess) 

### DIFF
--- a/lib/paperclip/media_type_spoof_detector.rb
+++ b/lib/paperclip/media_type_spoof_detector.rb
@@ -30,7 +30,8 @@ module Paperclip
     end
 
     def media_type_mismatch?
-      supplied_type_mismatch? || calculated_type_mismatch?
+      #if there are any media types from the filename, check for mismatch with calculated and supplied types
+      media_types_from_name.size > 0 && (supplied_type_mismatch? || calculated_type_mismatch?)
     end
 
     def supplied_type_mismatch?


### PR DESCRIPTION
to inferred(from `file` command) or supplied types

if there are no media types from name, we should not try to compare them

fixes #1944