### PR TITLE
Fix GeometryParser for '@>' special case

### DIFF
--- a/lib/paperclip/geometry_parser_factory.rb
+++ b/lib/paperclip/geometry_parser_factory.rb
@@ -1,6 +1,6 @@
 module Paperclip
   class GeometryParser
-    FORMAT = /\b(\d*)x?(\d*)\b(?:,(\d?))?([\>\<\#\@\%^!])?/i
+    FORMAT = /\b(\d*)x?(\d*)\b(?:,(\d?))?(\@\>|\>\@|[\>\<\#\@\%^!])?/i
     def initialize(string)
       @string = string
     end

--- a/spec/paperclip/geometry_spec.rb
+++ b/spec/paperclip/geometry_spec.rb
@@ -82,7 +82,7 @@ describe Paperclip::Geometry do
       assert_equal 456, @upper.height
     end
 
-    ['>', '<', '#', '@', '%', '^', '!', nil].each do |mod|
+    ['>', '<', '#', '@', '@>', '>@', '%', '^', '!', nil].each do |mod|
       it "ensures the modifier #{description} is preserved" do
         assert @geo = Paperclip::Geometry.parse("123x456#{mod}")
         assert_equal mod, @geo.modifier


### PR DESCRIPTION
According to the [ImageMagick documentation](http://www.imagemagick.org/Usage/resize/#pixel) the `@` flag is a special case that can be used in conjunction with `>` to prevent IM from scaling an image up. The `<` flag is ignored when using `@`.

This fixes the issue I reported in #1851, which I believe was incorrectly marked as duplicate.