### PR TITLE
add support for session token

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -234,7 +234,7 @@ module Paperclip
             config[:proxy_uri] = URI::HTTP.build(proxy_opts)
           end
 
-          [:access_key_id, :secret_access_key, :credential_provider].each do |opt|
+          [:access_key_id, :secret_access_key, :credential_provider, :session_token].each do |opt|
             config[opt] = s3_credentials[opt] if s3_credentials[opt]
           end
 


### PR DESCRIPTION
Essentially if you provision ephemeral credentials via AWS with STS, you'll want to use the `session_token` to access AWS. For docs, see http://docs.aws.amazon.com/STS/latest/UsingSTS/Welcome.html