### PR TITLE
Don't write original if it wasn't reprocessed

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -236,7 +236,9 @@ module Paperclip
     # the instance's errors and returns false, cancelling the save.
     def save
       flush_deletes unless @options[:keep_old_files]
-      @queued_for_write.except!(:original) unless @options[:only_process].empty? || @options[:only_process].include?(:original)
+      if @options[:only_process].any? && !@options[:only_process].include?(:original)
+        @queued_for_write.except!(:original)
+      end
       flush_writes
       @dirty = false
       true

--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -236,6 +236,7 @@ module Paperclip
     # the instance's errors and returns false, cancelling the save.
     def save
       flush_deletes unless @options[:keep_old_files]
+      @queued_for_write.except!(:original) unless @options[:only_process].empty? || @options[:only_process].include?(:original)
       flush_writes
       @dirty = false
       true

--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -382,14 +382,15 @@ describe Paperclip::Storage::S3 do
   context "An attachment that uses S3 for storage and has styles" do
     before do
       rebuild_model(
-        (aws2_add_region).merge({
+        (aws2_add_region).merge(
           storage: :s3,
           styles: { thumb: ["90x90#", :jpg] },
           bucket: "bucket",
           s3_credentials: {
             "access_key_id" => "12345",
             "secret_access_key" => "54321" }
-          }))
+        )
+      )
 
       @file = File.new(fixture_file("5k.png"), "rb")
       @dummy = Dummy.new
@@ -408,18 +409,21 @@ describe Paperclip::Storage::S3 do
 
       it "uploads original" do
         @object.expects((defined?(::Aws) ? :upload_file : :write)).
-          with(anything, content_type: "image/png",
-                acl: Paperclip::Storage::S3::DEFAULT_PERMISSION).returns(true)
+          with(anything,
+            content_type: "image/png",
+            acl: Paperclip::Storage::S3::DEFAULT_PERMISSION).returns(true)
         @object.expects((defined?(::Aws) ? :upload_file : :write)).
-          with(anything, content_type: "image/jpeg",
-                acl: Paperclip::Storage::S3::DEFAULT_PERMISSION).returns(true)
+          with(anything,
+            content_type: "image/jpeg",
+            acl: Paperclip::Storage::S3::DEFAULT_PERMISSION).returns(true)
         @dummy.avatar.reprocess!
       end
 
       it "doesn't upload original" do
-        @object.expects((defined?(::Aws) ? :upload_file : :write))
-          .with(anything, content_type: "image/jpeg",
-                acl: Paperclip::Storage::S3::DEFAULT_PERMISSION).returns(true)
+        @object.expects((defined?(::Aws) ? :upload_file : :write)).
+          with(anything,
+            content_type: "image/jpeg",
+            acl: Paperclip::Storage::S3::DEFAULT_PERMISSION).returns(true)
         @dummy.avatar.reprocess!(:thumb)
       end
     end

--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -382,12 +382,14 @@ describe Paperclip::Storage::S3 do
   context "An attachment that uses S3 for storage and has styles" do
     before do
       rebuild_model(
-        (aws2_add_region).merge storage: :s3,
-        styles: { thumb: ["90x90#", :jpg] },
-        bucket: "bucket",
-        s3_credentials: { "access_key_id" => "12345",
-                          "secret_access_key" => "54321" }
-        )
+        (aws2_add_region).merge({
+          storage: :s3,
+          styles: { thumb: ["90x90#", :jpg] },
+          bucket: "bucket",
+          s3_credentials: {
+            "access_key_id" => "12345",
+            "secret_access_key" => "54321" }
+          }))
 
       @file = File.new(fixture_file("5k.png"), "rb")
       @dummy = Dummy.new
@@ -400,23 +402,23 @@ describe Paperclip::Storage::S3 do
         @object = stub
         @dummy.avatar.stubs(:s3_object).with(:original).returns(@object)
         @dummy.avatar.stubs(:s3_object).with(:thumb).returns(@object)
-        @object.stubs(defined?(::Aws) ? :get : :read).with().yields(@file.read)
-        @object.stubs(:exists?).with().returns(true)
+        @object.stubs(defined?(::Aws) ? :get : :read).yields(@file.read)
+        @object.stubs(:exists?).returns(true)
       end
 
       it "uploads original" do
-        @object.expects((defined?(::Aws) ? :upload_file : :write))
-          .with(anything, content_type: 'image/png',
+        @object.expects((defined?(::Aws) ? :upload_file : :write)).
+          with(anything, content_type: "image/png",
                 acl: Paperclip::Storage::S3::DEFAULT_PERMISSION).returns(true)
-        @object.expects((defined?(::Aws) ? :upload_file : :write))
-          .with(anything, content_type: 'image/jpeg',
+        @object.expects((defined?(::Aws) ? :upload_file : :write)).
+          with(anything, content_type: "image/jpeg",
                 acl: Paperclip::Storage::S3::DEFAULT_PERMISSION).returns(true)
         @dummy.avatar.reprocess!
       end
 
       it "doesn't upload original" do
         @object.expects((defined?(::Aws) ? :upload_file : :write))
-          .with(anything, content_type: 'image/jpeg',
+          .with(anything, content_type: "image/jpeg",
                 acl: Paperclip::Storage::S3::DEFAULT_PERMISSION).returns(true)
         @dummy.avatar.reprocess!(:thumb)
       end

--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -379,6 +379,52 @@ describe Paperclip::Storage::S3 do
     end
   end
 
+  context "An attachment that uses S3 for storage and has styles" do
+    before do
+      rebuild_model(
+        (aws2_add_region).merge storage: :s3,
+        styles: { thumb: ["90x90#", :jpg] },
+        bucket: "bucket",
+        s3_credentials: { "access_key_id" => "12345",
+                          "secret_access_key" => "54321" }
+        )
+
+      @file = File.new(fixture_file("5k.png"), "rb")
+      @dummy = Dummy.new
+      @dummy.avatar = @file
+      @dummy.save
+    end
+
+    context "reprocess" do
+      before do
+        @object = stub
+        @dummy.avatar.stubs(:s3_object).with(:original).returns(@object)
+        @dummy.avatar.stubs(:s3_object).with(:thumb).returns(@object)
+        @object.stubs(defined?(::Aws) ? :get : :read).with().yields(@file.read)
+        @object.stubs(:exists?).with().returns(true)
+      end
+
+      it "uploads original" do
+        @object.expects((defined?(::Aws) ? :upload_file : :write))
+          .with(anything, content_type: 'image/png',
+                acl: Paperclip::Storage::S3::DEFAULT_PERMISSION).returns(true)
+        @object.expects((defined?(::Aws) ? :upload_file : :write))
+          .with(anything, content_type: 'image/jpeg',
+                acl: Paperclip::Storage::S3::DEFAULT_PERMISSION).returns(true)
+        @dummy.avatar.reprocess!
+      end
+
+      it "doesn't upload original" do
+        @object.expects((defined?(::Aws) ? :upload_file : :write))
+          .with(anything, content_type: 'image/jpeg',
+                acl: Paperclip::Storage::S3::DEFAULT_PERMISSION).returns(true)
+        @dummy.avatar.reprocess!(:thumb)
+      end
+    end
+
+    after { @file.close }
+  end
+
   context "An attachment that uses S3 for storage and has spaces in file name" do
     before do
       rebuild_model(

--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -408,22 +408,22 @@ describe Paperclip::Storage::S3 do
       end
 
       it "uploads original" do
-        @object.expects((defined?(::Aws) ? :upload_file : :write)).
-          with(anything,
-            content_type: "image/png",
-            acl: Paperclip::Storage::S3::DEFAULT_PERMISSION).returns(true)
-        @object.expects((defined?(::Aws) ? :upload_file : :write)).
-          with(anything,
-            content_type: "image/jpeg",
-            acl: Paperclip::Storage::S3::DEFAULT_PERMISSION).returns(true)
+        @object.expects((defined?(::Aws) ? :upload_file : :write)).with(
+          anything,
+          content_type: "image/png",
+          acl: Paperclip::Storage::S3::DEFAULT_PERMISSION).returns(true)
+        @object.expects((defined?(::Aws) ? :upload_file : :write)).with(
+          anything,
+          content_type: "image/jpeg",
+          acl: Paperclip::Storage::S3::DEFAULT_PERMISSION).returns(true)
         @dummy.avatar.reprocess!
       end
 
       it "doesn't upload original" do
-        @object.expects((defined?(::Aws) ? :upload_file : :write)).
-          with(anything,
-            content_type: "image/jpeg",
-            acl: Paperclip::Storage::S3::DEFAULT_PERMISSION).returns(true)
+        @object.expects((defined?(::Aws) ? :upload_file : :write)).with(
+          anything,
+          content_type: "image/jpeg",
+          acl: Paperclip::Storage::S3::DEFAULT_PERMISSION).returns(true)
         @dummy.avatar.reprocess!(:thumb)
       end
     end


### PR DESCRIPTION
If only_process list is not empty, but it doesn't contain :original style, original file hasn't been reprocessed and it's not needed to rewrite/reupload it.

Fixes #1055 again