### PR TITLE
Release version v4.3.1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,13 @@
-4.3.0:
+4.3.1 (9/9/2015):
+
+* Backport of bugfix to `remove_column`, so it works in Rails 3 and 4
+  c740fb171fe2f88c60b999d2a1c2122f2b8f43e9
+* Fix GeometryParser regex for usage of '@>' flag
+* `url` on a unpersisted record returns default_url
+* spec deprecation warnings and failures
+* README adjustments
+
+4.3.0 (6/18/2015):
 
 * Improvement: Update aws-sdk and cucumber gem versions.
 * Improvement: Add `length` alias for `size` method in AbstractAdapter.

--- a/README.md
+++ b/README.md
@@ -94,8 +94,12 @@ If you are dealing with pdf uploads or running the test suite, you'll also need
 to install GhostScript. On Mac OS X, you can also install that using Homebrew:
 
     brew install gs
-    
+
 If you're on Ubuntu, you'll want to run the following with apt-get:
+
+    sudo apt-get install imagemagick -y
+
+If you're on Ubuntu (or any Debian base Linux distribution), you'll want to run the following with apt-get:
 
     sudo apt-get install imagemagick -y
 
@@ -148,12 +152,6 @@ Include the gem in your Gemfile:
 
 ```ruby
 gem "paperclip", "~> 4.3"
-```
-
-If you're still using Rails 2.3.x, you should do this instead:
-
-```ruby
-gem "paperclip", "~> 2.7"
 ```
 
 Or, if you want to get the latest, you can get master from the main paperclip repository:

--- a/lib/paperclip/version.rb
+++ b/lib/paperclip/version.rb
@@ -1,3 +1,3 @@
 module Paperclip
-  VERSION = "4.3.0" unless defined? Paperclip::VERSION
+  VERSION = "4.3.1" unless defined? Paperclip::VERSION
 end


### PR DESCRIPTION
Removes note for running paperclip in EOL'd version of Rails (2.3).

This release got messy because history in master got intertwined commits for Rails 5, the backport to 3.2, and normal development. If we are not going to rebase Pull Requests with many "messy" commits, it's going to be good to use merge commits rather than rebasing them in, so it's easier to revert.

cc @jyurek @sikachu @iwz. Will release the new gem after your +1.