### PR TITLE
Remove from Travis JRuby and Rubinius

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
-  - jruby-19mode
-  - rbx-2
 
 script: "bundle exec rake clean spec cucumber"
 
@@ -17,12 +15,6 @@ gemfile:
   - gemfiles/3.2.awsv1.gemfile
   - gemfiles/4.1.awsv1.gemfile
   - gemfiles/4.2.awsv1.gemfile
-
-matrix:
-  fast_finish: true
-  allow_failures:
-    - rvm: jruby-19mode
-    - rvm: rbx-2
 
 sudo: false
 cache: bundler

--- a/Gemfile
+++ b/Gemfile
@@ -3,13 +3,6 @@ source "https://rubygems.org"
 gemspec
 
 gem 'sqlite3', '~> 1.3.8', :platforms => :ruby
-
-gem 'jruby-openssl', :platforms => :jruby
-gem 'activerecord-jdbcsqlite3-adapter', :platforms => :jruby
-
-gem 'rubysl', :platforms => :rbx
-gem 'racc', :platforms => :rbx
-
 gem 'pry'
 
 # Hinting at development dependencies

--- a/gemfiles/3.2.awsv1.gemfile
+++ b/gemfiles/3.2.awsv1.gemfile
@@ -3,10 +3,6 @@
 source "https://rubygems.org"
 
 gem "sqlite3", "~> 1.3.8", :platforms => :ruby
-gem "jruby-openssl", :platforms => :jruby
-gem "activerecord-jdbcsqlite3-adapter", :platforms => :jruby
-gem "rubysl", :platforms => :rbx
-gem "racc", :platforms => :rbx
 gem "pry"
 gem "rails", "~> 3.2.0"
 gem "aws-sdk", "~> 1.5"

--- a/gemfiles/3.2.awsv2.0.gemfile
+++ b/gemfiles/3.2.awsv2.0.gemfile
@@ -3,10 +3,6 @@
 source "https://rubygems.org"
 
 gem "sqlite3", "~> 1.3.8", :platforms => :ruby
-gem "jruby-openssl", :platforms => :jruby
-gem "activerecord-jdbcsqlite3-adapter", :platforms => :jruby
-gem "rubysl", :platforms => :rbx
-gem "racc", :platforms => :rbx
 gem "pry"
 gem "rails", "~> 3.2.0"
 gem "aws-sdk", "~> 2.0.0"

--- a/gemfiles/3.2.awsv2.1.gemfile
+++ b/gemfiles/3.2.awsv2.1.gemfile
@@ -3,10 +3,6 @@
 source "https://rubygems.org"
 
 gem "sqlite3", "~> 1.3.8", :platforms => :ruby
-gem "jruby-openssl", :platforms => :jruby
-gem "activerecord-jdbcsqlite3-adapter", :platforms => :jruby
-gem "rubysl", :platforms => :rbx
-gem "racc", :platforms => :rbx
 gem "pry"
 gem "rails", "~> 3.2.0"
 gem "aws-sdk", "~> 2.1.0"

--- a/gemfiles/4.1.awsv1.gemfile
+++ b/gemfiles/4.1.awsv1.gemfile
@@ -3,10 +3,6 @@
 source "https://rubygems.org"
 
 gem "sqlite3", "~> 1.3.8", :platforms => :ruby
-gem "jruby-openssl", :platforms => :jruby
-gem "activerecord-jdbcsqlite3-adapter", :platforms => :jruby
-gem "rubysl", :platforms => :rbx
-gem "racc", :platforms => :rbx
 gem "pry"
 gem "rails", "~> 4.1.0"
 gem "aws-sdk", "~> 1.5"

--- a/gemfiles/4.1.awsv2.0.gemfile
+++ b/gemfiles/4.1.awsv2.0.gemfile
@@ -3,10 +3,6 @@
 source "https://rubygems.org"
 
 gem "sqlite3", "~> 1.3.8", :platforms => :ruby
-gem "jruby-openssl", :platforms => :jruby
-gem "activerecord-jdbcsqlite3-adapter", :platforms => :jruby
-gem "rubysl", :platforms => :rbx
-gem "racc", :platforms => :rbx
 gem "pry"
 gem "rails", "~> 4.1.0"
 gem "aws-sdk", "~> 2.0.0"

--- a/gemfiles/4.1.awsv2.1.gemfile
+++ b/gemfiles/4.1.awsv2.1.gemfile
@@ -3,10 +3,6 @@
 source "https://rubygems.org"
 
 gem "sqlite3", "~> 1.3.8", :platforms => :ruby
-gem "jruby-openssl", :platforms => :jruby
-gem "activerecord-jdbcsqlite3-adapter", :platforms => :jruby
-gem "rubysl", :platforms => :rbx
-gem "racc", :platforms => :rbx
 gem "pry"
 gem "rails", "~> 4.1.0"
 gem "aws-sdk", "~> 2.1.0"

--- a/gemfiles/4.2.awsv1.gemfile
+++ b/gemfiles/4.2.awsv1.gemfile
@@ -3,10 +3,6 @@
 source "https://rubygems.org"
 
 gem "sqlite3", "~> 1.3.8", :platforms => :ruby
-gem "jruby-openssl", :platforms => :jruby
-gem "activerecord-jdbcsqlite3-adapter", :platforms => :jruby
-gem "rubysl", :platforms => :rbx
-gem "racc", :platforms => :rbx
 gem "pry"
 gem "rails", "~> 4.2.0"
 gem "aws-sdk", "~> 1.5"

--- a/gemfiles/4.2.awsv2.0.gemfile
+++ b/gemfiles/4.2.awsv2.0.gemfile
@@ -3,10 +3,6 @@
 source "https://rubygems.org"
 
 gem "sqlite3", "~> 1.3.8", :platforms => :ruby
-gem "jruby-openssl", :platforms => :jruby
-gem "activerecord-jdbcsqlite3-adapter", :platforms => :jruby
-gem "rubysl", :platforms => :rbx
-gem "racc", :platforms => :rbx
 gem "pry"
 gem "rails", "~> 4.2.0"
 gem "aws-sdk", "~> 2.0.0"

--- a/gemfiles/4.2.awsv2.1.gemfile
+++ b/gemfiles/4.2.awsv2.1.gemfile
@@ -3,10 +3,6 @@
 source "https://rubygems.org"
 
 gem "sqlite3", "~> 1.3.8", :platforms => :ruby
-gem "jruby-openssl", :platforms => :jruby
-gem "activerecord-jdbcsqlite3-adapter", :platforms => :jruby
-gem "rubysl", :platforms => :rbx
-gem "racc", :platforms => :rbx
 gem "pry"
 gem "rails", "~> 4.2.0"
 gem "aws-sdk", "~> 2.1.0"


### PR DESCRIPTION
They are allowed to fail, and they consistently fail. They only add up
time to our builds. If we wanted to keep them, they should be in the
build matrix and run tests successfully.