### PR TITLE
make style optional in copy_to_local_file

### DIFF
--- a/lib/paperclip/io_adapters/attachment_adapter.rb
+++ b/lib/paperclip/io_adapters/attachment_adapter.rb
@@ -24,7 +24,7 @@ module Paperclip
       if source.staged?
         FileUtils.cp(source.staged_path(@style), destination.path)
       else
-        source.copy_to_local_file(@style, destination.path)
+        source.copy_to_local_file(destination.path, @style)
       end
       destination
     end

--- a/lib/paperclip/storage/filesystem.rb
+++ b/lib/paperclip/storage/filesystem.rb
@@ -19,7 +19,7 @@ module Paperclip
     #   saved by paperclip. If you set this to an explicit octal value (0755, 0644, etc) then
     #   that value will be used to set the permissions for an uploaded file. The default is 0666.
     #   If you set :override_file_permissions to false, the chmod will be skipped. This allows
-    #   you to use paperclip on filesystems that don't understand unix file permissions, and has the 
+    #   you to use paperclip on filesystems that don't understand unix file permissions, and has the
     #   added benefit of using the storage directories default umask on those that do.
     module Filesystem
       def self.extended base
@@ -81,8 +81,8 @@ module Paperclip
         @queued_for_delete = []
       end
 
-      def copy_to_local_file(style, local_dest_path)
-        FileUtils.cp(path(style), local_dest_path)
+      def copy_to_local_file(local_dest_path, style_name = default_style)
+        FileUtils.cp(path(style_name), local_dest_path)
       end
     end
 

--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -160,10 +160,10 @@ module Paperclip
         (creds[RailsEnvironment.get] || creds).symbolize_keys
       end
 
-      def copy_to_local_file(style, local_dest_path)
-        log("copying #{path(style)} to local file #{local_dest_path}")
+      def copy_to_local_file(local_dest_path, style_name = default_style)
+        log("copying #{path(style_name)} to local file #{local_dest_path}")
         ::File.open(local_dest_path, 'wb') do |local_file|
-          file = directory.files.get(path(style))
+          file = directory.files.get(path(style_name))
           local_file.write(file.body)
         end
       rescue ::Fog::Errors::Error => e

--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -446,10 +446,10 @@ module Paperclip
         @queued_for_delete = []
       end
 
-      def copy_to_local_file(style, local_dest_path)
+      def copy_to_local_file(local_dest_path, style_name = default_style)
         log("copying #{path(style)} to local file #{local_dest_path}")
         ::File.open(local_dest_path, 'wb') do |local_file|
-          s3_object(style).send(aws_v1? ? :read : :get) do |chunk|
+          s3_object(style_name).send(aws_v1? ? :read : :get) do |chunk|
             local_file.write(chunk)
           end
         end

--- a/spec/paperclip/storage/filesystem_spec.rb
+++ b/spec/paperclip/storage/filesystem_spec.rb
@@ -44,7 +44,7 @@ describe Paperclip::Storage::Filesystem do
 
       it 'copies the file to a known location with copy_to_local_file' do
         tempfile = Tempfile.new("known_location")
-        @dummy.avatar.copy_to_local_file(:original, tempfile.path)
+        @dummy.avatar.copy_to_local_file(tempfile.path, :original)
         tempfile.rewind
         assert_equal @file.read, tempfile.read
         tempfile.close

--- a/spec/paperclip/storage/fog_spec.rb
+++ b/spec/paperclip/storage/fog_spec.rb
@@ -175,7 +175,7 @@ describe Paperclip::Storage::Fog do
         @dummy.save
         tempfile = Tempfile.new("known_location")
         tempfile.binmode
-        @dummy.avatar.copy_to_local_file(:original, tempfile.path)
+        @dummy.avatar.copy_to_local_file(tempfile.path, :original)
         tempfile.rewind
         assert_equal @connection.directories.get(@fog_directory).files.get(@dummy.avatar.path).body,
                      tempfile.read


### PR DESCRIPTION
I recently had to use `copy_to_local_file` and was frustrated by the fact that `style` was a required parameter. I had to dig into `Attachment::default_options` to realize that `:original` was what I needed to pass.
I changed `copy_to_local_file` so that the style falls back to `default_style` when not provided. This matches the behavior of existing methods like `expiring_url` and `s3_object` (in `module S3`).