### PR TITLE
Resolve broken CI tests due to upstream gem changes

### DIFF
--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('aws-sdk', '>= 1.5.7', "< 3.0", *((0..33).to_a.collect{ |release_number| "!= 2.0.#{release_number}" }))
   s.add_development_dependency('bourne')
   s.add_development_dependency('cucumber', '~> 1.3.18')
-  s.add_development_dependency('aruba')
+  s.add_development_dependency('aruba', '~> 0.9.0')
   s.add_development_dependency('nokogiri')
   # Ruby version < 1.9.3 can't install capybara > 2.0.3.
   s.add_development_dependency('capybara')

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -43,7 +43,8 @@ Gem::Specification.new do |s|
   # Ruby version < 1.9.3 can't install capybara > 2.0.3.
   s.add_development_dependency('capybara')
   s.add_development_dependency('bundler')
-  s.add_development_dependency('fog', '~> 1.0')
+  s.add_development_dependency('fog-aws')
+  s.add_development_dependency('fog-local')
   s.add_development_dependency('launchy')
   s.add_development_dependency('rake')
   s.add_development_dependency('fakeweb')

--- a/spec/paperclip/storage/fog_spec.rb
+++ b/spec/paperclip/storage/fog_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'fog'
+require 'fog/aws'
+require 'fog/local'
 require 'timecop'
 
 describe Paperclip::Storage::Fog do


### PR DESCRIPTION
There was a change in `aruba` that is breaking the cucumber tests. This PR doesn't fix the root problem, it just locks down the version to make it work. This partially addresses #2048 

The `fog` gem has been making updates to loosen dependencies on net-ssh (see fog/fog-core/pull/166 or fog/fog/commit/ebfaa0c97a387eeb18c5c797aaa33a1596e46676). Rather than explicitly requiring net-ssh this PR changes the development dependencies to the 2 providers that are tested.
