### PR TITLE
Add an interpolation for "base_class"

### DIFF
--- a/lib/paperclip/interpolations.rb
+++ b/lib/paperclip/interpolations.rb
@@ -93,6 +93,12 @@ module Paperclip
       plural_cache.underscore_and_pluralize_class(attachment.instance.class)
     end
 
+    # Returns the underscored, pluralized version of the base class' class name.
+    # e.g. "vehicles" for a Car class that descends from Vehicle.
+    def base_class attachment, style_name
+      plural_cache.underscore_and_pluralize_class(attachment.instance.class.base_class)
+    end
+
     # Returns the basename of the file. e.g. "file" for "file.jpg"
     def basename attachment, style_name
       File.basename(attachment.original_filename, ".*".freeze)

--- a/spec/paperclip/interpolations_spec.rb
+++ b/spec/paperclip/interpolations_spec.rb
@@ -31,6 +31,21 @@ describe Paperclip::Interpolations do
     assert_equal "things", Paperclip::Interpolations.class(attachment, :style)
   end
 
+  it "returns the base class of the instance" do
+    class Grandparent ; end
+    class Parent < Grandparent; end
+    class Child < Parent
+      def self.base_class
+        Grandparent
+      end
+    end
+
+    attachment = mock
+    attachment.expects(:instance).returns(attachment)
+    attachment.expects(:class).returns(Child)
+    assert_equal "grandparents", Paperclip::Interpolations.base_class(attachment, :style)
+  end
+
   it "returns the basename of the file" do
     attachment = mock
     attachment.expects(:original_filename).returns("one.jpg").times(1)


### PR DESCRIPTION
When using Paperclip and Rails with a model that uses STI, it's often easier to use one controller for all subclasses to control the download/access of the attached file. This interpolation allows you to reference that base class in the path/url.