### PR TITLE
Fix condition to include Schema, using 'ActiveRecord::Base' instead o…

### DIFF
--- a/lib/paperclip/glue.rb
+++ b/lib/paperclip/glue.rb
@@ -8,7 +8,7 @@ module Paperclip
       base.extend ClassMethods
       base.send :include, Callbacks
       base.send :include, Validators
-      base.send :include, Schema if defined? ActiveRecord
+      base.send :include, Schema if defined? ActiveRecord::Base
 
       locale_path = Dir.glob(File.dirname(__FILE__) + "/locales/*.{rb,yml}")
       I18n.load_path += locale_path unless I18n.load_path.include?(locale_path)


### PR DESCRIPTION
There are some gems that implements subclasses/submodules named ActiveRecord, that could wrongly trigger the Schema include.

Example: 
```ruby
module LogStasher
  module ActiveRecord
    class LogSubscriber < ::ActiveRecord::LogSubscriber
```
https://github.com/shadabahmed/logstasher/blob/7fbd7368734465a7bbd005d9fd2d7bb5c109d04e/lib/logstasher/active_record/log_subscriber.rb

To be safe that the real ActiveRecord is been used, I've added the ActiveRecord::Base class instead of the ActiveRecord class.

It's seems pretty safe in long term, since if they remove the Base subclass, all activerecord applications will be broken!