### PR TITLE
Modify the Gemfile for testing with mime-types 3

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,9 +1,17 @@
 appraise "4.2.awsv2.1" do
   gem "rails", "~> 4.2.0"
   gem "aws-sdk", "~> 2.1.0"
+
+  group :development, :test do
+    gem 'mime-types', '>= 1.16', '< 4'
+  end
 end
 
 appraise "4.2.awsv2.0" do
   gem "rails", "~> 4.2.0"
   gem "aws-sdk", "~> 2.0.0"
+
+  group :development, :test do
+    gem 'mime-types', '>= 1.16', '< 4'
+  end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'pry'
 # Prevents bundler from taking a long-time to resolve
 group :development, :test do
   gem 'activerecord-import'
-  gem 'mime-types', '~> 1.16'
+  gem 'mime-types'
   gem 'builder'
   gem 'rubocop', require: false
 end

--- a/gemfiles/4.2.awsv2.0.gemfile
+++ b/gemfiles/4.2.awsv2.0.gemfile
@@ -9,7 +9,7 @@ gem "aws-sdk", "~> 2.0.0"
 
 group :development, :test do
   gem "activerecord-import"
-  gem "mime-types", "~> 1.16"
+  gem "mime-types", ">= 1.16", "< 4"
   gem "builder"
   gem "rubocop", :require => false
 end

--- a/gemfiles/4.2.awsv2.1.gemfile
+++ b/gemfiles/4.2.awsv2.1.gemfile
@@ -9,7 +9,7 @@ gem "aws-sdk", "~> 2.1.0"
 
 group :development, :test do
   gem "activerecord-import"
-  gem "mime-types", "~> 1.16"
+  gem "mime-types", ">= 1.16", "< 4"
   gem "builder"
   gem "rubocop", :require => false
 end


### PR DESCRIPTION
- The specs pass for the bits related to mime-types. I don’t use Paperclip
  otherwise, but there were a couple of local failures.
- Fix the appraisals, too.
- This will not fully work until mikel/mail is updated to support the same
  restriction, but I have PR open to expand mime-types support there, currently
  being reviewed for merge.