### PR TITLE
upgrading aws-sdk to v2 requires changing 'public_read' to 'public-read'

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,8 @@ And then you can specify using S3 from `has_attached_file`.
 You can find more information about configuring and using S3 storage in
 [the `Paperclip::Storage::S3` documentation](http://www.rubydoc.info/gems/paperclip/Paperclip/Storage/S3).
 
+_**NOTE**: If upgrading aws-sdk from v1.x to v2.x, be sure to read the [UPGRADING guide](https://github.com/thoughtbot/paperclip/blob/master/UPGRADING)._
+
 Files on the local filesystem (and in the Rails app's public directory) will be
 available to the internet at large. If you require access control, it's
 possible to place your files in a different location. You will need to change

--- a/UPGRADING
+++ b/UPGRADING
@@ -4,7 +4,12 @@
 
 Paperclip is now compatible with aws-sdk >= 2.0.0.
 
-If you are using S3 storage, aws-sdk >= 2.0.0 requires you to set the s3_region.
+If you are using S3 storage, aws-sdk >= 2.0.0 requires you to make a few small changes:
+* You must set the s3_region.
+
+* If you are explicitly setting permissions anywhere, such as in an initializer,
+note that the format of the permissions changed from using an underscore to using a hyphen.
+For example, `:public_read` needs to be changed to `public-read`.
 
 If you want to continue using an earlier version of aws-sdk, replace
  aws-sdk with aws-sdk-v1 in your Gemfile.


### PR DESCRIPTION
See https://github.com/thoughtbot/paperclip/issues/1974