### PR TITLE
fix S3 adapter runtime constant definition not being thread-safe

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -113,21 +113,23 @@ module Paperclip
 
     module S3
       def self.extended base
-        unless defined?(AWS_CLASS)
-          begin
-            require 'aws-sdk'
-            const_set('AWS_CLASS', defined?(::Aws) ? ::Aws : ::AWS)
-            const_set('AWS_BASE_ERROR',
-              defined?(::Aws) ? Aws::Errors::ServiceError : AWS::Errors::Base)
-            const_set('DEFAULT_PERMISSION',
-              defined?(::AWS) ? :public_read : :'public-read')
+        Thread.exclusive do
+          unless defined?(AWS_CLASS)
+            begin
+              require 'aws-sdk'
+              const_set('AWS_CLASS', defined?(::Aws) ? ::Aws : ::AWS)
+              const_set('AWS_BASE_ERROR',
+                defined?(::Aws) ? Aws::Errors::ServiceError : AWS::Errors::Base)
+              const_set('DEFAULT_PERMISSION',
+                defined?(::AWS) ? :public_read : :'public-read')
 
-          rescue LoadError => e
-            e.message << " (You may need to install the aws-sdk gem)"
-            raise e
-          end
-          if Gem::Version.new(AWS_CLASS::VERSION) >= Gem::Version.new(2) && Gem::Version.new(AWS_CLASS::VERSION) <= Gem::Version.new("2.0.33")
-            raise LoadError, "paperclip does not support aws-sdk versions 2.0.0 - 2.0.33.  Please upgrade aws-sdk to a newer version."
+            rescue LoadError => e
+              e.message << " (You may need to install the aws-sdk gem)"
+              raise e
+            end
+            if Gem::Version.new(AWS_CLASS::VERSION) >= Gem::Version.new(2) && Gem::Version.new(AWS_CLASS::VERSION) <= Gem::Version.new("2.0.33")
+              raise LoadError, "paperclip does not support aws-sdk versions 2.0.0 - 2.0.33.  Please upgrade aws-sdk to a newer version."
+            end
           end
         end
 

--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -14,7 +14,7 @@ describe Paperclip::Storage::S3 do
     defined?(::Aws) ? { s3_region: 'us-east-1' } : {}
   end
 
-  context 'multithreaded initialization' do
+  context "multithreaded initialization" do
     it "should not fail on missing constants" do
       10.times.map do |i|
         Thread.new do

--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -15,8 +15,6 @@ describe Paperclip::Storage::S3 do
   end
 
   context 'multithreaded initialization' do
-    before do
-    end
     it "should not fail on missing constants" do
       10.times.map do |i|
         Thread.new do

--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -14,6 +14,21 @@ describe Paperclip::Storage::S3 do
     defined?(::Aws) ? { s3_region: 'us-east-1' } : {}
   end
 
+  context 'multithreaded initialization' do
+    before do
+    end
+    it "should not fail on missing constants" do
+      10.times.map do |i|
+        Thread.new do
+          ActiveRecord::Base.connection_pool.with_connection do |_|
+            rebuild_model (aws2_add_region).merge storage: :s3
+            Dummy.new.avatar
+          end
+        end
+      end.map{|t| t.join}
+    end
+  end
+
   context "Parsing S3 credentials" do
     before do
       @proxy_settings = {host: "127.0.0.1", port: 8888, user: "foo", password: "bar"}


### PR DESCRIPTION
After debugging seemingly random exceptions on DEFAULT_PERMISSION not being defined in a threaded downloader, it became clear the S3 adapter is not thread safe.

Here is a sample run with 2 threads and debug prints:
```
#<Thread:0x007f925d34eeb8> before defined? check AWS_CLASS
#<Thread:0x007f925d34eeb8> before const_set AWS_CLASS
#<Thread:0x007f925d34eeb8> after const_set AWS_CLASS
#<Thread:0x007f925d34ed78> before defined? check AWS_CLASS
#<Thread:0x007f925d34ed78> before usage of const DEFAULT_PERMISSION
#<Thread:0x007f925d34eeb8> before const_set DEFAULT_PERMISSION
#<Thread:0x007f925d34eeb8> after const_set DEFAULT_PERMISSION
#<Thread:0x007f925d34eeb8> before usage of const DEFAULT_PERMISSION
#<Thread:0x007f925d34eeb8> after usage of const DEFAULT_PERMISSION
```
The added Thread#exclusive block is probably too wide and blunt of an fix but should be fine until a better one comes along.

Decided to use 10 threads in the spec after making sure of a good-enough failure rate (it is still possible to get false-positives but they should be rare).