### PR TITLE
Accept a default_url for each style

### DIFF
--- a/lib/paperclip/url_generator.rb
+++ b/lib/paperclip/url_generator.rb
@@ -10,7 +10,7 @@ module Paperclip
     def for(style_name, options)
       timestamp_as_needed(
         escape_url_as_needed(
-          @attachment_options[:interpolator].interpolate(most_appropriate_url, @attachment, style_name),
+          @attachment_options[:interpolator].interpolate(most_appropriate_url(style_name), @attachment, style_name),
           options
       ), options)
     end
@@ -18,19 +18,29 @@ module Paperclip
     private
 
     # This method is all over the place.
-    def default_url
-      if @attachment_options[:default_url].respond_to?(:call)
-        @attachment_options[:default_url].call(@attachment)
-      elsif @attachment_options[:default_url].is_a?(Symbol)
-        @attachment.instance.send(@attachment_options[:default_url])
+    def determine_default_url(url)
+      if url.respond_to?(:call)
+        url.call(@attachment)
+      elsif url.is_a?(Symbol)
+        @attachment.instance.send(url)
       else
-        @attachment_options[:default_url]
+        url
       end
     end
 
-    def most_appropriate_url
+    def default_url_for_style(style_name)
+      url = @attachment_options[:default_url]
+
+      if url.is_a?(Hash)
+        url = @attachment_options[:default_url].fetch(style_name)
+      end
+
+      determine_default_url(url)
+    end
+
+    def most_appropriate_url(style_name)
       if @attachment.original_filename.nil?
-        default_url
+        default_url_for_style(style_name)
       else
         @attachment_options[:url]
       end


### PR DESCRIPTION
Alternative to #2066 to address #1597. 

This would allow something like:

``` ruby
has_attached_file :image,
  styles: { small: "48x48#" },
  url_generator: AssetAwareUrlGenerator,
  default_url: {
    original: "https://my-cdn/default.png",
    small:    lambda { |_| ActionController::Base.helpers.asset_path('images/default-small.png') },
  }
```