### PR TITLE
Remove unused vars `column_(type|options)` from `remove_attachment` method

### DIFF
--- a/lib/paperclip/schema.rb
+++ b/lib/paperclip/schema.rb
@@ -38,8 +38,7 @@ module Paperclip
         options = attachment_names.extract_options!
 
         attachment_names.each do |attachment_name|
-          COLUMNS.each_pair do |column_name, column_type|
-            column_options = options.merge(options[column_name.to_sym] || {})
+          COLUMNS.keys.each do |column_name|
             remove_column(table_name, "#{attachment_name}_#{column_name}")
           end
         end


### PR DESCRIPTION
These variables were introduced in:
https://github.com/thoughtbot/paperclip/commit/6ea7c26512434a
but their usage were canceled in:
https://github.com/thoughtbot/paperclip/commit/c740fb171fe