### PR TITLE
Skip calculating fingerprint when it is not used

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -427,7 +427,7 @@ module Paperclip
     def assign_attributes
       @queued_for_write[:original] = @file
       assign_file_information
-      assign_fingerprint(@file.fingerprint)
+      assign_fingerprint { @file.fingerprint }
       assign_timestamps
     end
 
@@ -437,9 +437,9 @@ module Paperclip
       instance_write(:file_size, @file.size)
     end
 
-    def assign_fingerprint(fingerprint)
+    def assign_fingerprint
       if instance_respond_to?(:fingerprint)
-        instance_write(:fingerprint, fingerprint)
+        instance_write(:fingerprint, yield)
       end
     end
 
@@ -465,7 +465,7 @@ module Paperclip
 
     def reset_file_if_original_reprocessed
       instance_write(:file_size, @queued_for_write[:original].size)
-      assign_fingerprint(@queued_for_write[:original].fingerprint)
+      assign_fingerprint { @queued_for_write[:original].fingerprint }
       reset_updater
     end
 

--- a/spec/paperclip/attachment_spec.rb
+++ b/spec/paperclip/attachment_spec.rb
@@ -1374,6 +1374,12 @@ describe Paperclip::Attachment do
     end
 
     it "does not calculate fingerprint" do
+      Digest::MD5.stubs(:file)
+      @dummy.avatar = @file
+      expect(Digest::MD5).to have_received(:file).never
+    end
+
+    it "does not assign fingerprint" do
       @dummy.avatar = @file
       assert_nil @dummy.avatar.fingerprint
     end


### PR DESCRIPTION
The MD5 sum of an attachment is only necessary if the model has a corresponding `_fingerprint` column. If this column is absent, there is no need to calculate the MD5, which can be an expensive operation for large files.

Accomplish this by deferring the fingerprint calculation using a block. If the `_fingerprint` column is absent, the block is never called, and the calculation is avoided.

This issue was fixed once before (see #357, #696), but a subsequent refactor seems to have reintroduced the problem.