### PR TITLE
Bugfix: Dynamic fog directory

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,5 @@
+* Bugfix: Dynamic fog directory option is now respected
+
 5.0.0.beta1
 
 * Drop support to end-of-life'd ruby 2.0.

--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -195,10 +195,10 @@ module Paperclip
       end
 
       def host_name_for_directory
-        if @options[:fog_directory].to_s =~ Fog::AWS_BUCKET_SUBDOMAIN_RESTRICTON_REGEX
-          "#{@options[:fog_directory]}.s3.amazonaws.com"
+        if directory_name.to_s =~ Fog::AWS_BUCKET_SUBDOMAIN_RESTRICTON_REGEX
+          "#{directory_name}.s3.amazonaws.com"
         else
-          "s3.amazonaws.com/#{@options[:fog_directory]}"
+          "s3.amazonaws.com/#{directory_name}"
         end
       end
 
@@ -224,13 +224,15 @@ module Paperclip
       end
 
       def directory
-        dir = if @options[:fog_directory].respond_to?(:call)
+        @directory ||= connection.directories.new(key: directory_name)
+      end
+
+      def directory_name
+        if @options[:fog_directory].respond_to?(:call)
           @options[:fog_directory].call(self)
         else
           @options[:fog_directory]
         end
-
-        @directory ||= connection.directories.new(:key => dir)
       end
 
       def scheme

--- a/spec/paperclip/storage/fog_spec.rb
+++ b/spec/paperclip/storage/fog_spec.rb
@@ -418,6 +418,9 @@ describe Paperclip::Storage::Fog do
           assert @connection.directories.get(@dynamic_fog_directory).inspect
         end
 
+        it "provides an url using dynamic bucket name" do
+          assert_match(/^https:\/\/dynamicpaperclip.s3.amazonaws.com\/avatars\/5k.png\?\d*$/, @dummy.avatar.url)
+        end
       end
 
       context "with a proc for the fog_host evaluating a model method" do


### PR DESCRIPTION
`Paperclip::Storage::Fog#host_name_for_directory` assumes a String-like object is set and doesn't check if `@options[:fog_directory]` is callable, while `Paperclip::Storage::Fog#directory` does. I would recommend extracting a new method with the condition and refactoring the other two methods to call it.

See https://github.com/thoughtbot/paperclip/blob/master/lib/paperclip/storage/fog.rb#L191 and https://github.com/thoughtbot/paperclip/blob/master/lib/paperclip/storage/fog.rb#L220

Fixes #2018.