### PR TITLE
Remove attr_protected related specs (was removed in rails 4)

### DIFF
--- a/spec/paperclip/paperclip_spec.rb
+++ b/spec/paperclip/paperclip_spec.rb
@@ -123,33 +123,6 @@ describe Paperclip do
       end
     end
 
-    if using_protected_attributes?
-      context "that is attr_protected" do
-        before do
-          Dummy.class_eval do
-            attr_protected :avatar
-          end
-          @dummy = Dummy.new
-        end
-
-        it "does not assign the avatar on mass-set" do
-          @dummy.attributes = { other: "I'm set!",
-                                avatar: @file }
-
-          assert_equal "I'm set!", @dummy.other
-          assert ! @dummy.avatar?
-        end
-
-        it "allows assigment on normal set" do
-          @dummy.other  = "I'm set!"
-          @dummy.avatar = @file
-
-          assert_equal "I'm set!", @dummy.other
-          assert @dummy.avatar?
-        end
-      end
-    end
-
     context "with a subclass" do
       before do
         class ::SubDummy < Dummy; end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,7 +37,6 @@ RSpec.configure do |config|
   config.include ModelReconstruction
   config.include TestData
   config.extend VersionHelper
-  config.extend RailsHelpers::ClassMethods
   config.mock_framework = :mocha
   config.before(:all) do
     rebuild_model

--- a/spec/support/rails_helpers.rb
+++ b/spec/support/rails_helpers.rb
@@ -1,7 +1,0 @@
-module RailsHelpers
-  module ClassMethods
-    def using_protected_attributes?
-      ActiveRecord::VERSION::MAJOR < 4
-    end
-  end
-end


### PR DESCRIPTION
Since support for Rails 3.2 was removed (https://github.com/thoughtbot/paperclip/pull/2074), those specs are not more needed