### PR TITLE
Add deprecation warnings for aws-sdk < 2 and active record < 4.2

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -56,6 +56,7 @@ require 'paperclip/has_attached_file'
 require 'paperclip/attachment_registry'
 require 'paperclip/filename_cleaner'
 require 'paperclip/rails_environment'
+require "paperclip/deprecations"
 
 begin
   # Use mime/types/columnar if available, for reduced memory usage
@@ -191,6 +192,7 @@ module Paperclip
     #     end
     #   end
     def has_attached_file(name, options = {})
+      Paperclip::Deprecations.check
       HasAttachedFile.define_on(self, name, options)
     end
   end

--- a/lib/paperclip/deprecations.rb
+++ b/lib/paperclip/deprecations.rb
@@ -19,15 +19,19 @@ module Paperclip
       end
 
       def warn_aws_sdk_v1
-        ActiveSupport::Deprecation.warn "[paperclip] [deprecation] AWS SDK v1 has been deprecated in paperclip 5. Please consider upgrading to AWS 2 before upgrading paperclip."
+        warn "[paperclip] [deprecation] AWS SDK v1 has been deprecated in paperclip 5. Please consider upgrading to AWS 2 before upgrading paperclip."
       end
 
       def warn_outdated_rails
-        ActiveSupport::Deprecation.warn "[paperclip] [deprecation] Rails 3.2 and 4.1 are unsupported as of Rails 5 release. Please upgrade to Rails 5 before upgrading paperclip."
+        warn "[paperclip] [deprecation] Rails 3.2 and 4.1 are unsupported as of Rails 5 release. Please upgrade to Rails 4.2 before upgrading paperclip."
       end
 
       def aws_sdk_version
         ::Aws::VERSION
+      end
+
+      def warn(message)
+        ActiveSupport::Deprecation.warn(message)
       end
     end
   end

--- a/lib/paperclip/deprecations.rb
+++ b/lib/paperclip/deprecations.rb
@@ -19,11 +19,15 @@ module Paperclip
       end
 
       def warn_aws_sdk_v1
-        warn "[paperclip] [deprecation] AWS SDK v1 has been deprecated in paperclip 5. Please consider upgrading to AWS 2 before upgrading paperclip."
+        warn "[paperclip] [deprecation] AWS SDK v1 has been deprecated in " \
+             "paperclip 5. Please consider upgrading to AWS 2 before " \
+             "upgrading paperclip."
       end
 
       def warn_outdated_rails
-        warn "[paperclip] [deprecation] Rails 3.2 and 4.1 are unsupported as of Rails 5 release. Please upgrade to Rails 4.2 before upgrading paperclip."
+        warn "[paperclip] [deprecation] Rails 3.2 and 4.1 are unsupported as " \
+             "of Rails 5 release. Please upgrade to Rails 4.2 before " \
+             "upgrading paperclip."
       end
 
       def aws_sdk_version

--- a/lib/paperclip/deprecations.rb
+++ b/lib/paperclip/deprecations.rb
@@ -1,0 +1,34 @@
+require "active_support/deprecation"
+
+module Paperclip
+  class Deprecations
+    class << self
+      def check
+        warn_aws_sdk_v1 if aws_sdk_v1?
+        warn_outdated_rails if active_record_version < "4.2"
+      end
+
+      private
+
+      def active_record_version
+        ::ActiveRecord::VERSION::STRING
+      end
+
+      def aws_sdk_v1?
+        defined?(::Aws) && aws_sdk_version < "2"
+      end
+
+      def warn_aws_sdk_v1
+        ActiveSupport::Deprecation.warn "[paperclip] [deprecation] AWS SDK v1 has been deprecated in paperclip 5. Please consider upgrading to AWS 2 before upgrading paperclip."
+      end
+
+      def warn_outdated_rails
+        ActiveSupport::Deprecation.warn "[paperclip] [deprecation] Rails 3.2 and 4.1 are unsupported as of Rails 5 release. Please upgrade to Rails 5 before upgrading paperclip."
+      end
+
+      def aws_sdk_version
+        ::Aws::VERSION
+      end
+    end
+  end
+end

--- a/spec/paperclip/deprecations_spec.rb
+++ b/spec/paperclip/deprecations_spec.rb
@@ -1,0 +1,61 @@
+require "spec_helper"
+require "aws-sdk"
+require "active_support/testing/deprecation"
+
+describe Paperclip::Deprecations do
+  include ActiveSupport::Testing::Deprecation
+
+  describe ".check" do
+    before do
+      ActiveSupport::Deprecation.silenced = false
+    end
+
+    context "when active record version is < 4.2" do
+      it "displays deprecation warning" do
+        Paperclip::Deprecations.stubs(:active_record_version).returns("4.1")
+
+        assert_deprecated("Rails 3.2 and 4.1 are unsupported") do
+          Paperclip::Deprecations.check
+        end
+      end
+    end
+
+    context "when active record version is 4.2" do
+      it "do not display deprecation warning" do
+        Paperclip::Deprecations.stubs(:active_record_version).returns("4.2")
+
+        assert_not_deprecated do
+          Paperclip::Deprecations.check
+        end
+      end
+    end
+
+    context "when aws sdk version is < 2" do
+      before do
+        ::AWS.stub! if !defined?(::Aws)
+      end
+
+      it "displays deprecation warning" do
+        Paperclip::Deprecations.stubs(:aws_sdk_version).returns("1.66.0")
+
+        assert_deprecated("AWS SDK v1 has been deprecated") do
+          Paperclip::Deprecations.check
+        end
+      end
+    end
+
+    context "when aws sdk version is 2" do
+      before do
+        ::AWS.stub! if !defined?(::Aws)
+      end
+
+      it "do not display deprecation warning" do
+        Paperclip::Deprecations.stubs(:aws_sdk_version).returns("2.0.0")
+
+        assert_not_deprecated do
+          Paperclip::Deprecations.check
+        end
+      end
+    end
+  end
+end

--- a/spec/paperclip/paperclip_spec.rb
+++ b/spec/paperclip/paperclip_spec.rb
@@ -109,6 +109,7 @@ describe Paperclip do
 
   context "An ActiveRecord model with an 'avatar' attachment" do
     before do
+      Paperclip::Deprecations.stubs(:check)
       rebuild_model path: "tmp/:class/omg/:style.:extension"
       @file = File.new(fixture_file("5k.png"), 'rb')
     end
@@ -121,6 +122,10 @@ describe Paperclip do
           has_attached_file :blah
         end
       end
+    end
+
+    it "calls Paperclip::Deprecations.check" do
+      expect(Paperclip::Deprecations).to have_received(:check)
     end
 
     if using_protected_attributes?


### PR DESCRIPTION
Related to #2049, this commit
* Adds a deprecation warning if the user is still on aws-sdk v1
* Adds a deprecation warning if the user is still on Rails 3.2.x, say 3.2.x support will be dropped in v5.0.0