### PR TITLE
Don't log all content types

### DIFF
--- a/lib/paperclip/media_type_spoof_detector.rb
+++ b/lib/paperclip/media_type_spoof_detector.rb
@@ -12,7 +12,7 @@ module Paperclip
 
     def spoofed?
       if has_name? && has_extension? && media_type_mismatch? && mapping_override_mismatch?
-        Paperclip.log("Content Type Spoof: Filename #{File.basename(@name)} (#{supplied_content_type} from Headers, #{content_types_from_name.map(&:to_s)} from Extension), content type discovered from file command: #{calculated_content_type}. See documentation to allow this combination.")
+        Paperclip.log("Content Type Spoof: Filename #{File.basename(@name)} (#{supplied_content_type} from Headers), content type discovered from file command: #{calculated_content_type}. See documentation to allow this combination.")
         true
       else
         false


### PR DESCRIPTION
When content type spoofing is detected Paperclip dumps all known content types to a log file creating an 1.8Mb entry there https://gist.github.com/anonymous/d04fb1f1c91c7eb7f9bd