### PR TITLE
Check ActiveModel instead of ActiveRecord for deprecations

### DIFF
--- a/lib/paperclip/deprecations.rb
+++ b/lib/paperclip/deprecations.rb
@@ -5,13 +5,13 @@ module Paperclip
     class << self
       def check
         warn_aws_sdk_v1 if aws_sdk_v1?
-        warn_outdated_rails if active_record_version < "4.2"
+        warn_outdated_rails if active_model_version < "4.2"
       end
 
       private
 
-      def active_record_version
-        ::ActiveRecord::VERSION::STRING
+      def active_model_version
+        ::ActiveModel::VERSION::STRING
       end
 
       def aws_sdk_v1?

--- a/spec/paperclip/deprecations_spec.rb
+++ b/spec/paperclip/deprecations_spec.rb
@@ -14,9 +14,9 @@ describe Paperclip::Deprecations do
       ActiveSupport::Deprecation.silenced = true
     end
 
-    context "when active record version is < 4.2" do
+    context "when active model version is < 4.2" do
       it "displays deprecation warning" do
-        Paperclip::Deprecations.stubs(:active_record_version).returns("4.1")
+        Paperclip::Deprecations.stubs(:active_model_version).returns("4.1")
 
         assert_deprecated("Rails 3.2 and 4.1 are unsupported") do
           Paperclip::Deprecations.check
@@ -24,9 +24,9 @@ describe Paperclip::Deprecations do
       end
     end
 
-    context "when active record version is 4.2" do
+    context "when active model version is 4.2" do
       it "do not display deprecation warning" do
-        Paperclip::Deprecations.stubs(:active_record_version).returns("4.2")
+        Paperclip::Deprecations.stubs(:active_model_version).returns("4.2")
 
         assert_not_deprecated do
           Paperclip::Deprecations.check

--- a/spec/support/deprecations.rb
+++ b/spec/support/deprecations.rb
@@ -3,7 +3,7 @@ RSpec.configure do |config|
     ActiveSupport::Deprecation.silenced = true
   end
   config.before(:each) do
-    Paperclip::Deprecations.stubs(:active_record_version).returns("4.2")
+    Paperclip::Deprecations.stubs(:active_model_version).returns("4.2")
     Paperclip::Deprecations.stubs(:aws_sdk_version).returns("2.0.0")
   end
 end


### PR DESCRIPTION
As @kt0 noticed in #2098, my commit https://github.com/thoughtbot/paperclip/commit/2e6335532ac24012cf473b60994d09f14952b891 broke  compatibility for non ActiveRecord user.
Checking ActiveModel version instead of ActiveRecord fixes this since it's a paperclip dependency