### PR TITLE
Fix incorect values for `attachment_content_type` and `attachment_file_name` in some case

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -464,6 +464,14 @@ module Paperclip
     end
 
     def reset_file_if_original_reprocessed
+      new_file_name = File.basename(@file.original_filename, ".*".freeze)
+      if (extension = ".#{interpolator.extension(self, :original)}")
+        new_file_name << extension
+      end
+      instance_write(:file_name, cleanup_filename(new_file_name))
+      instance_write(
+        :content_type, @queued_for_write[:original].content_type.to_s.strip
+      )
       instance_write(:file_size, @queued_for_write[:original].size)
       assign_fingerprint { @queued_for_write[:original].fingerprint }
       reset_updater

--- a/spec/paperclip/attachment_spec.rb
+++ b/spec/paperclip/attachment_spec.rb
@@ -423,6 +423,27 @@ describe Paperclip::Attachment do
     end
   end
 
+  context "An attachment with an extension interpolation on the original style" do
+    before do
+      rebuild_model path: ":basename.:extension",
+        styles: { original: ["100x100", :jpg] },
+        default_style: :default
+      @attachment = Dummy.new.avatar
+      @file = File.open(fixture_file("5k.png"))
+      @file.stubs(:original_filename).returns("file.png")
+    end
+
+    it "returns the right extension for the filename" do
+      @attachment.assign(@file)
+      assert_equal "file.jpg", @attachment.original_filename
+    end
+
+    it "returns the right mime type" do
+      @attachment.assign(@file)
+      assert_equal "image/jpeg", @attachment.content_type
+    end
+  end
+
   context "An attachment with :convert_options" do
     before do
       rebuild_model styles: {


### PR DESCRIPTION
Fix the 'file_name' and 'mime_type' attributes for attachments with an extension interpolation on the original style.

See issue https://github.com/thoughtbot/paperclip/issues/1665.