### PR TITLE
Backport fix for excessive logging from media type spoof detector 

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,5 @@
+* Bug Fix: megabytes of mime-types info in logs when a spoofed media type is detected.
+
 4.3.5 (2/8/2016):
 * Bug Fix: Remove deprecation warnings for v5.0 for now. Will re-add once the version has landed.
 

--- a/lib/paperclip/media_type_spoof_detector.rb
+++ b/lib/paperclip/media_type_spoof_detector.rb
@@ -12,7 +12,7 @@ module Paperclip
 
     def spoofed?
       if has_name? && has_extension? && media_type_mismatch? && mapping_override_mismatch?
-        Paperclip.log("Content Type Spoof: Filename #{File.basename(@name)} (#{supplied_content_type} from Headers, #{content_types_from_name} from Extension), content type discovered from file command: #{calculated_content_type}. See documentation to allow this combination.")
+        Paperclip.log("Content Type Spoof: Filename #{File.basename(@name)} (#{supplied_content_type} from Headers, #{content_types_from_name.map(&:to_s)} from Extension), content type discovered from file command: #{calculated_content_type}. See documentation to allow this combination.")
         true
       else
         false

--- a/spec/paperclip/media_type_spoof_detector_spec.rb
+++ b/spec/paperclip/media_type_spoof_detector_spec.rb
@@ -44,9 +44,18 @@ describe Paperclip::MediaTypeSpoofDetector do
     end
   end
 
-  it "rejects a file if named .html and is as HTML, but we're told JPG" do
-    file = File.open(fixture_file("empty.html"))
-    assert Paperclip::MediaTypeSpoofDetector.using(file, "empty.html", "image/jpg").spoofed?
+  context "file named .html and is as HTML, but we're told JPG" do
+    let(:file) { File.open(fixture_file("empty.html")) }
+    let(:spoofed?) { Paperclip::MediaTypeSpoofDetector.using(file, "empty.html", "image/jpg").spoofed? }
+
+    it "rejects the file" do
+      assert spoofed?
+    end
+
+    it "logs info about the detected spoof" do
+      Paperclip.expects(:log).with('Content Type Spoof: Filename empty.html (image/jpg from Headers, ["text/html"] from Extension), content type discovered from file command: text/html. See documentation to allow this combination.')
+      spoofed?
+    end
   end
 
   it "does not reject if content_type is empty but otherwise checks out" do


### PR DESCRIPTION
Backport 8339e0f (#2017) to 4.3 to prevent excessive logging, which [might be abused](https://cwe.mitre.org/data/definitions/779.html). Fixes #2125. 

Please release 4.3.6 as soon as possible to prevent abuse.