### PR TITLE
Add fog_options to configuration that can be passed to the fog

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,5 @@
+* Improvement: Add `fog_options` configuration to send options to fog when storing files.
+
 4.3.6 (3/13/2016):
 
 * Bug Fix: When a spoofed media type is detected, megabytes of mime-types info are added to logs. See https://cwe.mitre.org/data/definitions/779.html.

--- a/spec/paperclip/storage/fog_spec.rb
+++ b/spec/paperclip/storage/fog_spec.rb
@@ -484,6 +484,25 @@ describe Paperclip::Storage::Fog do
           assert_equal @dummy.avatar.fog_credentials, @dynamic_fog_credentials
         end
       end
+
+      context "with custom fog_options" do
+        before do
+          rebuild_model(
+            @options.merge(fog_options: { multipart_chunk_size: 104857600 }),
+          )
+          @dummy = Dummy.new
+          @dummy.avatar = @file
+        end
+
+        it "applies the options to the fog #create call" do
+          files = stub
+          @dummy.avatar.stubs(:directory).returns stub(files: files)
+          files.expects(:create).with(
+            has_entries(multipart_chunk_size: 104857600),
+          )
+          @dummy.save
+        end
+      end
     end
 
   end


### PR DESCRIPTION
We found that uploading large files to S3 would result in a socket error ("connection reset by peer") occasionally and lately much more consistently. In researching this I saw that many people got this error when uploading too large of a file without multipart chunking. I would have assumed fog did this automatically but the default chunk size may be too high. In order to address this I wanted to drop the chunk size to 100MB.

Rather than hard-code this I opted to expose a `fog_option` configuration option that lets me pass any additional options I want to the fog's `#create` call. This is similar to the `fog_attributes` option implemented in CarrierWave which [addresses the same problem](http://stackoverflow.com/a/11867978/201911).

We've been running this now for a week in production and it seems to resolve the issue.