### PR TITLE
close+unlink leaking tempfiles + add specs to prevent regression

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -523,6 +523,10 @@ module Paperclip
         @queued_for_write[name] = style.processors.inject(@queued_for_write[:original]) do |file, processor|
           file = Paperclip.processor(processor).make(file, style.processor_options, self)
           intermediate_files << file unless file == @queued_for_write[:original]
+          # if we're processing the original, close + unlink the source tempfile
+          if name == :original
+            @queued_for_write[:original].close(true)
+          end
           file
         end
 

--- a/lib/paperclip/io_adapters/abstract_adapter.rb
+++ b/lib/paperclip/io_adapters/abstract_adapter.rb
@@ -4,7 +4,7 @@ module Paperclip
   class AbstractAdapter
     OS_RESTRICTED_CHARACTERS = %r{[/:]}
 
-    attr_reader :content_type, :original_filename, :size
+    attr_reader :content_type, :original_filename, :size, :tempfile
     delegate :binmode, :binmode?, :close, :close!, :closed?, :eof?, :path, :rewind, :unlink, :to => :@tempfile
     alias :length :size
 

--- a/lib/paperclip/io_adapters/attachment_adapter.rb
+++ b/lib/paperclip/io_adapters/attachment_adapter.rb
@@ -24,7 +24,13 @@ module Paperclip
       if source.staged?
         FileUtils.cp(source.staged_path(@style), destination.path)
       else
-        source.copy_to_local_file(@style, destination.path)
+        begin
+          source.copy_to_local_file(@style, destination.path)
+        rescue Errno::EACCES => e
+          # clean up lingering tempfile if we cannot access source file
+          destination.close(true)
+          raise
+        end
       end
       destination
     end

--- a/lib/paperclip/validators/media_type_spoof_detection_validator.rb
+++ b/lib/paperclip/validators/media_type_spoof_detection_validator.rb
@@ -8,6 +8,7 @@ module Paperclip
         if Paperclip::MediaTypeSpoofDetector.using(adapter, value.original_filename, value.content_type).spoofed?
           record.errors.add(attribute, :spoofed_media_type)
         end
+        adapter.tempfile.close(true) if adapter.tempfile
       end
     end
 

--- a/spec/paperclip/integration_spec.rb
+++ b/spec/paperclip/integration_spec.rb
@@ -3,14 +3,25 @@ require 'spec_helper'
 require 'open-uri'
 
 describe 'Paperclip' do
+  around do |example|
+    files, files2 = nil, nil
+    files = ObjectSpace.each_object(Tempfile).select{|x| x.path && File.file?(x.path)}
+    example.run
+    files2 = ObjectSpace.each_object(Tempfile).select{|x| x.path && File.file?(x.path)}
+    diff = files2-files
+    expect(diff).to eq([]), "Leaked tempfiles: #{diff.inspect}"
+  end
+
   context "Many models at once" do
     before do
       rebuild_model
       @file = File.new(fixture_file("5k.png"), 'rb')
       # Deals with `Too many open files` error
-      Dummy.import 100.times.map { Dummy.new avatar: @file }
-      Dummy.import 100.times.map { Dummy.new avatar: @file }
-      Dummy.import 100.times.map { Dummy.new avatar: @file }
+      dummies = 300.times.map { Dummy.new avatar: @file }
+      Dummy.import dummies
+      # save attachment instances to run after hooks including tempfile cleanup
+      # since activerecord-import does not use our usually hooked-in hooks (such as after_save)
+      dummies.each{|d| d.avatar.save }
     end
 
     after { @file.close }
@@ -159,7 +170,11 @@ describe 'Paperclip' do
       assert_not_equal File.size(@file.path), @dummy.avatar.size
     end
 
-    after { @file.close }
+    after do
+      @file.close
+      # save attachment instance to run after hooks (including tempfile cleanup)
+      @dummy.avatar.save
+    end
   end
 
   context "A model with attachments scoped under an id" do
@@ -347,6 +362,8 @@ describe 'Paperclip' do
     it "is not ok with bad files" do
       @dummy.avatar = @bad_file
       assert ! @dummy.valid?
+      # save attachment instance to run after hooks (including tempfile cleanup)
+      @dummy.avatar.save
     end
 
     it "knows the difference between good files, bad files, and not files when validating" do
@@ -354,8 +371,13 @@ describe 'Paperclip' do
       @d2 = Dummy.find(@dummy.id)
       @d2.avatar = @file
       assert  @d2.valid?, @d2.errors.full_messages.inspect
+      # save attachment instance to run after hooks (including tempfile cleanup)
+      @d2.avatar.save
+
       @d2.avatar = @bad_file
       assert ! @d2.valid?
+      # save attachment instance to run after hooks (including tempfile cleanup)
+      @d2.avatar.save
     end
 
     it "is able to reload without saving and not have the file disappear" do


### PR DESCRIPTION
This fixes at least some of lingering issues reported in #1326 ; I'll need to run this through some testing in production to see if there's any breakages outside of what the specs cover.

In the meanwhile would appreciate if anyone has any comments or suggestions.