### PR TITLE
Remove Rails 3 snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,18 +189,6 @@ Quick Start
 
 ### Models
 
-**Rails 3**
-
-```ruby
-class User < ActiveRecord::Base
-  attr_accessible :avatar
-  has_attached_file :avatar, styles: { medium: "300x300>", thumb: "100x100>" }, default_url: "/images/:style/missing.png"
-  validates_attachment_content_type :avatar, content_type: /\Aimage\/.*\Z/
-end
-```
-
-**Rails 4**
-
 ```ruby
 class User < ActiveRecord::Base
   has_attached_file :avatar, styles: { medium: "300x300>", thumb: "100x100>" }, default_url: "/images/:style/missing.png"
@@ -240,16 +228,6 @@ end
 ```
 
 ### Controller
-
-**Rails 3**
-
-```ruby
-def create
-  @user = User.create( params[:user] )
-end
-```
-
-**Rails 4**
 
 ```ruby
 def create

--- a/features/migration.feature
+++ b/features/migration.feature
@@ -68,27 +68,3 @@ Feature: Migration
 
     When I rollback a migration
     Then I should not have attachment columns for "avatar"
-
-  Scenario: Rails 3.2 change method
-    Given I am using Rails newer than 3.1
-    When I write to "db/migrate/01_create_users.rb" with:
-      """
-      class CreateUsers < ActiveRecord::Migration
-        def self.up
-          create_table :users
-        end
-      end
-      """
-    When I write to "db/migrate/02_add_attachment_to_users.rb" with:
-      """
-      class AddAttachmentToUsers < ActiveRecord::Migration
-        def change
-          add_attachment :users, :avatar
-        end
-      end
-      """
-    And I run a migration
-    Then I should have attachment columns for "avatar"
-
-    When I rollback a migration
-    Then I should not have attachment columns for "avatar"

--- a/features/step_definitions/rails_steps.rb
+++ b/features/step_definitions/rails_steps.rb
@@ -190,12 +190,6 @@ When /^I comment out the gem "([^"]*)" from the Gemfile$/ do |gemname|
   comment_out_gem_in_gemfile gemname
 end
 
-Given /^I am using Rails newer than ([\d\.]+)$/ do |version|
-  if framework_version < version
-    pending "Not supported in Rails < #{version}"
-  end
-end
-
 Given(/^I add a "(.*?)" processor in "(.*?)"$/) do |processor, directory|
   filename = "#{directory}/#{processor}.rb"
   cd(".") do

--- a/lib/paperclip/schema.rb
+++ b/lib/paperclip/schema.rb
@@ -12,10 +12,7 @@ module Paperclip
       ActiveRecord::ConnectionAdapters::Table.send :include, TableDefinition
       ActiveRecord::ConnectionAdapters::TableDefinition.send :include, TableDefinition
       ActiveRecord::ConnectionAdapters::AbstractAdapter.send :include, Statements
-
-      if defined?(ActiveRecord::Migration::CommandRecorder) # Rails 3.1+
-        ActiveRecord::Migration::CommandRecorder.send :include, CommandRecorder
-      end
+      ActiveRecord::Migration::CommandRecorder.send :include, CommandRecorder
     end
 
     module Statements
@@ -34,8 +31,6 @@ module Paperclip
 
       def remove_attachment(table_name, *attachment_names)
         raise ArgumentError, "Please specify attachment name in your remove_attachment call in your migration." if attachment_names.empty?
-
-        options = attachment_names.extract_options!
 
         attachment_names.each do |attachment_name|
           COLUMNS.keys.each do |column_name|

--- a/spec/paperclip/attachment_spec.rb
+++ b/spec/paperclip/attachment_spec.rb
@@ -222,9 +222,6 @@ describe Paperclip::Attachment do
     dummy.avatar_file_name = "fake.jpg"
     dummy.stubs(:new_record?).returns(false)
     expected_string = '{"avatar":"/system/dummies/avatars/000/001/234/original/fake.jpg"}'
-    if ActiveRecord::Base.include_root_in_json # This is true by default in Rails 3, and false in 4
-      expected_string = %({"dummy":#{expected_string}})
-    end
     # active_model pre-3.2 checks only by calling any? on it, thus it doesn't work if it is empty
     assert_equal expected_string, dummy.to_json(only: [:dummy_key_for_old_active_model], methods: [:avatar])
   end


### PR DESCRIPTION
Rails 3 is not supported anymore. We can safely remove mentions and
snippets for it.