### PR TITLE
README update (AWS SDK version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,15 +572,12 @@ You may also choose to store your files using Amazon's S3 service. To do so, inc
 the `aws-sdk` gem in your Gemfile:
 
 ```ruby
-gem 'aws-sdk', '>= 2.0.0' # If using paperclip `master` (upcoming v5.0)
+gem 'aws-sdk', '>= 2.0.34'
 ```
 
 And then you can specify using S3 from `has_attached_file`.
 You can find more information about configuring and using S3 storage in
 [the `Paperclip::Storage::S3` documentation](http://www.rubydoc.info/gems/paperclip/Paperclip/Storage/S3).
-
-_**NOTE**: If upgrading aws-sdk from v1.x to v2.x, be sure to read the
-[UPGRADING guide](https://github.com/thoughtbot/paperclip/blob/master/UPGRADING)._
 
 Files on the local filesystem (and in the Rails app's public directory) will be
 available to the internet at large. If you require access control, it's

--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -121,6 +121,10 @@ module Paperclip
           e.message << " (You may need to install the aws-sdk gem)"
           raise e
         end
+        if Gem::Version.new(Aws::VERSION) >= Gem::Version.new(2) &&
+           Gem::Version.new(Aws::VERSION) <= Gem::Version.new("2.0.33")
+          raise LoadError, "paperclip does not support aws-sdk versions 2.0.0 - 2.0.33.  Please upgrade aws-sdk to a newer version."
+        end
 
         # Overriding log formatter to make sure it return a UTF-8 string
         if defined?(::Aws::Core::LogFormatter)


### PR DESCRIPTION
Brings back warning on not supported SDK versions.

Related: https://github.com/thoughtbot/paperclip/commit/25be0b25d67923e28419c6146e8f8307741a974b#commitcomment-16831800