### PR TITLE
allow user to specify frame_index for generating thumbnails from videos or pdfs

### DIFF
--- a/lib/paperclip/thumbnail.rb
+++ b/lib/paperclip/thumbnail.rb
@@ -77,7 +77,11 @@ module Paperclip
 
         parameters = parameters.flatten.compact.join(" ").strip.squeeze(" ")
 
-        success = convert(parameters, :source => "#{File.expand_path(src.path)}#{'[' + @frame_index.to_s + ']' unless animated?}", :dest => File.expand_path(dst.path))
+        success = convert(parameters, 
+          :source => "#{File.expand_path(src.path)}#{'[' + @frame_index.to_s + ']' unless animated?}", 
+          :dest => File.expand_path(dst.path)
+          )
+          
       rescue Cocaine::ExitStatusError => e
         raise Paperclip::Error, "There was an error processing the thumbnail for #{@basename}" if @whiny
       rescue Cocaine::CommandNotFoundError => e

--- a/lib/paperclip/thumbnail.rb
+++ b/lib/paperclip/thumbnail.rb
@@ -42,7 +42,7 @@ module Paperclip
       if @auto_orient && @current_geometry.respond_to?(:auto_orient)
         @current_geometry.auto_orient
       end
-
+      
       @source_file_options = @source_file_options.split(/\s+/) if @source_file_options.respond_to?(:split)
       @convert_options     = @convert_options.split(/\s+/)     if @convert_options.respond_to?(:split)
 

--- a/lib/paperclip/thumbnail.rb
+++ b/lib/paperclip/thumbnail.rb
@@ -42,7 +42,6 @@ module Paperclip
       if @auto_orient && @current_geometry.respond_to?(:auto_orient)
         @current_geometry.auto_orient
       end
-      
       @source_file_options = @source_file_options.split(/\s+/) if @source_file_options.respond_to?(:split)
       @convert_options     = @convert_options.split(/\s+/)     if @convert_options.respond_to?(:split)
 
@@ -78,10 +77,9 @@ module Paperclip
         parameters = parameters.flatten.compact.join(" ").strip.squeeze(" ")
 
         success = convert(parameters, 
-          :source => "#{File.expand_path(src.path)}#{'[' + @frame_index.to_s + ']' unless animated?}", 
-          :dest => File.expand_path(dst.path)
-          )
-          
+                          :source => "#{File.expand_path(src.path)}#{'[' + @frame_index.to_s + ']' unless animated?}", 
+                          :dest => File.expand_path(dst.path),
+                          )
       rescue Cocaine::ExitStatusError => e
         raise Paperclip::Error, "There was an error processing the thumbnail for #{@basename}" if @whiny
       rescue Cocaine::CommandNotFoundError => e

--- a/lib/paperclip/thumbnail.rb
+++ b/lib/paperclip/thumbnail.rb
@@ -5,13 +5,12 @@ module Paperclip
     attr_accessor :current_geometry, :target_geometry, :format, :whiny, :convert_options,
                   :source_file_options, :animated, :auto_orient, :frame_index
 
-    #List of multi frame formats to check against the source file type
-    #this is not an exhaustive list, should be updated to include more formats
-    MULTI_FRAME_FORMATS = %w(mkv avi mp4 mov mpg mpeg gif) 
+    # List of multi frame formats to check against the source file type
+    # this is not an exhaustive list, should be updated to include more formats
+    MULTI_FRAME_FORMATS = %w(mkv avi mp4 mov mpg mpeg gif)
     
     # List of formats that we need to preserve animation
     ANIMATED_FORMATS = %w(gif)
-
 
     # Creates a Thumbnail object set to work on the +file+ given. It
     # will attempt to transform the image into one defined by +target_geometry+
@@ -87,7 +86,7 @@ module Paperclip
         parameters = parameters.flatten.compact.join(" ").strip.squeeze(" ")
         
         desired_frame = animated? ? "" : "[#{@frame_index.to_s}]"
-        success = convert(parameters, 
+        success = convert(parameters,
                           :source => "#{File.expand_path(src.path)}#{desired_frame}",
                           :dest => File.expand_path(dst.path),
                           )
@@ -117,14 +116,14 @@ module Paperclip
 
     # Return true if the source file format is animated
     def multi_frame_format?
-      #removing the leading . from the extension
+      # removing the leading . from the extension
       ext = @current_format.to_s[1..@current_format.length]
       MULTI_FRAME_FORMATS.include?(ext)
     end
     
     # Return true if the format is animated
     def animated?
-      @animated && (ANIMATED_FORMATS.include?(@format.to_s) || @format.blank?)  && identified_as_animated?
+      @animated && (ANIMATED_FORMATS.include?(@format.to_s) || @format.blank?) && identified_as_animated?
     end
 
     # Return true if ImageMagick's +identify+ returns an animated format

--- a/lib/paperclip/thumbnail.rb
+++ b/lib/paperclip/thumbnail.rb
@@ -36,14 +36,12 @@ module Paperclip
       @convert_options     = options[:convert_options]
       @whiny               = options.fetch(:whiny, true)
       @format              = options[:format]
-      @frame_index         = options[:frame_index]
+      @frame_index         = options.fetch(:frame_index, 0)
       @animated            = options.fetch(:animated, true)
       @auto_orient         = options.fetch(:auto_orient, true)
       if @auto_orient && @current_geometry.respond_to?(:auto_orient)
         @current_geometry.auto_orient
       end
-      
-      @frame_index ||= 0
 
       @source_file_options = @source_file_options.split(/\s+/) if @source_file_options.respond_to?(:split)
       @convert_options     = @convert_options.split(/\s+/)     if @convert_options.respond_to?(:split)
@@ -79,7 +77,7 @@ module Paperclip
 
         parameters = parameters.flatten.compact.join(" ").strip.squeeze(" ")
 
-        success = convert(parameters, :source => "#{File.expand_path(src.path)}#{'['+@frame_index.to_s+']' unless animated?}", :dest => File.expand_path(dst.path))
+        success = convert(parameters, :source => "#{File.expand_path(src.path)}#{'[' + @frame_index.to_s + ']' unless animated?}", :dest => File.expand_path(dst.path))
       rescue Cocaine::ExitStatusError => e
         raise Paperclip::Error, "There was an error processing the thumbnail for #{@basename}" if @whiny
       rescue Cocaine::CommandNotFoundError => e
@@ -112,7 +110,7 @@ module Paperclip
     # Return true if ImageMagick's +identify+ returns an animated format
     def identified_as_animated?
       if @identified_as_animated.nil?
-        @identified_as_animated = ANIMATED_FORMATS.include? identify("-format %m :file", :file => "#{@file.path}[#{@frame_index.to_s}]").to_s.downcase.strip
+        @identified_as_animated = ANIMATED_FORMATS.include? identify("-format %m :file", :file => "#{@file.path}[0]").to_s.downcase.strip
       end
       @identified_as_animated
     rescue Cocaine::ExitStatusError => e

--- a/spec/paperclip/thumbnail_spec.rb
+++ b/spec/paperclip/thumbnail_spec.rb
@@ -483,18 +483,24 @@ describe Paperclip::Thumbnail do
     
     context "with a specified frame_index" do
       before do
-        @thumb = Paperclip::Thumbnail.new(@file, geometry: "50x50", frame_index: 5, format: :jpg)
+        @thumb = Paperclip::Thumbnail.new(@file,geometry: "50x50",
+                                          frame_index: 5,
+                                          format: :jpg,
+                                          )
       end
 
-      it "creates the single frame thumbnail with the specified frame index when sent #make" do
-        dst = @thumb.make
+      it "creates the thumbnail from the frame index when sent #make" do
+        @thumb.make
         assert_equal @thumb.frame_index, 5
       end
     end
     
     context "with a specified frame_index out of bounds" do
       before do
-        @thumb = Paperclip::Thumbnail.new(@file, geometry: "50x50", frame_index: 20, format: :jpg)
+        @thumb = Paperclip::Thumbnail.new(@file, geometry: "50x50", 
+                                          frame_index: 20,
+                                          format: :jpg,
+                                          )
       end
       
       it "errors when trying to create the thumbnail" do
@@ -522,5 +528,4 @@ describe Paperclip::Thumbnail do
       expect { thumb.make }.to_not raise_error
     end
   end
-
 end

--- a/spec/paperclip/thumbnail_spec.rb
+++ b/spec/paperclip/thumbnail_spec.rb
@@ -480,6 +480,31 @@ describe Paperclip::Thumbnail do
         assert_equal "50x50", `#{cmd}`.chomp
       end
     end
+    
+    context "with a specified frame_index" do
+      before do
+        @thumb = Paperclip::Thumbnail.new(@file, geometry: "50x50", frame_index: 5, format: :jpg)
+      end
+
+      it "creates the single frame thumbnail with the specified frame index when sent #make" do
+        dst = @thumb.make
+        assert_equal @thumb.frame_index, 5
+      end
+    end
+    
+    context "with a specified frame_index out of bounds" do
+      before do
+        @thumb = Paperclip::Thumbnail.new(@file, geometry: "50x50", frame_index: 20, format: :jpg)
+      end
+      
+      it "errors when trying to create the thumbnail" do
+        assert_raises(Paperclip::Error) do
+          silence_stream(STDERR) do
+            @thumb.make
+          end
+        end
+      end
+    end
   end
 
   context "with a really long file name" do
@@ -497,4 +522,5 @@ describe Paperclip::Thumbnail do
       expect { thumb.make }.to_not raise_error
     end
   end
+
 end

--- a/spec/paperclip/thumbnail_spec.rb
+++ b/spec/paperclip/thumbnail_spec.rb
@@ -483,7 +483,8 @@ describe Paperclip::Thumbnail do
     
     context "with a specified frame_index" do
       before do
-        @thumb = Paperclip::Thumbnail.new(@file,geometry: "50x50",
+        @thumb = Paperclip::Thumbnail.new(@file,
+                                          geometry: "50x50",
                                           frame_index: 5,
                                           format: :jpg,
                                           )
@@ -497,7 +498,8 @@ describe Paperclip::Thumbnail do
     
     context "with a specified frame_index out of bounds" do
       before do
-        @thumb = Paperclip::Thumbnail.new(@file, geometry: "50x50", 
+        @thumb = Paperclip::Thumbnail.new(@file,
+                                          geometry: "50x50",
                                           frame_index: 20,
                                           format: :jpg,
                                           )


### PR DESCRIPTION
add optional parameter in style options to specify a frame_index to use for generating thumbnails from videos or pdfs.  If no value is set, it will default to 0 to maintain default paperclip functionality. 