### PR TITLE
Add link to walkthrough of upgrading from 4 to 5.

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -12,3 +12,5 @@ changes:
   note that the format of the permissions changed from using an underscore to
   using a hyphen. For example, `:public_read` needs to be changed to
   `public-read`.
+
+For a walkthrough of upgrading from 4 to 5 and aws-sdk >= 2.0.0, watch http://rubythursday.com/episodes/ruby-snack-27-upgrade-paperclip-and-aws-sdk-in-prep-for-rails-5


### PR DESCRIPTION
This PR adds a link to a video walkthrough of upgrading from v4 to v5 and includes upgrading to use aws-sdk >= 2.0.0.