### PR TITLE
Improve deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ https://github.com/thoughtbot/paperclip/releases
   - [Dynamic Processors](#dynamic-processors)
 - [Logging](#logging)
 - [Deployment](#deployment)
+  - [Attachment Styles] (#attachment-styles)
 - [Testing](#testing)
 - [Contributing](#contributing)
 - [License](#license)
@@ -559,7 +560,7 @@ The files that are assigned as attachments are, by default, placed in the
 directory specified by the `:path` option to `has_attached_file`. By default, this
 location is `:rails_root/public/system/:class/:attachment/:id_partition/:style/:filename`.
 This location was chosen because, on standard Capistrano deployments, the
-`public/system` directory is symlinked to the app's shared directory, meaning it
+`public/system` directory used to be symlinked to the app's shared directory, meaning it
 will survive between deployments. For example, using that `:path`, you may have a
 file at
 
@@ -820,6 +821,13 @@ More information in the [rdocs](http://www.rubydoc.info/github/thoughtbot/paperc
 
 Deployment
 ----------
+
+Getting Paperclip ready to work with Capistrano is pretty straight forward. Unlike older versions of Capistrano the more recent ones don't symlink the `public/system` folder by default anymore. Therefore you need to explicitly configure Capistrano to symlink the `public/system` folder so that attachments will survive new deployments. In order to do this you have to set the `linked_dirs` option in your `config/deploy.rb` file:
+```ruby
+set :linked_dirs, fetch(:linked_dirs, []).push('public/system')
+```
+
+### Attachment Styles
 
 Paperclip is aware of new attachment styles you have added in previous deploys. The only thing you should do after each deployment is to call
 `rake paperclip:refresh:missing_styles`.  It will store current attachment styles in `RAILS_ROOT/public/system/paperclip_attachments.yml`


### PR DESCRIPTION
Capistrano won't symlink the public/system folder by default anymore. So Capistrano needs to be configured accordingly. Hopefully solves issue #2141.