### PR TITLE
Fixes cocaine path duplication bug

### DIFF
--- a/lib/paperclip/helpers.rb
+++ b/lib/paperclip/helpers.rb
@@ -24,7 +24,8 @@ module Paperclip
     #
     def run(cmd, arguments = "", interpolation_values = {}, local_options = {})
       command_path = options[:command_path]
-      Cocaine::CommandLine.path = [Cocaine::CommandLine.path, command_path].flatten.compact.uniq
+      cocaine_path_array = Cocaine::CommandLine.path.try(:split, Cocaine::OS.path_separator)
+      Cocaine::CommandLine.path = [cocaine_path_array, command_path].flatten.compact.uniq
       if logging? && (options[:log_command] || local_options[:log_command])
         local_options = local_options.merge(:logger => logger)
       end

--- a/spec/paperclip/paperclip_spec.rb
+++ b/spec/paperclip/paperclip_spec.rb
@@ -29,7 +29,7 @@ describe Paperclip do
       Paperclip.options[:command_path] = "/opt/my_app/bin"
       Paperclip.run("convert", "stuff")
       Paperclip.run("convert", "more_stuff")
-      assert_equal 1, [Cocaine::CommandLine.path].flatten.size
+      assert_equal 1, Cocaine::CommandLine.path.scan(Paperclip.options[:command_path]).count
     end
   end
 


### PR DESCRIPTION
If your path gets too big (e.g., you start appending your path thousands of times) you're going to have a bad time. On our boxes we noticed that paperclip would keep appending the Cocaine command line path, which crushes the CPU after some threshold.

Modified test to check for this and added a fix.