### PR TITLE
Correct failing S3 storage spec

### DIFF
--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -672,7 +672,9 @@ describe Paperclip::Storage::S3 do
           s3_host_name: "s3-world-end.amazonaws.com" },
         development: {
           s3_region: "ap-northeast-1",
-          s3_host_name: "s3-ap-northeast-1.amazonaws.com" }
+          s3_host_name: "s3-ap-northeast-1.amazonaws.com" },
+        test: {
+          s3_region: "" }
         }
       @dummy = Dummy.new
     end
@@ -1578,5 +1580,4 @@ describe Paperclip::Storage::S3 do
       Rails.env = stored_env
     end
   end
-
 end


### PR DESCRIPTION
This is part of the effort started at https://github.com/thoughtbot/paperclip/issues/2199 to ensure the test suite is green locally.

This spec was failing on obtaining a S3 instance with an `nil` region key. Since `Aws::Resource` does a regex match against the region key passed in, we would fail on `NoMethodError`.

This corrects the issue by setting a region key to an empty string in the test setup.