### PR TITLE
Correct attachment processing spec

### DIFF
--- a/spec/paperclip/attachment_processing_spec.rb
+++ b/spec/paperclip/attachment_processing_spec.rb
@@ -2,11 +2,9 @@
 require 'spec_helper'
 
 describe 'Attachment Processing' do
-  context 'using validates_attachment_content_type' do
-    before do
-      rebuild_class
-    end
+  before { rebuild_class }
 
+  context 'using validates_attachment_content_type' do
     it 'processes attachments given a valid assignment' do
       file = File.new(fixture_file("5k.png"))
       Dummy.validates_attachment_content_type :avatar, content_type: "image/png"


### PR DESCRIPTION
This is part of the effort started at https://github.com/thoughtbot/paperclip/issues/2199 to ensure the test suite is green locally.

The attachment processing spec was failing since the setup required done in a before block, namely a call to `rebuild_class`, was running restricted to one of two contexts in the test file.
This was leaving the `Dummy` class in a bad state and affected other tests.

This PR moves the `before` block to run for the both of the contexts.