### PR TITLE
Correct validators spec

### DIFF
--- a/spec/paperclip/validators_spec.rb
+++ b/spec/paperclip/validators_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Paperclip::Validators do
   context "using the helper" do
     before do
+      rebuild_class
       Dummy.validates_attachment :avatar, presence: true, content_type: { content_type: "image/jpeg" }, size: { in: 0..10240 }
     end
 


### PR DESCRIPTION
This is part of the effort started at https://github.com/thoughtbot/paperclip/issues/2199 to ensure the test suite is green locally.

The validators spec was failing since the setup required was missing a call to 'rebuild_class' and leaving the Dummy class in a bad state.

This PR adds the call to the before block setup.