### PR TITLE
DRAFT toward fixing after_post_process is run even if validations fail

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -50,7 +50,7 @@ module Paperclip
     # +url+ - a relative URL of the attachment. This is interpolated using +interpolator+
     # +path+ - where on the filesystem to store the attachment. This is interpolated using +interpolator+
     # +styles+ - a hash of options for processing the attachment. See +has_attached_file+ for the details
-    # +only_process+ - style args to be run through the post-processor. This defaults to the empty list (which is 
+    # +only_process+ - style args to be run through the post-processor. This defaults to the empty list (which is
     #                  a special case that indicates all styles should be processed)
     # +default_url+ - a URL for the missing image
     # +default_style+ - the style to use when an argument is not specified e.g. #url, #path
@@ -499,15 +499,17 @@ module Paperclip
 
     def post_process(*style_args) #:nodoc:
       return if @queued_for_write[:original].nil?
-      catch(:cancel_outer_callbacks) do
+      catch(:cancel_all_after_callbacks) do
         instance.run_paperclip_callbacks(:post_process) do
           inner_result = instance.run_paperclip_callbacks(:"#{name}_post_process") do
-            if !@options[:check_validity_before_processing] || !instance.errors.any?
-              post_process_styles(*style_args)
+            # paperclip validations set instance.errors at this point...
+            unless !@options[:check_validity_before_processing] || !instance.errors.any?
+              throw :cancel_all_after_callbacks
             end
+            post_process_styles(*style_args)
             true
           end
-          throw :cancel_outer_callbacks unless inner_result
+          throw :cancel_all_after_callbacks unless inner_result
         end
       end
     end

--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -499,12 +499,15 @@ module Paperclip
 
     def post_process(*style_args) #:nodoc:
       return if @queued_for_write[:original].nil?
-
-      instance.run_paperclip_callbacks(:post_process) do
-        instance.run_paperclip_callbacks(:"#{name}_post_process") do
-          if !@options[:check_validity_before_processing] || !instance.errors.any?
-            post_process_styles(*style_args)
+      catch(:cancel_outer_callbacks) do
+        instance.run_paperclip_callbacks(:post_process) do
+          inner_result = instance.run_paperclip_callbacks(:"#{name}_post_process") do
+            if !@options[:check_validity_before_processing] || !instance.errors.any?
+              post_process_styles(*style_args)
+            end
+            true
           end
+          throw :cancel_outer_callbacks unless inner_result
         end
       end
     end

--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -503,13 +503,15 @@ module Paperclip
         instance.run_paperclip_callbacks(:post_process) do
           inner_result = instance.run_paperclip_callbacks(:"#{name}_post_process") do
             # paperclip validations set instance.errors at this point...
-            unless !@options[:check_validity_before_processing] || !instance.errors.any?
+            if @options[:check_validity_before_processing] && instance.errors.any?
               throw :cancel_all_after_callbacks
             end
             post_process_styles(*style_args)
             true
           end
-          throw :cancel_all_after_callbacks unless inner_result
+          unless inner_result
+            throw :cancel_all_after_callbacks
+          end
         end
       end
     end

--- a/lib/paperclip/callbacks.rb
+++ b/lib/paperclip/callbacks.rb
@@ -9,7 +9,7 @@ module Paperclip
       def define_paperclip_callbacks(*callbacks)
         options = {
           terminator: hasta_la_vista_baby,
-          skip_after_callbacks_if_terminated: true
+          skip_after_callbacks_if_terminated: true,
         }
         define_callbacks(*[callbacks, options].flatten)
         callbacks.each do |callback|

--- a/lib/paperclip/callbacks.rb
+++ b/lib/paperclip/callbacks.rb
@@ -7,7 +7,11 @@ module Paperclip
 
     module Defining
       def define_paperclip_callbacks(*callbacks)
-        define_callbacks(*[callbacks, { terminator: hasta_la_vista_baby, skip_after_callbacks_if_terminated: true }].flatten)
+        options = {
+          terminator: hasta_la_vista_baby,
+          skip_after_callbacks_if_terminated: true
+        }
+        define_callbacks(*[callbacks, options].flatten)
         callbacks.each do |callback|
           eval <<-end_callbacks
             def before_#{callback}(*args, &blk)

--- a/lib/paperclip/callbacks.rb
+++ b/lib/paperclip/callbacks.rb
@@ -7,7 +7,7 @@ module Paperclip
 
     module Defining
       def define_paperclip_callbacks(*callbacks)
-        define_callbacks(*[callbacks, { terminator: hasta_la_vista_baby }].flatten)
+        define_callbacks(*[callbacks, { terminator: hasta_la_vista_baby, skip_after_callbacks_if_terminated: true }].flatten)
         callbacks.each do |callback|
           eval <<-end_callbacks
             def before_#{callback}(*args, &blk)

--- a/spec/paperclip/attachment_callbacks_spec.rb
+++ b/spec/paperclip/attachment_callbacks_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe Paperclip::Attachment do
+  context "callbacks" do
+    context "with content_type validation" do
+      def rebuild(required_content_type)
+        rebuild_class styles: { something: "100x100#" }
+        Dummy.class_eval do
+          validates_attachment_content_type :avatar, content_type: [required_content_type]
+          before_avatar_post_process :do_before_avatar
+          after_avatar_post_process :do_after_avatar
+          before_post_process :do_before_all
+          after_post_process :do_after_all
+          def do_before_avatar ; end
+          def do_after_avatar; end
+          def do_before_all; end
+          def do_after_all; end
+        end
+        @dummy = Dummy.new
+      end
+
+      context "that passes" do
+        let!(:required_content_type) { "image/png" }
+        before { rebuild(required_content_type) }
+        let(:fake_file) {  StringIO.new(".").tap { |s| s.stubs(:to_tempfile).returns(s) } }
+
+        it "calls all callbacks when assigned" do
+          @dummy.expects(:do_before_avatar).with()
+          @dummy.expects(:do_after_avatar).with()
+          @dummy.expects(:do_before_all).with()
+          @dummy.expects(:do_after_all).with()
+          Paperclip::Thumbnail.expects(:make).returns(fake_file)
+          @dummy.avatar = File.new(fixture_file("5k.png"))
+        end
+      end
+
+      context "that fails" do
+        let!(:required_content_type) { "image/jpeg" }
+        before { rebuild(required_content_type) }
+
+        it "does not call after callbacks when assigned" do
+          # before callbacks ARE still called at present
+          @dummy.expects(:do_before_all).with()
+          @dummy.expects(:do_before_avatar).with()
+
+          # But after_* are not
+          @dummy.expects(:do_after_avatar).never
+          @dummy.expects(:do_after_all).never
+          Paperclip::Thumbnail.expects(:make).never
+
+          @dummy.avatar = File.new(fixture_file("5k.png"))
+        end
+      end
+    end
+  end
+end

--- a/spec/paperclip/attachment_processing_spec.rb
+++ b/spec/paperclip/attachment_processing_spec.rb
@@ -44,40 +44,6 @@ describe 'Attachment Processing' do
 
       attachment.assign(invalid_assignment)
     end
-
-    context "with custom post-processing" do
-      before do
-        Dummy.class_eval do
-          validates_attachment_content_type :avatar, content_type: "image/png"
-          before_avatar_post_process :do_before_avatar
-          after_avatar_post_process :do_after_avatar
-          before_post_process :do_before_all
-          after_post_process :do_after_all
-          def do_before_avatar; end
-
-          def do_after_avatar; end
-
-          def do_before_all; end
-
-          def do_after_all; end
-        end
-      end
-      ## FALSE POSITIVE: This passes even before our change in callbacks.rb,
-      # even though we know it had a problem with this. This passes
-      # even if we don't trigger a validation error, we haven't succesfully
-      # set up our callbacks at all somehow.
-      it "does not run custom post-processing if validation fails" do
-        file = File.new(fixture_file("5k.png"))
-
-        instance = Dummy.new
-        attachment = instance.avatar
-
-        attachment.expects(:do_after_avatar).never
-        attachment.expects(:do_after_all).never
-
-        attachment.assign(file)
-      end
-    end
   end
 
   context 'using validates_attachment' do

--- a/spec/paperclip/attachment_processing_spec.rb
+++ b/spec/paperclip/attachment_processing_spec.rb
@@ -44,6 +44,37 @@ describe 'Attachment Processing' do
 
       attachment.assign(invalid_assignment)
     end
+
+    context "with custom post-processing" do
+      before do
+        Dummy.class_eval do
+          validates_attachment_content_type :avatar, content_type: "image/png"
+          before_avatar_post_process :do_before_avatar
+          after_avatar_post_process :do_after_avatar
+          before_post_process :do_before_all
+          after_post_process :do_after_all
+          def do_before_avatar; end
+          def do_after_avatar; end
+          def do_before_all; end
+          def do_after_all; end
+        end
+      end
+      ## FALSE POSITIVE: This passes even before our change in callbacks.rb,
+      # even though we know it had a problem with this. This passes
+      # even if we don't trigger a validation error, we haven't succesfully
+      # set up our callbacks at all somehow.
+      it 'does not run custom post-processing if validation fails' do
+        file = File.new(fixture_file("5k.png"))
+
+        instance = Dummy.new
+        attachment = instance.avatar
+
+        attachment.expects(:do_after_avatar).never
+        attachment.expects(:do_after_all).never
+
+        attachment.assign(file)
+      end
+    end
   end
 
   context 'using validates_attachment' do

--- a/spec/paperclip/attachment_processing_spec.rb
+++ b/spec/paperclip/attachment_processing_spec.rb
@@ -54,8 +54,11 @@ describe 'Attachment Processing' do
           before_post_process :do_before_all
           after_post_process :do_after_all
           def do_before_avatar; end
+
           def do_after_avatar; end
+
           def do_before_all; end
+
           def do_after_all; end
         end
       end
@@ -63,7 +66,7 @@ describe 'Attachment Processing' do
       # even though we know it had a problem with this. This passes
       # even if we don't trigger a validation error, we haven't succesfully
       # set up our callbacks at all somehow.
-      it 'does not run custom post-processing if validation fails' do
+      it "does not run custom post-processing if validation fails" do
         file = File.new(fixture_file("5k.png"))
 
         instance = Dummy.new

--- a/spec/paperclip/attachment_spec.rb
+++ b/spec/paperclip/attachment_spec.rb
@@ -847,16 +847,16 @@ describe Paperclip::Attachment do
       @dummy.expects(:do_before_avatar).never
       @dummy.expects(:do_after_avatar).never
       @dummy.expects(:do_before_all).with().returns(false)
-      @dummy.expects(:do_after_all)
+      @dummy.expects(:do_after_all).never
       Paperclip::Thumbnail.expects(:make).never
       @dummy.avatar = @file
     end
 
     it "cancels the processing if a before_avatar_post_process returns false" do
       @dummy.expects(:do_before_avatar).with().returns(false)
-      @dummy.expects(:do_after_avatar)
+      @dummy.expects(:do_after_avatar).never
       @dummy.expects(:do_before_all).with().returns(true)
-      @dummy.expects(:do_after_all)
+      @dummy.expects(:do_after_all).never
       Paperclip::Thumbnail.expects(:make).never
       @dummy.avatar = @file
     end


### PR DESCRIPTION
@tute, re #2178

This is not a solution, it may or may not be even the road to the solution, but sharing what I've figured out and where I've gotten to. 
### Context

Paperclip lets you set `before_` and `after_` callbacks, both attribute-specific (eg `after_avatar_post_process`), and that apply to any attribute (`after_post_process`). 

Paperclip README says: 

> The callbacks are intended to be as close to normal ActiveRecord callbacks as possible, so if you return false (specifically - returning nil is not the same) in a before_filter, the post processing step will halt. Returning false in an after_filter will not halt anything, but you can access the model and the attachment if necessary."

And indeed, the callbacks are implemented using [ActiveSupport::Callbacks](http://api.rubyonrails.org/classes/ActiveSupport/Callbacks.html)

The README also says, regarding validations:

> NOTE: Post processing will not even start if the attachment is not valid according to the validations. Your callbacks and processors will only be called with valid attachments.

The latter _appears_ not to be true, see #2204.  I am not sure how much of the former is true or not, I have not tested it extensively. 
### skip_after_callbacks_if_terminated

AS::Callbacks has a [skip_after_callbacks_if_terminated](http://api.rubyonrails.org/classes/ActiveSupport/Callbacks/ClassMethods.html#method-i-define_callbacks):  "Determines if after callbacks should be terminated by the :terminator option. By default after callbacks executed no matter if callback chain was terminated or not. Option makes sense only when :terminator option is specified."

Paperclip [does not supply this option](https://github.com/thoughtbot/paperclip/blob/master/lib/paperclip/callbacks.rb#L10) (it does supply the `terminator` option). 

Paperclip validations are implemented as before callbacks. And the problem seemed to be after callbacks (`after_post_process`) running if even validations failed, so after spelunking through the paperclip code and seeing this, my first thought was to try setting `skip_after_callbacks_if_terminated: true`. 
### Wrong specifications in attachment_spec.rb.

That change made some specs fail. On further reflection, I think these specs were failing becuase they were _wrong_, they were ensuring precisely the wrong behavior. 

They were ensuring that even if a before action cancelled, the after actions still _would_ run. They should have been ensuring the opposite. 

Maybe?  Clearly they should have been for validations, but is that true for other types of callback actions? The intended behavior is not entirely clear. _Should_ a terminated before callback stop after processing in general, even  if it's not validation-related?

I would suggest probably so -- the docs say it's intended to be as much like ActiveRecord callbacks as possible, and I _think_ that's how ActiveRecord callbacks work. The docs say "if you return false (specifically - returning nil is not the same) in a before_filter, the post processing step will halt."

So I think the pre-existing specs were wrong, and `skip_after_callbacks_if_terminated: true` should be added. **BUT**, that's not enough...
### The two callback chains

For every attribute, there are _two_ callback chains.  The attribute-specific one, and the general one. `skip_after_callbacks_if_terminated` will make _one_ of the callbacks halt, but the other one is uneffected. 

So after I changed all specs to look like the _right_ requirements (in this PR).... there were still one or two failing even after this change. 

Again, it's not entirely clear what the expected behavior is with the callbacks in general, before we get to validations. 

If a `before_avater_post_process` returns false, _should_ a (generic) `after_post_process` callback be cancelled? And vice versa?  I _think_ so, but that's the thing that doesn't work with just `skip_after_callbacks_if_terminated`. For validations (implemented as before callbacks), it's more clear that it _should_ do this. For callbacks in general... not sure. 

If it's going to be done for callbacks in general, some more architecture is required. Maybe something involving the little-seen ruby throw/catch, like @tute pointed out Rails5 has done?  A throw that gets caught outside the specific callbacks entirely, unlike Rails5?  I experimented a bit with this, but didn't get anywhere, might try more. (Rails5 new func is implemented pretty much entirely in the `default_terminator`, paperclip [supplies it's own terminator], so can do whatever it wants possibly inspired by but independent from Rails5). 

Or the fix could be specific to validations, instead of just treating at as a bug in callbacks in general. Especially if it's determined that callbacks in general are working as desired, it's just validations that need fixing. (I don't think so though). 

The relevant paperclip code is here: https://github.com/thoughtbot/paperclip/blob/master/lib/paperclip/attachment.rb#L503-L508
### Validation-specific

In addition to messing with specs as above in `attachment_spec.rb` for general callback related behavior, I _tried_ to add [some content-type-validation specific specs related to this behavior](https://github.com/thoughtbot/paperclip/pull/2204/files#diff-ad299b17d6f64068d0d5b30e179242abR66). However, I was not successful at doing so -- the tests I tried to add are 'false negatives', they pass _no matter what_, even without any other changes. 

Not sure why i was not successful at adding broken tests for the current reproducibly broken behavior. Advice welcome. 
### Do other parts of the documented callbacks work as advertised?

The README suggests to me that a before callback returning false should cancel _everything_. We've talked about it cancelling after callbacks -- but I think it should probably cancel the _meat_ of the thing itself, the README says not just that after callbacks won't happen, but that "the post processing step will halt"

I _think_ that may be broken too. There is [some code](https://github.com/thoughtbot/paperclip/blob/master/lib/paperclip/attachment.rb#L505) specific to cancelling the `post_process_styles` step for _validation failures_ specifically, but my reading of the docs is that it should be called for _any_ before callback termination. I don't _think_ that is happening, bug I haven't tested it. I _think_ it should be. 

It's possible that a solution to the after callbacks truly being cancelled (for both attribute-specific and general chains) might also easily flow to `post_process_styles` not happening either in general not just for validation failures. I _think_ that would be a correction. 
## Assistance welcome

So, yeah, this starts to get more confusing and complicated the more I look at it, with part of the issue being lack of clarity about what _should_ happen. Assistance welcome. I hope this long narrative helped clarify rather than confuse. 

I'm ignoring the annoying Hound warnings, because we have way bigger challenges then that here, 
although they are annoying. Someone else is welcome to fix them -- oops, except I guess you can't commit to my fork. I'll give @tute et al rights to commit to my fork if that will help with some collaboration. 
