### PR TITLE
The uri io adapter should use the content-disposition filename

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,5 @@
+* Improvement: the `URI adapter` now uses the content-disposition header to name the downloaded file.
+
 * Improvement: Add `fog_options` configuration to send options to fog when storing files.
 
 4.3.6 (3/13/2016):

--- a/lib/paperclip/io_adapters/.#data_uri_adapter.rb
+++ b/lib/paperclip/io_adapters/.#data_uri_adapter.rb
@@ -1,1 +1,0 @@
-netmask@Janet.35319

--- a/lib/paperclip/io_adapters/.#data_uri_adapter.rb
+++ b/lib/paperclip/io_adapters/.#data_uri_adapter.rb
@@ -1,0 +1,1 @@
+netmask@Janet.35319

--- a/lib/paperclip/io_adapters/uri_adapter.rb
+++ b/lib/paperclip/io_adapters/uri_adapter.rb
@@ -32,8 +32,8 @@ module Paperclip
     end
 
     def extract_attachment_filename
-      if @content.meta.has_key? 'content-disposition'
-        @original_filename = @content.meta['content-disposition']
+      if @content.meta.has_key? "content-disposition"
+        @original_filename = @content.meta["content-disposition"]
                                  .match(/filename="([^"]*)"/)[1]
       end
     end

--- a/lib/paperclip/io_adapters/uri_adapter.rb
+++ b/lib/paperclip/io_adapters/uri_adapter.rb
@@ -2,6 +2,8 @@ require 'open-uri'
 
 module Paperclip
   class UriAdapter < AbstractAdapter
+    attr_writer :content_type
+
     def initialize(target)
       @target = target
       @content = download_content
@@ -9,33 +11,40 @@ module Paperclip
       @tempfile = copy_to_tempfile(@content)
     end
 
-    attr_writer :content_type
+    def cache_current_values
+      self.content_type = content_type_from_content || "text/html"
+
+      self.original_filename = filename_from_content_disposition ||
+        filename_from_path || default_filename
+
+      @size = @content.size
+    end
+
+    def content_type_from_content
+      if @content.respond_to?(:content_type)
+        @content.content_type
+      end
+    end
+
+    def filename_from_content_disposition
+      if @content.meta.has_key?("content-disposition")
+        @content.meta["content-disposition"].
+          match(/filename="([^"]*)"/)[1]
+      end
+    end
+
+    def filename_from_path
+      @target.path.split("/").last
+    end
+
+    def default_filename
+      "index.html"
+    end
 
     private
 
     def download_content
       open(@target)
-    end
-
-    def cache_current_values
-      extract_attachment_filename
-
-      @original_filename ||= @target.path.split("/").last
-      @original_filename ||= "index.html"
-
-      self.original_filename = @original_filename.strip
-
-      @content_type = @content.content_type if @content.respond_to?(:content_type)
-      @content_type ||= "text/html"
-
-      @size = @content.size
-    end
-
-    def extract_attachment_filename
-      if @content.meta.has_key? "content-disposition"
-        @original_filename = @content.meta["content-disposition"]
-                                 .match(/filename="([^"]*)"/)[1]
-      end
     end
 
     def copy_to_tempfile(src)

--- a/lib/paperclip/io_adapters/uri_adapter.rb
+++ b/lib/paperclip/io_adapters/uri_adapter.rb
@@ -18,14 +18,24 @@ module Paperclip
     end
 
     def cache_current_values
-      @original_filename = @target.path.split("/").last
+      extract_attachment_filename
+
+      @original_filename ||= @target.path.split("/").last
       @original_filename ||= "index.html"
+
       self.original_filename = @original_filename.strip
 
       @content_type = @content.content_type if @content.respond_to?(:content_type)
       @content_type ||= "text/html"
 
       @size = @content.size
+    end
+
+    def extract_attachment_filename
+      if @content.meta.has_key? 'content-disposition'
+        @original_filename = @content.meta['content-disposition']
+                                 .match(/filename="([^"]*)"/)[1]
+      end
     end
 
     def copy_to_tempfile(src)

--- a/lib/paperclip/io_adapters/uri_adapter.rb
+++ b/lib/paperclip/io_adapters/uri_adapter.rb
@@ -11,12 +11,13 @@ module Paperclip
       @tempfile = copy_to_tempfile(@content)
     end
 
+    private
+
     def cache_current_values
       self.content_type = content_type_from_content || "text/html"
 
       self.original_filename = filename_from_content_disposition ||
-        filename_from_path || default_filename
-
+                               filename_from_path || default_filename
       @size = @content.size
     end
 
@@ -40,8 +41,6 @@ module Paperclip
     def default_filename
       "index.html"
     end
-
-    private
 
     def download_content
       open(@target)

--- a/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
 describe Paperclip::HttpUrlProxyAdapter do
-
   before do
     @open_return = StringIO.new("xxx")
     @open_return.stubs(:content_type).returns("image/png")
     @open_return.stubs(:meta).returns({})
-    Paperclip::HttpUrlProxyAdapter.any_instance.stubs(:download_content).returns(@open_return)
+    Paperclip::HttpUrlProxyAdapter.any_instance.
+      stubs(:download_content).returns(@open_return)
   end
 
   context "a new instance" do

--- a/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
@@ -1,11 +1,16 @@
 require 'spec_helper'
 
 describe Paperclip::HttpUrlProxyAdapter do
+
+  before do
+    @open_return = StringIO.new("xxx")
+    @open_return.stubs(:content_type).returns("image/png")
+    @open_return.stubs(:meta).returns({})
+    Paperclip::HttpUrlProxyAdapter.any_instance.stubs(:download_content).returns(@open_return)
+  end
+
   context "a new instance" do
     before do
-      @open_return = StringIO.new("xxx")
-      @open_return.stubs(:content_type).returns("image/png")
-      Paperclip::HttpUrlProxyAdapter.any_instance.stubs(:download_content).returns(@open_return)
       @url = "http://thoughtbot.com/images/thoughtbot-logo.png"
       @subject = Paperclip.io_adapters.for(@url)
     end
@@ -60,7 +65,6 @@ describe Paperclip::HttpUrlProxyAdapter do
 
   context "a url with query params" do
     before do
-      Paperclip::HttpUrlProxyAdapter.any_instance.stubs(:download_content).returns(StringIO.new("x"))
       @url = "https://github.com/thoughtbot/paperclip?file=test"
       @subject = Paperclip.io_adapters.for(@url)
     end
@@ -76,7 +80,6 @@ describe Paperclip::HttpUrlProxyAdapter do
 
   context "a url with restricted characters in the filename" do
     before do
-      Paperclip::HttpUrlProxyAdapter.any_instance.stubs(:download_content).returns(StringIO.new("x"))
       @url = "https://github.com/thoughtbot/paper:clip.jpg"
       @subject = Paperclip.io_adapters.for(@url)
     end

--- a/spec/paperclip/io_adapters/uri_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/uri_adapter_spec.rb
@@ -1,11 +1,18 @@
 require 'spec_helper'
 
 describe Paperclip::UriAdapter do
+  let(:content_type) { "image/png" }
+  let(:meta) { { } }
+
+  before do
+    @open_return = StringIO.new("xxx")
+    @open_return.stubs(:content_type).returns(content_type)
+    @open_return.stubs(:meta).returns(meta)
+    Paperclip::UriAdapter.any_instance.stubs(:download_content).returns(@open_return)
+  end
+
   context "a new instance" do
     before do
-      @open_return = StringIO.new("xxx")
-      @open_return.stubs(:content_type).returns("image/png")
-      Paperclip::UriAdapter.any_instance.stubs(:download_content).returns(@open_return)
       @uri = URI.parse("http://thoughtbot.com/images/thoughtbot-logo.png")
       @subject = Paperclip.io_adapters.for(@uri)
     end
@@ -56,8 +63,9 @@ describe Paperclip::UriAdapter do
   end
 
   context "a directory index url" do
+    let(:content_type) { "text/html" }
+
     before do
-      Paperclip::UriAdapter.any_instance.stubs(:download_content).returns(StringIO.new("xxx"))
       @uri = URI.parse("http://thoughtbot.com")
       @subject = Paperclip.io_adapters.for(@uri)
     end
@@ -73,7 +81,6 @@ describe Paperclip::UriAdapter do
 
   context "a url with query params" do
     before do
-      Paperclip::UriAdapter.any_instance.stubs(:download_content).returns(StringIO.new("xxx"))
       @uri = URI.parse("https://github.com/thoughtbot/paperclip?file=test")
       @subject = Paperclip.io_adapters.for(@uri)
     end
@@ -83,9 +90,22 @@ describe Paperclip::UriAdapter do
     end
   end
 
+  context "a url with content disposition headers" do
+    let(:file_name) { 'test_document.pdf' }
+    let(:meta) { { 'content-disposition' => "attachment; filename=\"#{file_name}\";" } }
+
+    before do
+      @uri = URI.parse("https://github.com/thoughtbot/paperclip?file=test")
+      @subject = Paperclip.io_adapters.for(@uri)
+    end
+
+    it "returns a file name" do
+      assert_equal file_name, @subject.original_filename
+    end
+  end
+
   context "a url with restricted characters in the filename" do
     before do
-      Paperclip::UriAdapter.any_instance.stubs(:download_content).returns(StringIO.new("xxx"))
       @uri = URI.parse("https://github.com/thoughtbot/paper:clip.jpg")
       @subject = Paperclip.io_adapters.for(@uri)
     end

--- a/spec/paperclip/io_adapters/uri_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/uri_adapter_spec.rb
@@ -2,13 +2,14 @@ require 'spec_helper'
 
 describe Paperclip::UriAdapter do
   let(:content_type) { "image/png" }
-  let(:meta) { { } }
+  let(:meta) { {} }
 
   before do
     @open_return = StringIO.new("xxx")
     @open_return.stubs(:content_type).returns(content_type)
     @open_return.stubs(:meta).returns(meta)
-    Paperclip::UriAdapter.any_instance.stubs(:download_content).returns(@open_return)
+    Paperclip::UriAdapter.any_instance.
+      stubs(:download_content).returns(@open_return)
   end
 
   context "a new instance" do
@@ -91,8 +92,12 @@ describe Paperclip::UriAdapter do
   end
 
   context "a url with content disposition headers" do
-    let(:file_name) { 'test_document.pdf' }
-    let(:meta) { { 'content-disposition' => "attachment; filename=\"#{file_name}\";" } }
+    let(:file_name) { "test_document.pdf" }
+    let(:meta) do
+      {
+        "content-disposition" => "attachment; filename=\"#{file_name}\";",
+      }
+    end
 
     before do
       @uri = URI.parse("https://github.com/thoughtbot/paperclip?file=test")


### PR DESCRIPTION
When a URI is passed to the model attachment  as the "attachment source"

example:

```ruby 
model.document = "http://examle.com/download_pdf"
```
paperclip will download this resource and set the last element of the path in this case, "download_pdf" as the file name, This PR allows the URI adapter to use the "content-disposition" header if is available and set that value as the original filename which in most cases are the expected one.

``` 
model.document = "http://examle.com/download_pdf"
# the response header contains the real name
# Content-disposition: attachment; filename=awesome_pdf_2016.pdf
# model.document.url => /storage/awesome_pdf_2016.pdf instead of download_pdf
```
