### PR TITLE
Use Paperclip namespace as Capistrano task

### DIFF
--- a/README.md
+++ b/README.md
@@ -851,9 +851,9 @@ Paperclip.registered_attachments_styles_path = '/tmp/config/paperclip_attachment
 Here is an example for Capistrano:
 
 ```ruby
-namespace :deploy do
+namespace :paperclip do
   desc "build missing paperclip styles"
-  task :build_missing_paperclip_styles do
+  task :build_missing_styles do
     on roles(:app) do
       within release_path do
         with rails_env: fetch(:rails_env) do


### PR DESCRIPTION
Since the task `deploy` is quite exclusive to Capistrano, we should use Paperclip's own namespace instead, so not to be confused with Capistrano's `deploy`.