### PR TITLE
Update deployment sequence to paperclip namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,7 +864,7 @@ namespace :paperclip do
   end
 end
 
-after("deploy:compile_assets", "deploy:build_missing_paperclip_styles")
+after("deploy:compile_assets", "paperclip:build_missing_styles")
 ```
 
 Now you don't have to remember to refresh thumbnails in production every time you add a new style.


### PR DESCRIPTION
Missed out the deployment sequence in README.md after this merge https://github.com/thoughtbot/paperclip/commit/0eb3310410c5450b7fd265c7322487f757181b1d

@tute Please review again.