### PR TITLE
Add read_timeout option to UriAdapter download_content method

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 master:
 
+* Improvement: Add `read_timeout` configuration for URI Adapter download_content method.
 * README adjustments for Ruby beginners (add links, elucidate model in Quick Start)
 * Bugfix: Now it's possible to save images from URLs with special characters [#1932]
 * Fix a nil error in content type validation matcher [#1910]

--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -98,7 +98,7 @@ module Paperclip
       :swallow_stderr => true,
       :content_type_mappings => {},
       :use_exif_orientation => true,
-      :read_timeout => 120
+      :read_timeout => nil
     }
   end
 

--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -97,7 +97,8 @@ module Paperclip
       :log_command => true,
       :swallow_stderr => true,
       :content_type_mappings => {},
-      :use_exif_orientation => true
+      :use_exif_orientation => true,
+      :read_timeout => 120
     }
   end
 

--- a/lib/paperclip/io_adapters/uri_adapter.rb
+++ b/lib/paperclip/io_adapters/uri_adapter.rb
@@ -14,7 +14,9 @@ module Paperclip
     private
 
     def download_content
-      open(@target, read_timeout: Paperclip.options[:read_timeout])
+      options = { read_timeout: Paperclip.options[:read_timeout] }.compact
+
+      open(@target, **options)
     end
 
     def cache_current_values

--- a/lib/paperclip/io_adapters/uri_adapter.rb
+++ b/lib/paperclip/io_adapters/uri_adapter.rb
@@ -14,7 +14,7 @@ module Paperclip
     private
 
     def download_content
-      open(@target)
+      open(@target, read_timeout: Paperclip.options[:read_timeout])
     end
 
     def cache_current_values

--- a/spec/paperclip/io_adapters/uri_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/uri_adapter_spec.rb
@@ -101,7 +101,6 @@ describe Paperclip::UriAdapter do
 
   describe "#download_content" do
     before do
-      Paperclip.options[:read_timeout] = 240
       Paperclip::UriAdapter.any_instance.stubs(:open).returns(StringIO.new("xxx"))
       @uri = URI.parse("https://github.com/thoughtbot/paper:clip.jpg")
       @subject = Paperclip.io_adapters.for(@uri)
@@ -111,9 +110,20 @@ describe Paperclip::UriAdapter do
       @subject.send(:download_content)
     end
 
-    it "calls open with given read_timeout" do
-      @subject.expects(:open).with(@uri, read_timeout: 240).at_least_once
+    context "with default read_timeout" do
+      it "calls open without options" do
+        @subject.expects(:open).with(@uri, {}).at_least_once
+      end
+    end
+
+    context "with custom read_timeout" do
+      before do
+        Paperclip.options[:read_timeout] = 120
+      end
+
+      it "calls open with read_timeout option" do
+        @subject.expects(:open).with(@uri, read_timeout: 120).at_least_once
+      end
     end
   end
-
 end

--- a/spec/paperclip/io_adapters/uri_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/uri_adapter_spec.rb
@@ -99,4 +99,21 @@ describe Paperclip::UriAdapter do
     end
   end
 
+  describe "#download_content" do
+    before do
+      Paperclip.options[:read_timeout] = 240
+      Paperclip::UriAdapter.any_instance.stubs(:open).returns(StringIO.new("xxx"))
+      @uri = URI.parse("https://github.com/thoughtbot/paper:clip.jpg")
+      @subject = Paperclip.io_adapters.for(@uri)
+    end
+
+    after do
+      @subject.send(:download_content)
+    end
+
+    it "calls open with given read_timeout" do
+      @subject.expects(:open).with(@uri, read_timeout: 240).at_least_once
+    end
+  end
+
 end


### PR DESCRIPTION
`Net::ReadTimeout` exception will occur if remote file couldn't be reached within default timeout.
This PR adds option `:read_timeout` to Paperclip to override default `open` timeout from UriAdapter download_content method.

#1923 