### PR TITLE
on after_save and before_destroy hooks use public methods from attachment object

### DIFF
--- a/lib/paperclip/has_attached_file.rb
+++ b/lib/paperclip/has_attached_file.rb
@@ -89,8 +89,8 @@ module Paperclip
 
     def add_active_record_callbacks
       name = @name
-      @klass.send(:after_save) { send(name).send(:save) }
-      @klass.send(:before_destroy) { send(name).send(:queue_all_for_delete) }
+      @klass.send(:after_save) { send(name).save }
+      @klass.send(:before_destroy) { send(name).clear }
       if @klass.respond_to?(:after_commit)
         @klass.send(:after_commit, on: :destroy) do
           send(name).send(:flush_deletes)


### PR DESCRIPTION
The reason why I want this change is because we are writing a paperclip plugin, and we want to override the on attachment deletion behavior. Adding a new behavior to `queue_all_for_delete` just does not seems correct in our plugin.

I think there is no functional difference between calling `clear` or `queue_all_for_delete` for `before_destroy` AR hook, rather it should make the paperclip code simpler.
