### PR TITLE
Update accepted server_side_encryption value

### DIFF
--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -1207,7 +1207,7 @@ describe Paperclip::Storage::S3 do
           'access_key_id' => "12345",
           'secret_access_key' => "54321"
         },
-        s3_server_side_encryption: :aes256
+        s3_server_side_encryption: "AES256"
     end
 
     context "when assigned" do
@@ -1227,7 +1227,7 @@ describe Paperclip::Storage::S3 do
           object.expects(:upload_file)
             .with(anything, content_type: "image/png",
                   acl: :"public-read",
-                  server_side_encryption: :aes256)
+                  server_side_encryption: "AES256")
           @dummy.save
         end
 


### PR DESCRIPTION
AWS no longer accepts `:aes256` as an encryption value and will raise
`Aws::S3::Errors::InvalidArgument` with the message `The encryption method
specified is not supported`. It should instead be `"AES256"`.

This commit makes no implementation change, but for those that use
source code and tests as documentation, it should help prevent
confusion.