### PR TITLE
Assign file attributes before only_process

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -102,6 +102,7 @@ module Paperclip
       ensure_required_validations!
 
       if @file.assignment?
+        assign_attributes
         clear(*only_process)
 
         if @file.nil?


### PR DESCRIPTION
There could be a better way to do this, but this seems to be working.

I am using the `only_process` attribute in conjunction with [Delayed Paperclip](https://github.com/jrgifford/delayed_paperclip/) to process some files in the background. When I started using DP, I was getting errors saying that the attributes associated with the uploaded file (e.i. _content_type) were not set. 