### PR TITLE
[backport] The uri io adapter should use the content-disposition filename

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,5 @@
 master:
+* (port from 4.3) Improvement: the `URI adapter` now uses the content-disposition header to name the downloaded file.
 
 5.0.0 (2016-07-01):
 

--- a/lib/paperclip/io_adapters/uri_adapter.rb
+++ b/lib/paperclip/io_adapters/uri_adapter.rb
@@ -2,6 +2,8 @@ require 'open-uri'
 
 module Paperclip
   class UriAdapter < AbstractAdapter
+    attr_writer :content_type
+
     def initialize(target)
       @target = target
       @content = download_content
@@ -9,25 +11,41 @@ module Paperclip
       @tempfile = copy_to_tempfile(@content)
     end
 
-    attr_writer :content_type
-
     private
+
+    def cache_current_values
+      self.content_type = content_type_from_content || "text/html"
+
+      self.original_filename = filename_from_content_disposition ||
+                               filename_from_path || default_filename
+      @size = @content.size
+    end
+
+    def content_type_from_content
+      if @content.respond_to?(:content_type)
+        @content.content_type
+      end
+    end
+
+    def filename_from_content_disposition
+      if @content.meta.has_key?("content-disposition")
+        @content.meta["content-disposition"].
+          match(/filename="([^"]*)"/)[1]
+      end
+    end
+
+    def filename_from_path
+      @target.path.split("/").last
+    end
+
+    def default_filename
+      "index.html"
+    end
 
     def download_content
       options = { read_timeout: Paperclip.options[:read_timeout] }.compact
 
       open(@target, **options)
-    end
-
-    def cache_current_values
-      @original_filename = @target.path.split("/").last
-      @original_filename ||= "index.html"
-      self.original_filename = @original_filename.strip
-
-      @content_type = @content.content_type if @content.respond_to?(:content_type)
-      @content_type ||= "text/html"
-
-      @size = @content.size
     end
 
     def copy_to_tempfile(src)

--- a/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
@@ -1,11 +1,16 @@
 require 'spec_helper'
 
 describe Paperclip::HttpUrlProxyAdapter do
+  before do
+    @open_return = StringIO.new("xxx")
+    @open_return.stubs(:content_type).returns("image/png")
+    @open_return.stubs(:meta).returns({})
+    Paperclip::HttpUrlProxyAdapter.any_instance.
+      stubs(:download_content).returns(@open_return)
+  end
+
   context "a new instance" do
     before do
-      @open_return = StringIO.new("xxx")
-      @open_return.stubs(:content_type).returns("image/png")
-      Paperclip::HttpUrlProxyAdapter.any_instance.stubs(:download_content).returns(@open_return)
       @url = "http://thoughtbot.com/images/thoughtbot-logo.png"
       @subject = Paperclip.io_adapters.for(@url)
     end
@@ -60,7 +65,6 @@ describe Paperclip::HttpUrlProxyAdapter do
 
   context "a url with query params" do
     before do
-      Paperclip::HttpUrlProxyAdapter.any_instance.stubs(:download_content).returns(StringIO.new("x"))
       @url = "https://github.com/thoughtbot/paperclip?file=test"
       @subject = Paperclip.io_adapters.for(@url)
     end
@@ -76,7 +80,6 @@ describe Paperclip::HttpUrlProxyAdapter do
 
   context "a url with restricted characters in the filename" do
     before do
-      Paperclip::HttpUrlProxyAdapter.any_instance.stubs(:download_content).returns(StringIO.new("x"))
       @url = "https://github.com/thoughtbot/paper:clip.jpg"
       @subject = Paperclip.io_adapters.for(@url)
     end
@@ -101,7 +104,7 @@ describe Paperclip::HttpUrlProxyAdapter do
   context "a url with special characters in the filename" do
     it "returns a encoded filename" do
       Paperclip::HttpUrlProxyAdapter.any_instance.stubs(:download_content).
-        returns(StringIO.new("x"))
+        returns(@open_return)
       url = "https://github.com/thoughtbot/paperclip-öäü字´½♥Ø²È.png"
       subject = Paperclip.io_adapters.for(url)
       filename = "paperclip-%C3%B6%C3%A4%C3%BC%E5%AD%97%C2%B4%C2%BD%E2%99%A5"\


### PR DESCRIPTION
@tute port from https://github.com/thoughtbot/paperclip/pull/2210

- The uri io adapter now seeks for the content-disposition header
  if this is pressent the value filename is taken instead of the
  last path segment for the resource file name
- Fix style comments
- Applied the Tute Costa refactor to URI Adapter.
- Added entry to  the NEWS file.
- Removed editor tracking file
- Fix test cases