### PR TITLE
Background processing

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -53,7 +53,8 @@ module Paperclip
     # +styles+ - a hash of options for processing the attachment. See +has_attached_file+ for the details
     # +only_process+ - style args to be run through the post-processor. This defaults to the empty list (which is
     #                  a special case that indicates all styles should be processed)
-    # +process_in_background+ - an array of styles to be processed in background (requires "active_job")
+    # +process_in_background+ - an array of styles to be processed in background
+    #                           (requires "active_job")
     # +default_url+ - a URL for the missing image
     # +default_style+ - the style to use when an argument is not specified e.g. #url, #path
     # +storage+ - the storage mechanism. Defaults to :filesystem
@@ -392,6 +393,14 @@ module Paperclip
       flush_writes
     end
 
+    def clear_enqueue_background_processing
+      @enqueue_background_processing = false
+    end
+
+    def enqueue_background_processing?
+      @enqueue_background_processing
+    end
+
     private
 
     def path_option
@@ -439,6 +448,7 @@ module Paperclip
       assign_file_information
       assign_fingerprint { @file.fingerprint }
       assign_timestamps
+      assign_background_processing
     end
 
     def assign_file_information
@@ -459,6 +469,12 @@ module Paperclip
       end
 
       instance_write(:updated_at, Time.now)
+    end
+
+    def assign_background_processing
+      if @options[:process_in_background].any?
+        @enqueue_background_processing = true
+      end
     end
 
     def post_process_file

--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -21,6 +21,7 @@ module Paperclip
         :hash_digest           => "SHA1",
         :interpolator          => Paperclip::Interpolations,
         :only_process          => [],
+        :process_in_background => [],
         :path                  => ":rails_root/public:url",
         :preserve_files        => false,
         :processors            => [:thumbnail],
@@ -50,8 +51,9 @@ module Paperclip
     # +url+ - a relative URL of the attachment. This is interpolated using +interpolator+
     # +path+ - where on the filesystem to store the attachment. This is interpolated using +interpolator+
     # +styles+ - a hash of options for processing the attachment. See +has_attached_file+ for the details
-    # +only_process+ - style args to be run through the post-processor. This defaults to the empty list (which is 
+    # +only_process+ - style args to be run through the post-processor. This defaults to the empty list (which is
     #                  a special case that indicates all styles should be processed)
+    # +process_in_background+ - an array of styles to be processed in background (requires "active_job")
     # +default_url+ - a URL for the missing image
     # +default_style+ - the style to use when an argument is not specified e.g. #url, #path
     # +storage+ - the storage mechanism. Defaults to :filesystem
@@ -381,6 +383,13 @@ module Paperclip
       if instance.respond_to?(getter)
         instance.send(getter)
       end
+    end
+
+    def generate_style_files(*styles)
+      @file = Paperclip.io_adapters.for(self)
+      @queued_for_write[:original] = @file
+      post_process(*styles)
+      flush_writes
     end
 
     private

--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -312,6 +312,12 @@ module Paperclip
       time && time.to_f.to_i
     end
 
+    # Returns true when record is enqueued for background processing
+    # and job did not finish yet.
+    def processing_in_background
+      instance_read(:processing_in_background)
+    end
+
     # The time zone to use for timestamp interpolation.  Using the default
     # time zone ensures that results are consistent across all threads.
     def time_zone
@@ -473,6 +479,7 @@ module Paperclip
 
     def assign_background_processing
       if @options[:process_in_background].any?
+        instance_write(:processing_in_background, true)
         @enqueue_background_processing = true
       end
     end

--- a/lib/paperclip/has_attached_file.rb
+++ b/lib/paperclip/has_attached_file.rb
@@ -102,11 +102,15 @@ module Paperclip
     end
 
     def add_background_processing
-      require 'paperclip/process_job'
+      require "paperclip/process_job"
       name = @name
       if @klass.respond_to?(:after_commit)
         @klass.send(:after_commit, on: [:create, :update]) do
-          ProcessJob.perform_later(self, name.to_s)
+          attachment = send(name)
+          if attachment.enqueue_background_processing?
+            ProcessJob.perform_later(self, name.to_s)
+            attachment.clear_enqueue_background_processing
+          end
         end
       end
     end

--- a/lib/paperclip/has_attached_file.rb
+++ b/lib/paperclip/has_attached_file.rb
@@ -16,6 +16,7 @@ module Paperclip
       define_setter
       define_query
       register_new_attachment
+      add_background_processing if @options[:process_in_background]
       add_active_record_callbacks
       add_paperclip_callbacks
       add_required_validations
@@ -97,6 +98,16 @@ module Paperclip
         end
       else
         @klass.send(:after_destroy) { send(name).send(:flush_deletes) }
+      end
+    end
+
+    def add_background_processing
+      require 'paperclip/process_job'
+      name = @name
+      if @klass.respond_to?(:after_commit)
+        @klass.send(:after_commit, on: [:create, :update]) do
+          ProcessJob.perform_later(self, name.to_s)
+        end
       end
     end
 

--- a/lib/paperclip/process_job.rb
+++ b/lib/paperclip/process_job.rb
@@ -11,6 +11,11 @@ module Paperclip
       attachment = instance.send(attachment_name)
       styles = attachment.options[:process_in_background]
       attachment.generate_style_files(*styles)
+
+      if attachment.instance_respond_to?(:processing_in_background)
+        attachment.instance_write(:processing_in_background, false)
+        instance.save!
+      end
     end
   end
 end

--- a/lib/paperclip/process_job.rb
+++ b/lib/paperclip/process_job.rb
@@ -1,0 +1,15 @@
+begin
+  require "active_job"
+rescue LoadError
+  raise LoadError, "To use background processing you have to include 'active_job' in load path"
+end
+
+module Paperclip
+  class ProcessJob < ActiveJob::Base
+    def perform(instance, attachment_name)
+      attachment = instance.send(attachment_name)
+      styles = attachment.options[:process_in_background]
+      attachment.generate_style_files(*styles)
+    end
+  end
+end

--- a/lib/paperclip/process_job.rb
+++ b/lib/paperclip/process_job.rb
@@ -1,7 +1,8 @@
 begin
   require "active_job"
 rescue LoadError
-  raise LoadError, "To use background processing you have to include 'active_job' in load path"
+  raise LoadError,
+    "To use background processing you have to include 'active_job' in load path"
 end
 
 module Paperclip

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency('mimemagic', '~> 0.3.0')
 
   s.add_development_dependency('activerecord', '>= 4.2.0')
+  s.add_development_dependency('activejob', '>= 4.2.0')
   s.add_development_dependency('shoulda')
   s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('appraisal')

--- a/spec/paperclip/attachment_spec.rb
+++ b/spec/paperclip/attachment_spec.rb
@@ -1523,6 +1523,19 @@ describe Paperclip::Attachment do
 
       assert_equal 0, jobs.count
     end
+
+    it "populates avatar_processing_in_background column" do
+      ActiveRecord::Base.connection.add_column :dummies, :avatar_processing_in_background, :boolean
+      rebuild_class styles: { thumb: "100x100" },
+                    only_process: [:none],
+                    process_in_background: [:thumb]
+      GlobalID.app = "paperclip-test"
+      Dummy.send(:include, GlobalID::Identification)
+      @dummy = Dummy.new
+      @dummy.avatar = @file
+
+      assert_equal true, @dummy.avatar_processing_in_background
+    end
   end
 
   context "An attached file" do

--- a/spec/paperclip/process_job_spec.rb
+++ b/spec/paperclip/process_job_spec.rb
@@ -6,8 +6,14 @@ RSpec.describe Paperclip::ProcessJob do
     ActiveJob::Base.queue_adapter = :test
     ActiveJob::Base.logger = nil
 
+    @file = File.new(fixture_file("5k.png"), "rb")
     @thumb_path = "tmp/public/system/dummies/avatars/000/000/001/thumb/5k.png"
     File.delete(@thumb_path) if File.exist?(@thumb_path)
+
+    FileUtils.cp(@file, "tmp/public/system/dummies/avatars/000/000/001/original/5k.png")
+    rebuild_model styles: { thumb: "100x100" },
+                  only_process: [:none],
+                  process_in_background: [:thumb]
   end
 
   after do
@@ -15,17 +21,22 @@ RSpec.describe Paperclip::ProcessJob do
   end
 
   it "processes styles marked for background processing" do
-    file = File.new(fixture_file("5k.png"), "rb")
-    FileUtils.cp(file, "tmp/public/system/dummies/avatars/000/000/001/original/5k.png")
-    rebuild_model styles: { thumb: "100x100" },
-                  only_process: [:none],
-                  process_in_background: [:thumb]
-
-    dummy = Dummy.create!
-    dummy.update_columns(avatar_file_name: "5k.png")
+    dummy = Dummy.create!(avatar_file_name: "5k.png")
 
     assert_file_not_exists(@thumb_path)
     Paperclip::ProcessJob.perform_now(dummy, "avatar")
     assert_file_exists(@thumb_path)
+  end
+
+  it "updates avatar_processing_in_background to false when finished" do
+    ActiveRecord::Base.connection.add_column :dummies, :avatar_processing_in_background, :boolean
+    rebuild_class styles: { thumb: "100x100" },
+                  only_process: [:none],
+                  process_in_background: [:thumb]
+
+    dummy = Dummy.create!(avatar_file_name: "5k.png", avatar_processing_in_background: true)
+    Paperclip::ProcessJob.perform_now(dummy, "avatar")
+
+    assert_equal false, dummy.reload.avatar_processing_in_background
   end
 end

--- a/spec/paperclip/process_job_spec.rb
+++ b/spec/paperclip/process_job_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+require "paperclip/process_job"
+
+RSpec.describe Paperclip::ProcessJob do
+  before do
+    ActiveJob::Base.queue_adapter = :test
+    ActiveJob::Base.logger = nil
+
+    @thumb_path = "tmp/public/system/dummies/avatars/000/000/001/thumb/5k.png"
+    File.delete(@thumb_path) if File.exist?(@thumb_path)
+  end
+
+  after do
+    ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+  end
+
+  it "processes styles marked for background processing" do
+    file = File.new(fixture_file("5k.png"), "rb")
+    FileUtils.cp(file, "tmp/public/system/dummies/avatars/000/000/001/original/5k.png")
+    rebuild_model styles: { thumb: "100x100" },
+                  only_process: [:none],
+                  process_in_background: [:thumb]
+
+    dummy = Dummy.create!
+    dummy.update_columns(avatar_file_name: "5k.png")
+
+    assert_file_not_exists(@thumb_path)
+    Paperclip::ProcessJob.perform_now(dummy, "avatar")
+    assert_file_exists(@thumb_path)
+  end
+end


### PR DESCRIPTION
Very basic implementation for background processing support using ActvieJob.

It requires more work, but I would like to start collecting your feedback about implementation and possible features.

I tested it with file and s3 storages locally.

Questions:
- ~~I think it make sense to add db column where we can mark that file is being processed () - do you think boolean `:attachment_name:_processing_in_background` is fine?~~ done
- To force processing in background one have to set array of styles in `process_in_background` options, but also set `only_processing` to fake `[:none]`, as empty array processes all by default. I would like to solve it some better way. How it should behave?

[ref #2260]
