### PR TITLE
Don't allow trailing newlines in various checks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Quick Start
 ```ruby
 class User < ActiveRecord::Base
   has_attached_file :avatar, styles: { medium: "300x300>", thumb: "100x100>" }, default_url: "/images/:style/missing.png"
-  validates_attachment_content_type :avatar, content_type: /\Aimage\/.*\Z/
+  validates_attachment_content_type :avatar, content_type: /\Aimage\/.*\z/
 end
 ```
 
@@ -417,7 +417,7 @@ class ActiveRecord::Base
   # Validate content type
   validates_attachment_content_type :avatar, content_type: /\Aimage/
   # Validate filename
-  validates_attachment_file_name :avatar, matches: [/png\Z/, /jpe?g\Z/]
+  validates_attachment_file_name :avatar, matches: [/png\z/, /jpe?g\z/]
   # Explicitly do not validate
   do_not_validate_attachment_file_type :avatar
 end

--- a/lib/paperclip/interpolations.rb
+++ b/lib/paperclip/interpolations.rb
@@ -141,7 +141,7 @@ module Paperclip
         # It's possible, though unlikely, that the mime type is not in the
         # database, so just use the part after the '/' in the mime type as the
         # extension.
-        %r{/([^/]*)\Z}.match(attachment.content_type)[1]
+        %r{/([^/]*)\z}.match(attachment.content_type)[1]
       end
     end
 

--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -48,7 +48,7 @@ module Paperclip
         end unless defined?(Fog)
 
         base.instance_eval do
-          unless @options[:url].to_s.match(/\A:fog.*url\Z/)
+          unless @options[:url].to_s.match(/\A:fog.*url\z/)
             @options[:path]  = @options[:path].gsub(/:url/, @options[:url]).gsub(/\A:rails_root\/public\/system\//, '')
             @options[:url]   = ':fog_public_url'
           end
@@ -58,7 +58,7 @@ module Paperclip
         end
       end
 
-      AWS_BUCKET_SUBDOMAIN_RESTRICTON_REGEX = /\A(?:[a-z]|\d(?!\d{0,2}(?:\.\d{1,3}){3}\Z))(?:[a-z0-9]|\.(?![\.\-])|\-(?![\.])){1,61}[a-z0-9]\Z/
+      AWS_BUCKET_SUBDOMAIN_RESTRICTON_REGEX = /\A(?:[a-z]|\d(?!\d{0,2}(?:\.\d{1,3}){3}\z))(?:[a-z0-9]|\.(?![\.\-])|\-(?![\.])){1,61}[a-z0-9]\z/
 
       def exists?(style = default_style)
         if original_filename

--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -147,7 +147,7 @@ module Paperclip
             @s3_server_side_encryption = @options[:s3_server_side_encryption]
           end
 
-          unless @options[:url].to_s.match(/\A:s3.*url\Z/) || @options[:url] == ":asset_host".freeze
+          unless @options[:url].to_s.match(/\A:s3.*url\z/) || @options[:url] == ":asset_host".freeze
             @options[:path] = path_option.gsub(/:url/, @options[:url]).sub(/\A:rails_root\/public\/system/, "".freeze)
             @options[:url]  = ":s3_path_url".freeze
           end

--- a/lib/paperclip/validators.rb
+++ b/lib/paperclip/validators.rb
@@ -36,7 +36,7 @@ module Paperclip
         options = attributes.extract_options!.dup
 
         Paperclip::Validators.constants.each do |constant|
-          if constant.to_s =~ /\AAttachment(.+)Validator\Z/
+          if constant.to_s =~ /\AAttachment(.+)Validator\z/
             validator_kind = $1.underscore.to_sym
 
             if options.has_key?(validator_kind)

--- a/spec/paperclip/validators_spec.rb
+++ b/spec/paperclip/validators_spec.rb
@@ -31,8 +31,8 @@ describe Paperclip::Validators do
     before do
       rebuild_class
       Dummy.validates_attachment :avatar, file_type_ignorance: true, file_name: [
-          { matches: /\A.*\.jpe?g\Z/i, message: :invalid_extension },
-          { matches: /\A.{,8}\..+\Z/i, message: [:too_long, count: 8] },
+          { matches: /\A.*\.jpe?g\z/i, message: :invalid_extension },
+          { matches: /\A.{,8}\..+\z/i, message: [:too_long, count: 8] },
       ]
     end
 


### PR DESCRIPTION
There's a subtle difference between what `\Z` and `\z` consider the "end of string" which is that the uppercase version allows a single trailing newline:

```ruby
/\Afoo\Z/.match("foo\n")
# => #<MatchData "foo">

/\Afoo\Z/.match("foo\n\n")
# => nil

/\Afoo\z/.match("foo\n")
# => nil
```

The current usage of `\Z` / `\z` in the project can be discovered with:

```
$ git grep -iI "\\\z"
```

I've left the Cucumber steps alone as changing them makes adding the `has_attached_file` line fail.