### PR TITLE
Default to Paperclip::ContentTypeDetector

### DIFF
--- a/lib/paperclip/io_adapters/uploaded_file_adapter.rb
+++ b/lib/paperclip/io_adapters/uploaded_file_adapter.rb
@@ -24,7 +24,7 @@ module Paperclip
     end
 
     def content_type_detector
-      self.class.content_type_detector
+      self.class.content_type_detector || Paperclip::ContentTypeDetector
     end
 
     def determine_content_type

--- a/spec/paperclip/io_adapters/uploaded_file_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/uploaded_file_adapter_spec.rb
@@ -29,7 +29,7 @@ describe Paperclip::UploadedFileAdapter do
       end
 
       it "gets the content type" do
-        assert_equal "image/x-png-by-browser", @subject.content_type
+        assert_equal "image/png", @subject.content_type
       end
 
       it "gets the file's size" do
@@ -98,7 +98,7 @@ describe Paperclip::UploadedFileAdapter do
       end
 
       it "gets the content type" do
-        assert_equal "image/x-png-by-browser", @subject.content_type
+        assert_equal "image/png", @subject.content_type
       end
 
       it "gets the file's size" do


### PR DESCRIPTION
This patch defaults `Paperclip::UploadedFileAdapter.content_type_detector` to `Paperclip::ContentTypeDetector`.

Without it, Paperclip allows the upload of any content, _including executables_, so long as the client forges a permitted content-type.

Security holes shouldn't be the default setting where we can avoid it.