### PR TITLE
Add Code Climate Config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,17 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - ruby
+  fixme:
+    enabled: true
+  rubocop:
+    enabled: true
+ratings:
+  paths:
+  - "**.rb"
+exclude_paths:
+- features/
+- spec/

--- a/.hound.yml
+++ b/.hound.yml
@@ -20,7 +20,8 @@ AllCops:
     - "db/schema.rb"
     - 'vendor/**/*'
     - 'gemfiles/vendor/**/*'
-  RunRailsCops: false
+  Rails:
+    Enabled: false
   DisplayCopNames: false
   StyleGuideCopsOnly: false
 Style/AccessModifierIndentation:
@@ -434,7 +435,7 @@ Style/TrailingBlankLines:
   SupportedStyles:
   - final_newline
   - final_blank_line
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
   Description: Checks for trailing comma in parameter lists and literals.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
   Enabled: false
@@ -560,11 +561,6 @@ Rails/ActionFilter:
   - filter
   Include:
   - app/controllers/**/*.rb
-Rails/DefaultScope:
-  Description: Checks if the argument passed to default_scope is a block.
-  Enabled: true
-  Include:
-  - app/models/**/*.rb
 Rails/HasAndBelongsToMany:
   Description: Prefer has_many :through to has_and_belongs_to_many.
   Enabled: true
@@ -685,10 +681,6 @@ Style/DefWithParentheses:
   Description: Use def with parentheses when there are arguments.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#method-parens
   Enabled: true
-Style/DeprecatedHashMethods:
-  Description: Checks for use of deprecated Hash methods.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#hash-key
-  Enabled: false
 Style/Documentation:
   Description: Document classes and non-namespace modules.
   Enabled: false
@@ -840,7 +832,7 @@ Style/SelfAssignment:
     used.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#self-assignment
   Enabled: false
-Style/SingleSpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Description: Checks that exactly one space is used between a method name and the
     first argument for method calls without parentheses.
   Enabled: true
@@ -852,7 +844,7 @@ Style/SpaceAfterComma:
   Description: Use spaces after commas.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
   Enabled: true
-Style/SpaceAfterControlKeyword:
+Style/SpaceAroundKeyword:
   Description: Use spaces after if/elsif/unless/while/until/case/when.
   Enabled: true
 Style/SpaceAfterMethodName:
@@ -880,9 +872,6 @@ Style/SpaceBeforeSemicolon:
 Style/SpaceAroundOperators:
   Description: Use spaces around operators.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: true
-Style/SpaceBeforeModifierKeyword:
-  Description: Put a space before the modifier keyword.
   Enabled: true
 Style/SpaceInsideBrackets:
   Description: No spaces after [ or before ].


### PR DESCRIPTION
Hello friends,

Earlier today, we unintentionally deleted this repository from Code Climate while doing some administrative cleanup. I'm really sorry this happened and please know we can get the data back if that's what you'd like, but we were wondering if you'd rather have the repository re-added using our new Platform.

The one hiccup is that your rubocop config is too old for our engine to use, so analyses on the new Platform don't succeed. This PR corrects that (and tries not to step on Hound in the process), making the repository suitable for adding again on Code Climate.

Please let me know what you think.

