### PR TITLE
Updated documentation

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -99,17 +99,21 @@ module Paperclip
     #   "x-amz-meta-" before sending it as a header on the object
     #   upload request. Can be defined both globally and within a style-specific hash.
     # * +s3_storage_class+: If this option is set to
-    #   <tt>:reduced_redundancy</tt>, the object will be stored using Reduced
-    #   Redundancy Storage.  RRS enables customers to reduce their
+    #   <tt>:REDUCED_REDUNDANCY</tt>, the object will be stored using Reduced
+    #   Redundancy Storage. RRS enables customers to reduce their
     #   costs by storing non-critical, reproducible data at lower
     #   levels of redundancy than Amazon S3's standard storage.
     #
     #   You can set storage class on a per style bases by doing the following:
     #     :s3_storage_class => {
-    #       :thumb => :reduced_reduncancy
+    #       :thumb => :REDUCED_REDUNDANCY
     #     }
+    #
     #   Or globally:
-    #     :s3_storage_class => :reduced_redundancy
+    #     :s3_storage_class => :REDUCED_REDUNDANCY
+    #
+    #   Other storage classes, such as <tt>:STANDARD_IA</tt>, are also available—see the
+    #   documentation for the <tt>aws-sdk</tt> gem for the full list.
 
     module S3
       def self.extended base


### PR DESCRIPTION
[These lines](https://github.com/thoughtbot/paperclip/blob/95acf3b898bd782f4429d42fd2d8812505390328/lib/paperclip/storage/s3.rb#L101-L112) in the documentation indicated that the value for the `s3_storage_class` configuration option should be `:reduced_redundancy`. However, using this value with Paperclip 5.0.0 results in a `Aws::S3::Errors::InvalidStorageClass` error with the message `The storage class you specified is not valid`.

The [documentation for the `Aws::S3::Object#storage_class` method](http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Object.html#storage_class-instance_method) in the `aws-sdk` gem documentation indicates that the correct value is now `REDUCED_REDUNDANCY` (along with a few other potential values).