### PR TITLE
fix broken anchor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ https://github.com/thoughtbot/paperclip/releases
 - [Custom Attachment Processors](#custom-attachment-processors)
 - [Events](#events)
 - [URI Obfuscation](#uri-obfuscation)
-- [MD5 Checksum / Fingerprint](#md5-checksum--fingerprint)
+- [Checksum / Fingerprint](#checksum--fingerprint)
 - [File Preservation for Soft-Delete](#file-preservation-for-soft-delete)
 - [Dynamic Configuration](#dynamic-configuration)
   - [Dynamic Styles:](#dynamic-styles)


### PR DESCRIPTION
header was [changed recently](https://github.com/thoughtbot/paperclip/commit/5202acbf4b642230bef71a8dd534bcca11fb4373#diff-04c6e90faac2675aa89e2176d2eec7d8L740), but link was not and now it's broken