### PR TITLE
Update docs for s3_permissions

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -45,10 +45,10 @@ module Paperclip
     #
     #   You can set permission on a per style bases by doing the following:
     #     :s3_permissions => {
-    #       :original => :private
+    #       :original => "private"
     #     }
     #   Or globally:
-    #     :s3_permissions => :private
+    #     :s3_permissions => "private"
     #
     # * +s3_protocol+: The protocol for the URLs generated to your S3 assets.
     #   Can be either 'http', 'https', or an empty string to generate


### PR DESCRIPTION
s3_permissions can no longer be a symbol. Must be a string.
Providing a string causes hard to debug errors in AWS.

As a side note, when these sorts of breaking changes occur to 
config I really think checks need to be put in place to validate
user input. Debugging this was time consuming as the errors
I was getting in no way made it obvious this was the problem.

N.B. I'm assuming that a change was made at some point to 
change s3_permissions from a symbol to a string. We were
previously using an older version of paperclip where this 
worked fine but when I updated this started failing.