### PR TITLE
uri adapter: allow filenames with unquoted syntax

### DIFF
--- a/lib/paperclip/io_adapters/uri_adapter.rb
+++ b/lib/paperclip/io_adapters/uri_adapter.rb
@@ -30,7 +30,7 @@ module Paperclip
     def filename_from_content_disposition
       if @content.meta.has_key?("content-disposition")
         matches = @content.meta["content-disposition"].
-          match(/filename="([^"]*)"/)
+          match(/filename=['"]?([^'";]+)['"]?/)
         matches[1] if matches
       end
     end

--- a/spec/paperclip/io_adapters/uri_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/uri_adapter_spec.rb
@@ -117,6 +117,18 @@ describe Paperclip::UriAdapter do
     it "returns a file name" do
       assert_equal file_name, @subject.original_filename
     end
+
+    context "with unquoted syntax" do
+      let(:meta) do
+        {
+          "content-disposition" => "attachment; filename=#{file_name};",
+        }
+      end
+
+      it "returns a file name with unquoted syntax" do
+        assert_equal file_name, @subject.original_filename
+      end
+    end
   end
 
   context "a url with restricted characters in the filename" do


### PR DESCRIPTION
There is sort of this gray area where two RFCs conflict about the format
for the filename parameter. It is legal for servers to send unquoted
filenames, though no server should do this since it complicates things.
Nevertheless, client implementations should be able to handle both kinds
of syntax.

https://tools.ietf.org/html/rfc2616
https://tools.ietf.org/html/rfc6266#section-5
http://rubular.com/r/6m0tqSfenR
