### PR TITLE
Check for spoofing of files without an extension

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,7 @@ master:
   `CLASS=User rake paperclip:refresh:fingerprints`
   You can optionally limit the attachment that will be processed, e.g:
   `CLASS=User ATTACHMENT=avatar rake paperclip:refresh:fingerprints`
+* Improvement: Files without an extension will now be checked for spoofing attempts
 
 5.1.0 (2016-08-19):
 

--- a/lib/paperclip/media_type_spoof_detector.rb
+++ b/lib/paperclip/media_type_spoof_detector.rb
@@ -34,11 +34,14 @@ module Paperclip
     end
 
     def extension_type_mismatch?
-      supplied_media_type.present? && has_extension? && !media_types_from_name.include?(supplied_media_type)
+      supplied_media_type.present? &&
+        has_extension? &&
+        !media_types_from_name.include?(supplied_media_type)
     end
 
     def calculated_type_mismatch?
-      supplied_media_type.present? && !calculated_content_type.include?(supplied_media_type)
+      supplied_media_type.present? &&
+        !calculated_content_type.include?(supplied_media_type)
     end
 
     def mapping_override_mismatch?

--- a/lib/paperclip/media_type_spoof_detector.rb
+++ b/lib/paperclip/media_type_spoof_detector.rb
@@ -11,7 +11,7 @@ module Paperclip
     end
 
     def spoofed?
-      if has_name? && has_extension? && media_type_mismatch? && mapping_override_mismatch?
+      if has_name? && media_type_mismatch? && mapping_override_mismatch?
         Paperclip.log("Content Type Spoof: Filename #{File.basename(@name)} (#{supplied_content_type} from Headers, #{content_types_from_name.map(&:to_s)} from Extension), content type discovered from file command: #{calculated_content_type}. See documentation to allow this combination.")
         true
       else
@@ -34,11 +34,11 @@ module Paperclip
     end
 
     def supplied_type_mismatch?
-      supplied_media_type.present? && !media_types_from_name.include?(supplied_media_type)
+      supplied_media_type.present? && has_extension? && !media_types_from_name.include?(supplied_media_type)
     end
 
     def calculated_type_mismatch?
-      !media_types_from_name.include?(calculated_media_type)
+      supplied_media_type.present? && !calculated_content_type.include?(supplied_media_type)
     end
 
     def mapping_override_mismatch?

--- a/lib/paperclip/media_type_spoof_detector.rb
+++ b/lib/paperclip/media_type_spoof_detector.rb
@@ -30,10 +30,10 @@ module Paperclip
     end
 
     def media_type_mismatch?
-      supplied_type_mismatch? || calculated_type_mismatch?
+      extension_type_mismatch? || calculated_type_mismatch?
     end
 
-    def supplied_type_mismatch?
+    def extension_type_mismatch?
       supplied_media_type.present? && has_extension? && !media_types_from_name.include?(supplied_media_type)
     end
 

--- a/spec/paperclip/media_type_spoof_detector_spec.rb
+++ b/spec/paperclip/media_type_spoof_detector_spec.rb
@@ -58,18 +58,26 @@ describe Paperclip::MediaTypeSpoofDetector do
     end
   end
 
-  context "GIF file named without extension, but we're told it's a GIF file" do
+  context "GIF file named without extension, but we're told GIF" do
     let(:file) { File.open(fixture_file("animated")) }
-    let(:spoofed?) { Paperclip::MediaTypeSpoofDetector.using(file, "animated", "image/gif").spoofed? }
+    let(:spoofed?) do
+      Paperclip::MediaTypeSpoofDetector.
+        using(file, "animated", "image/gif").
+        spoofed?
+    end
 
     it "accepts the file" do
-      assert ! spoofed?
+      assert !spoofed?
     end
   end
 
-  context "GIF file named without extension, but we're told it's an HTML file" do
+  context "GIF file named without extension, but we're told HTML" do
     let(:file) { File.open(fixture_file("animated")) }
-    let(:spoofed?) { Paperclip::MediaTypeSpoofDetector.using(file, "animated", "text/html").spoofed? }
+    let(:spoofed?) do
+      Paperclip::MediaTypeSpoofDetector.
+        using(file, "animated", "text/html").
+        spoofed?
+    end
 
     it "rejects the file" do
       assert spoofed?

--- a/spec/paperclip/media_type_spoof_detector_spec.rb
+++ b/spec/paperclip/media_type_spoof_detector_spec.rb
@@ -58,6 +58,24 @@ describe Paperclip::MediaTypeSpoofDetector do
     end
   end
 
+  context "GIF file named without extension, but we're told it's a GIF file" do
+    let(:file) { File.open(fixture_file("animated")) }
+    let(:spoofed?) { Paperclip::MediaTypeSpoofDetector.using(file, "animated", "image/gif").spoofed? }
+
+    it "accepts the file" do
+      assert ! spoofed?
+    end
+  end
+
+  context "GIF file named without extension, but we're told it's an HTML file" do
+    let(:file) { File.open(fixture_file("animated")) }
+    let(:spoofed?) { Paperclip::MediaTypeSpoofDetector.using(file, "animated", "text/html").spoofed? }
+
+    it "rejects the file" do
+      assert spoofed?
+    end
+  end
+
   it "does not reject if content_type is empty but otherwise checks out" do
     file = File.open(fixture_file("empty.html"))
     assert ! Paperclip::MediaTypeSpoofDetector.using(file, "empty.html", "").spoofed?


### PR DESCRIPTION
While using the Paperclip gem, we noticed during some ad-hoc testing that if you do not supply an extension when uploading a file, Paperclip effectively skipped it's spoofing check, which allowed potentially dangerous files to slip through into your application.

This addresses that by moving the checks around a little bit and only testing against the extension when there is one.
