### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ rvm:
 
 script: "bundle exec rake clean spec cucumber"
 
+before_install:
+  - rvm @global do gem uninstall bundler -a -x
+  - rvm @global do gem install bundler -v 1.12.5
+
 gemfile:
   - gemfiles/4.2.gemfile
   - gemfiles/5.0.gemfile

--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -23,7 +23,7 @@ When /^I modify my attachment definition to:$/ do |definition|
 end
 
 When /^I upload the fixture "([^"]*)"$/ do |filename|
-  run_simple %(bundle exec #{runner_command} "User.create!(:attachment => File.open('#{fixture_path(filename)}'))")
+  run_simple %(bundle exec rails runner "User.create!(:attachment => File.open('#{fixture_path(filename)}'))")
 end
 
 Then /^the attachment "([^"]*)" should have a dimension of (\d+x\d+)$/ do |filename, dimension|
@@ -56,7 +56,7 @@ Then /^the attachment should have the same content type as the fixture "([^"]*)"
       require "mime/types"
     end
 
-    attachment_content_type = `bundle exec #{runner_command} "puts User.last.attachment_content_type"`.strip
+    attachment_content_type = `bundle exec rails runner "puts User.last.attachment_content_type"`.strip
     expected = MIME::Types.type_for(filename).first.content_type
     expect(attachment_content_type).to eq(expected)
   end
@@ -64,14 +64,14 @@ end
 
 Then /^the attachment should have the same file name as the fixture "([^"]*)"$/ do |filename|
   cd(".") do
-    attachment_file_name = `bundle exec #{runner_command} "puts User.last.attachment_file_name"`.strip
+    attachment_file_name = `bundle exec rails runner "puts User.last.attachment_file_name"`.strip
     expect(attachment_file_name).to eq(File.name(fixture_path(filename)).to_s)
   end
 end
 
 Then /^the attachment should have the same file size as the fixture "([^"]*)"$/ do |filename|
   cd(".") do
-    attachment_file_size = `bundle exec #{runner_command} "puts User.last.attachment_file_size"`.strip
+    attachment_file_size = `bundle exec rails runner "puts User.last.attachment_file_size"`.strip
     expect(attachment_file_size).to eq(File.size(fixture_path(filename)).to_s)
   end
 end
@@ -84,7 +84,7 @@ end
 
 Then /^I should have attachment columns for "([^"]*)"$/ do |attachment_name|
   cd(".") do
-    columns = eval(`bundle exec #{runner_command} "puts User.columns.map{ |column| [column.name, column.type] }.inspect"`.strip)
+    columns = eval(`bundle exec rails runner "puts User.columns.map{ |column| [column.name, column.type] }.inspect"`.strip)
     expect_columns = [
       ["#{attachment_name}_file_name", :string],
       ["#{attachment_name}_content_type", :string],
@@ -97,7 +97,7 @@ end
 
 Then /^I should not have attachment columns for "([^"]*)"$/ do |attachment_name|
   cd(".") do
-    columns = eval(`bundle exec #{runner_command} "puts User.columns.map{ |column| [column.name, column.type] }.inspect"`.strip)
+    columns = eval(`bundle exec rails runner "puts User.columns.map{ |column| [column.name, column.type] }.inspect"`.strip)
     expect_columns = [
       ["#{attachment_name}_file_name", :string],
       ["#{attachment_name}_content_type", :string],

--- a/features/step_definitions/rails_steps.rb
+++ b/features/step_definitions/rails_steps.rb
@@ -1,7 +1,12 @@
 Given /^I generate a new rails application$/ do
   steps %{
-    When I run `bundle exec #{new_application_command} #{APP_NAME} --skip-bundle`
+    When I run `rails new #{APP_NAME} --skip-bundle`
     And I cd to "#{APP_NAME}"
+  }
+
+  FileUtils.chdir("tmp/aruba/testapp/")
+
+  steps %{
     And I turn off class caching
     And I fix the application.rb for 3.0.12
     And I write to "Gemfile" with:
@@ -21,6 +26,8 @@ Given /^I generate a new rails application$/ do
     And I empty the application.js file
     And I configure the application to use "paperclip" from this project
   }
+
+  FileUtils.chdir("../../..")
 end
 
 Given "I fix the application.rb for 3.0.12" do
@@ -60,11 +67,7 @@ Given /^I attach :attachment with:$/ do |definition|
 end
 
 def attach_attachment(name, definition = nil)
-  snippet = ""
-  if using_protected_attributes?
-    snippet += "attr_accessible :name, :#{name}\n"
-  end
-  snippet += "has_attached_file :#{name}"
+  snippet = "has_attached_file :#{name}"
   if definition
     snippet += ", \n"
     snippet += definition
@@ -86,19 +89,19 @@ Given "I empty the application.js file" do
 end
 
 Given /^I run a rails generator to generate a "([^"]*)" scaffold with "([^"]*)"$/ do |model_name, attributes|
-  step %[I successfully run `bundle exec #{generator_command} scaffold #{model_name} #{attributes}`]
+  step %[I successfully run `rails generate scaffold #{model_name} #{attributes}`]
 end
 
 Given /^I run a paperclip generator to add a paperclip "([^"]*)" to the "([^"]*)" model$/ do |attachment_name, model_name|
-  step %[I successfully run `bundle exec #{generator_command} paperclip #{model_name} #{attachment_name}`]
+  step %[I successfully run `rails generate paperclip #{model_name} #{attachment_name}`]
 end
 
 Given /^I run a migration$/ do
-  step %[I successfully run `bundle exec rake db:migrate --trace`]
+  step %[I successfully run `rake db:migrate --trace`]
 end
 
 When /^I rollback a migration$/ do
-  step %[I successfully run `bundle exec rake db:rollback STEPS=1 --trace`]
+  step %[I successfully run `rake db:rollback STEPS=1 --trace`]
 end
 
 Given /^I update my new user view to include the file upload field$/ do

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -17,7 +17,7 @@ module NavigationHelpers
         page_name =~ /the (.*) page/
         path_components = $1.split(/\s+/)
         self.send(path_components.push('path').join('_').to_sym)
-      rescue Object => e
+      rescue Object
         raise "Can't find mapping from \"#{page_name}\" to a path.\n" +
           "Now, go and add a mapping in #{__FILE__}"
       end

--- a/features/support/rails.rb
+++ b/features/support/rails.rb
@@ -35,29 +35,5 @@ module RailsCommandHelpers
   def framework_major_version
     framework_version.split(".").first.to_i
   end
-
-  def using_protected_attributes?
-    framework_major_version < 4
-  end
-
-  def new_application_command
-    "rails new"
-  end
-
-  def generator_command
-    if framework_major_version >= 4
-      "rails generate"
-    else
-      "script/rails generate"
-    end
-  end
-
-  def runner_command
-    if framework_major_version >= 4
-      "rails runner"
-    else
-      "script/rails runner"
-    end
-  end
 end
 World(RailsCommandHelpers)

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('mocha')
   s.add_development_dependency('aws-sdk', '>= 2.3.0', '< 3.0')
   s.add_development_dependency('bourne')
-  s.add_development_dependency('cucumber', '~> 1.3.18')
+  s.add_development_dependency('cucumber-rails')
   s.add_development_dependency('aruba', '~> 0.9.0')
   s.add_development_dependency('nokogiri')
   s.add_development_dependency('capybara')
@@ -48,7 +48,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake')
   s.add_development_dependency('fakeweb')
   s.add_development_dependency('railties')
-  s.add_development_dependency('actionmailer', '>= 4.2.0')
   s.add_development_dependency('generator_spec')
   s.add_development_dependency('timecop')
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,8 @@ FIXTURES_DIR = File.join(File.dirname(__FILE__), "fixtures")
 config = YAML::load(IO.read(File.dirname(__FILE__) + '/database.yml'))
 ActiveRecord::Base.logger = Logger.new(File.dirname(__FILE__) + "/debug.log")
 ActiveRecord::Base.establish_connection(config['test'])
-unless ActiveRecord::VERSION::STRING < "4.2"
+if ActiveRecord::VERSION::STRING >= "4.2" &&
+    ActiveRecord::VERSION::STRING < "5.0"
   ActiveRecord::Base.raise_in_transactional_callbacks = true
 end
 Paperclip.options[:logger] = ActiveRecord::Base.logger


### PR DESCRIPTION
- Removes `bundle exec` from commands ran in cucumber steps
- Simplifies `framework_major_version` (we can assume it always is 4 or higher)