### PR TITLE
fix ImageMagick command in Windows

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -98,7 +98,8 @@ module Paperclip
       :swallow_stderr => true,
       :content_type_mappings => {},
       :use_exif_orientation => true,
-      :read_timeout => nil
+      :read_timeout => nil,
+      :is_windows => Gem.win_platform?
     }
   end
 

--- a/lib/paperclip/geometry_detector_factory.rb
+++ b/lib/paperclip/geometry_detector_factory.rb
@@ -17,7 +17,7 @@ module Paperclip
         orientation = Paperclip.options[:use_exif_orientation] ?
           "%[exif:orientation]" : "1"
         Paperclip.run(
-          Gem.win_platform?"magick identify":"identify",
+          (Gem.win_platform?)?"magick identify":"identify",
           "-format '%wx%h,#{orientation}' :file", {
             :file => "#{path}[0]"
           }, {

--- a/lib/paperclip/geometry_detector_factory.rb
+++ b/lib/paperclip/geometry_detector_factory.rb
@@ -17,7 +17,7 @@ module Paperclip
         orientation = Paperclip.options[:use_exif_orientation] ?
           "%[exif:orientation]" : "1"
         Paperclip.run(
-          (Gem.win_platform?)?"magick identify":"identify",
+          Gem.win_platform? ? "magick identify" : "identify",
           "-format '%wx%h,#{orientation}' :file", {
             :file => "#{path}[0]"
           }, {

--- a/lib/paperclip/geometry_detector_factory.rb
+++ b/lib/paperclip/geometry_detector_factory.rb
@@ -16,13 +16,8 @@ module Paperclip
       begin
         orientation = Paperclip.options[:use_exif_orientation] ?
           "%[exif:orientation]" : "1"
-        if Gem.win_platform?
-          command = "magick identify"
-        else 
-          command = "identify"
-        end
         Paperclip.run(
-          command,
+          Gem.win_platform?"magick identify":"identify",
           "-format '%wx%h,#{orientation}' :file", {
             :file => "#{path}[0]"
           }, {

--- a/lib/paperclip/geometry_detector_factory.rb
+++ b/lib/paperclip/geometry_detector_factory.rb
@@ -16,8 +16,13 @@ module Paperclip
       begin
         orientation = Paperclip.options[:use_exif_orientation] ?
           "%[exif:orientation]" : "1"
+        if Gem.win_platform 
+          command = "magick identify"
+        else 
+          command = "identify"
+        end
         Paperclip.run(
-          "identify",
+          command,
           "-format '%wx%h,#{orientation}' :file", {
             :file => "#{path}[0]"
           }, {

--- a/lib/paperclip/geometry_detector_factory.rb
+++ b/lib/paperclip/geometry_detector_factory.rb
@@ -17,7 +17,7 @@ module Paperclip
         orientation = Paperclip.options[:use_exif_orientation] ?
           "%[exif:orientation]" : "1"
         Paperclip.run(
-          Gem.win_platform? ? "magick identify" : "identify",
+          Paperclip.options[:is_windows] ? "magick identify" : "identify",
           "-format '%wx%h,#{orientation}' :file", {
             :file => "#{path}[0]"
           }, {

--- a/lib/paperclip/geometry_detector_factory.rb
+++ b/lib/paperclip/geometry_detector_factory.rb
@@ -16,7 +16,7 @@ module Paperclip
       begin
         orientation = Paperclip.options[:use_exif_orientation] ?
           "%[exif:orientation]" : "1"
-        if Gem.win_platform 
+        if Gem.win_platform?
           command = "magick identify"
         else 
           command = "identify"

--- a/lib/paperclip/processor.rb
+++ b/lib/paperclip/processor.rb
@@ -37,7 +37,7 @@ module Paperclip
     # The convert method runs the convert binary with the provided arguments.
     # See Paperclip.run for the available options.
     def convert(arguments = "", local_options = {})
-      Paperclip.run(Gem.win_platform?"magick convert":"convert", arguments, local_options)
+      Paperclip.run(Gem.win_platform ? "magick convert" : "convert", arguments, local_options)
     end
 
     # The identify method runs the identify binary with the provided arguments.

--- a/lib/paperclip/processor.rb
+++ b/lib/paperclip/processor.rb
@@ -38,9 +38,9 @@ module Paperclip
     # See Paperclip.run for the available options.
     def convert(arguments = "", local_options = {})
       if Gem.win_platform?
-        Paperclip.run('magick convert', arguments, local_options)
-      else 
-        Paperclip.run('convert', arguments, local_options)
+        Paperclip.run("magick convert", arguments, local_options)
+      else
+        Paperclip.run("convert", arguments, local_options)
       end
     end
 
@@ -48,9 +48,9 @@ module Paperclip
     # See Paperclip.run for the available options.
     def identify(arguments = "", local_options = {})
       if Gem.win_platform?
-        Paperclip.run('magick identify', arguments, local_options)
-      else 
-        Paperclip.run('identify', arguments, local_options)
+        Paperclip.run("magick identify", arguments, local_options)
+      else
+        Paperclip.run("identify", arguments, local_options)
       end
     end
   end

--- a/lib/paperclip/processor.rb
+++ b/lib/paperclip/processor.rb
@@ -38,7 +38,7 @@ module Paperclip
     # See Paperclip.run for the available options.
     def convert(arguments = "", local_options = {})
       Paperclip.run(
-        Gem.win_platform ? "magick convert" : "convert",
+        Paperclip.options[:is_windows] ? "magick convert" : "convert",
         arguments,
         local_options,
       )
@@ -48,7 +48,7 @@ module Paperclip
     # See Paperclip.run for the available options.
     def identify(arguments = "", local_options = {})
       Paperclip.run(
-        Gem.win_platform? ? "magick identify" : "identify",
+        Paperclip.options[:is_windows] ? "magick identify" : "identify",
         arguments,
         local_options,
       )

--- a/lib/paperclip/processor.rb
+++ b/lib/paperclip/processor.rb
@@ -40,7 +40,7 @@ module Paperclip
       Paperclip.run(
         Gem.win_platform ? "magick convert" : "convert",
         arguments,
-        local_options
+        local_options,
       )
     end
 
@@ -50,7 +50,7 @@ module Paperclip
       Paperclip.run(
         Gem.win_platform? ? "magick identify" : "identify",
         arguments,
-        local_options
+        local_options,
       )
     end
   end

--- a/lib/paperclip/processor.rb
+++ b/lib/paperclip/processor.rb
@@ -37,13 +37,21 @@ module Paperclip
     # The convert method runs the convert binary with the provided arguments.
     # See Paperclip.run for the available options.
     def convert(arguments = "", local_options = {})
-      Paperclip.run('convert', arguments, local_options)
+      if Gem.win_platform?
+        Paperclip.run('magick convert', arguments, local_options)
+      else 
+        Paperclip.run('convert', arguments, local_options)
+      end
     end
 
     # The identify method runs the identify binary with the provided arguments.
     # See Paperclip.run for the available options.
     def identify(arguments = "", local_options = {})
-      Paperclip.run('identify', arguments, local_options)
+      if Gem.win_platform?
+        Paperclip.run('magick identify', arguments, local_options)
+      else 
+        Paperclip.run('identify', arguments, local_options)
+      end
     end
   end
 end

--- a/lib/paperclip/processor.rb
+++ b/lib/paperclip/processor.rb
@@ -43,7 +43,7 @@ module Paperclip
     # The identify method runs the identify binary with the provided arguments.
     # See Paperclip.run for the available options.
     def identify(arguments = "", local_options = {})
-      Paperclip.run(Gem.win_platform?"magick identify":"identify", arguments, local_options)
+      Paperclip.run(Gem.win_platform? ? "magick identify" : "identify", arguments, local_options)
     end
   end
 end

--- a/lib/paperclip/processor.rb
+++ b/lib/paperclip/processor.rb
@@ -37,13 +37,21 @@ module Paperclip
     # The convert method runs the convert binary with the provided arguments.
     # See Paperclip.run for the available options.
     def convert(arguments = "", local_options = {})
-      Paperclip.run(Gem.win_platform ? "magick convert" : "convert", arguments, local_options)
+      Paperclip.run(
+        Gem.win_platform ? "magick convert" : "convert",
+        arguments,
+        local_options
+      )
     end
 
     # The identify method runs the identify binary with the provided arguments.
     # See Paperclip.run for the available options.
     def identify(arguments = "", local_options = {})
-      Paperclip.run(Gem.win_platform? ? "magick identify" : "identify", arguments, local_options)
+      Paperclip.run(
+        Gem.win_platform? ? "magick identify" : "identify",
+        arguments,
+        local_options
+      )
     end
   end
 end

--- a/lib/paperclip/processor.rb
+++ b/lib/paperclip/processor.rb
@@ -37,21 +37,13 @@ module Paperclip
     # The convert method runs the convert binary with the provided arguments.
     # See Paperclip.run for the available options.
     def convert(arguments = "", local_options = {})
-      if Gem.win_platform?
-        Paperclip.run("magick convert", arguments, local_options)
-      else
-        Paperclip.run("convert", arguments, local_options)
-      end
+      Paperclip.run(Gem.win_platform?"magick convert":"convert", arguments, local_options)
     end
 
     # The identify method runs the identify binary with the provided arguments.
     # See Paperclip.run for the available options.
     def identify(arguments = "", local_options = {})
-      if Gem.win_platform?
-        Paperclip.run("magick identify", arguments, local_options)
-      else
-        Paperclip.run("identify", arguments, local_options)
-      end
+      Paperclip.run(Gem.win_platform?"magick identify":"identify", arguments, local_options)
     end
   end
 end


### PR DESCRIPTION
Add OS detect to choose right command.

It seems that paperclip use identify as exe in windows,

`Command :: SET PATH=C:\file-5.03-bin\bin;%PATH% & identify -format '%wx%h,%[exif:orientation]' "C:/Users/AppData/Local/Temp/5415c7fe534a63366b48d388f204c32820161028-7156-f2nblm.jpg[0]" 2>NUL`.,

while only `magick identify` command  works in windows,and there in no identify.exe in windows in the latest version ImageMagic.
And only `Paperclip.options[:command_path]` is used, the `Paperclip.options[:image_magick_path]` seems ignored.

About imageMagick in windows can be found [there](http://www.imagemagick.org/script/binary-releases.php).
