### PR TITLE
Remove Tempfile tests from Thumbnail spec

### DIFF
--- a/spec/paperclip/tempfile_spec.rb
+++ b/spec/paperclip/tempfile_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Paperclip::Tempfile do
   context "A Paperclip Tempfile" do

--- a/spec/paperclip/tempfile_spec.rb
+++ b/spec/paperclip/tempfile_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Paperclip::Tempfile do
+  context "A Paperclip Tempfile" do
+    before do
+      @tempfile = described_class.new(["file", ".jpg"])
+    end
+
+    after { @tempfile.close }
+
+    it "has its path contain a real extension" do
+      assert_equal ".jpg", File.extname(@tempfile.path)
+    end
+
+    it "is a real Tempfile" do
+      assert @tempfile.is_a?(::Tempfile)
+    end
+  end
+
+  context "Another Paperclip Tempfile" do
+    before do
+      @tempfile = described_class.new("file")
+    end
+
+    after { @tempfile.close }
+
+    it "does not have an extension if not given one" do
+      assert_equal "", File.extname(@tempfile.path)
+    end
+
+    it "is a real Tempfile" do
+      assert @tempfile.is_a?(::Tempfile)
+    end
+  end
+end

--- a/spec/paperclip/thumbnail_spec.rb
+++ b/spec/paperclip/thumbnail_spec.rb
@@ -1,38 +1,6 @@
 require 'spec_helper'
 
 describe Paperclip::Thumbnail do
-  context "A Paperclip Tempfile" do
-    before do
-      @tempfile = Paperclip::Tempfile.new(["file", ".jpg"])
-    end
-
-    after { @tempfile.close }
-
-    it "has its path contain a real extension" do
-      assert_equal ".jpg", File.extname(@tempfile.path)
-    end
-
-    it "is a real Tempfile" do
-      assert @tempfile.is_a?(::Tempfile)
-    end
-  end
-
-  context "Another Paperclip Tempfile" do
-    before do
-      @tempfile = Paperclip::Tempfile.new("file")
-    end
-
-    after { @tempfile.close }
-
-    it "does not have an extension if not given one" do
-      assert_equal "", File.extname(@tempfile.path)
-    end
-
-    it "is a real Tempfile" do
-      assert @tempfile.is_a?(::Tempfile)
-    end
-  end
-
   context "An image" do
     before do
       @file = File.new(fixture_file("5k.png"), 'rb')


### PR DESCRIPTION
## What's Up

Was browsing the paperclip test suite and noticed that the `thumbnail_spec` had a few tests from a while back that did not belong - they were testing `Paperclip::Tempfile` instead.

## What This Does

This PR removes those tests.