### PR TITLE
Skip validity check when reprocess attachment

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -337,8 +337,15 @@ module Paperclip
     # inconsistencies in timing of S3 commands. It's possible that calling
     # #reprocess! will lose data if the files are not kept.
     def reprocess!(*style_args)
-      saved_only_process, @options[:only_process] = @options[:only_process], style_args
-      saved_preserve_files, @options[:preserve_files] = @options[:preserve_files], true
+      saved_flags = @options.slice(
+        :only_process,
+        :preserve_files,
+        :check_validity_before_processing
+      )
+      @options[:only_process] = style_args
+      @options[:preserve_files] = true
+      @options[:check_validity_before_processing] = false
+
       begin
         assign(self)
         save
@@ -347,8 +354,7 @@ module Paperclip
         warn "#{e} - skipping file."
         false
       ensure
-        @options[:only_process] = saved_only_process
-        @options[:preserve_files] = saved_preserve_files
+        @options.merge!(saved_flags)
       end
     end
 

--- a/spec/paperclip/attachment_spec.rb
+++ b/spec/paperclip/attachment_spec.rb
@@ -53,6 +53,22 @@ describe Paperclip::Attachment do
     expect(dummy.avatar.path(:original)).to exist
   end
 
+  it "reprocess works with virtual content_type attribute" do
+    rebuild_class styles: { small: "100x>" }
+    modify_table { |t| t.remove :avatar_content_type }
+    Dummy.send :attr_accessor, :avatar_content_type
+    Dummy.validates_attachment_content_type(
+      :avatar,
+      content_type: %w(image/jpeg image/png)
+    )
+    Dummy.create!(avatar: File.new(fixture_file("50x50.png"), "rb"))
+
+    dummy = Dummy.first
+    dummy.avatar.reprocess!(:small)
+
+    expect(dummy.avatar.path(:small)).to exist
+  end
+
   context "having a not empty hash as a default option" do
     before do
       @old_default_options = Paperclip::Attachment.default_options.dup

--- a/spec/support/model_reconstruction.rb
+++ b/spec/support/model_reconstruction.rb
@@ -27,7 +27,7 @@ module ModelReconstruction
     ActiveRecord::Base.connection.create_table :dummies, {force: true}, &block
   end
 
-  def modify_table table_name, &block
+  def modify_table &block
     ActiveRecord::Base.connection.change_table :dummies, &block
   end
 


### PR DESCRIPTION
This validation was causing issue when there is no content_type column in the database, as the content type of the attachment would be empty. There should be no need to check attachment's validity because this `#reprocess!` method is running internally on the server.

Fix #2078