### PR TITLE
Introduce `add_validation_errors_to` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ Example Usage:
 validates_attachment_presence :avatar
 ```
 
-Lastly, you can also define multiple validations on a single attachment using `validates_attachment`:
+You can also define multiple validations on a single attachment using `validates_attachment`:
 
 ```ruby
 validates_attachment :avatar, presence: true,
@@ -401,6 +401,28 @@ validates_attachment :avatar,
 
 `Paperclip::ContentTypeDetector` will attempt to match a file's extension to an
 inferred content_type, regardless of the actual contents of the file.
+
+### Duplicate error messages
+
+By default Paperclip will copy validation errors from the attribute to the base
+of your model. Depending on how you display your validation errors, this can lead
+to confusing duplicate errors (one on the attribute and another referring to the
+base model).
+
+You can override this behaviour with the `add_validation_errors_to` option. By
+default this is set to `:both` but can be set to either `:attribute` or `:base`.
+
+* `:both` creates errors on both the attribute and base model.
+* `:attribute` only creates an error on the attribute of the model.
+* `:base` only creates an error on the base model.
+
+You can set this option globally:
+
+`Paperclip.options[:add_validation_errors_to] = :attribute`
+
+or pass it in to an individual validation declaration:
+
+`validates_attachment :document, content_type: { content_type: "application/pdf" }, add_validation_errors_to: :attribute`
 
 ---
 

--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -98,6 +98,7 @@ module Paperclip
       swallow_stderr: true,
       use_exif_orientation: true,
       whiny: true,
+      add_validation_errors_to: :both
     }
   end
 

--- a/lib/paperclip/validators.rb
+++ b/lib/paperclip/validators.rb
@@ -20,10 +20,10 @@ module Paperclip
     ::Paperclip::REQUIRED_VALIDATORS = [AttachmentFileNameValidator, AttachmentContentTypeValidator, AttachmentFileTypeIgnoranceValidator]
 
     module ClassMethods
-      # This method is a shortcut to validator classes that is in
-      # "Attachment...Validator" format. It is almost the same thing as the
-      # +validates+ method that shipped with Rails, but this is customized to
-      # be using with attachment validators. This is helpful when you're using
+      # This method is a shortcut to the validator classes that are in
+      # "Attachment...Validator" format. It is almost the same as the
+      # +validates+ method that ships with Rails, but is customized for
+      # use with attachment validators. This is helpful when you're using
       # multiple attachment validators on a single attachment.
       #
       # Example of using the validator:

--- a/lib/paperclip/validators/attachment_content_type_validator.rb
+++ b/lib/paperclip/validators/attachment_content_type_validator.rb
@@ -3,6 +3,9 @@ module Paperclip
     class AttachmentContentTypeValidator < ActiveModel::EachValidator
       def initialize(options)
         options[:allow_nil] = true unless options.has_key?(:allow_nil)
+        unless options.has_key?(:add_validation_errors_to)
+          options[:add_validation_errors_to] = Paperclip.options[:add_validation_errors_to]
+        end
         super
       end
 
@@ -20,10 +23,13 @@ module Paperclip
         validate_whitelist(record, attribute, value)
         validate_blacklist(record, attribute, value)
 
-        if record.errors.include? attribute
+        if record.errors.include?(attribute) &&
+        [:both, :base].include?(options[:add_validation_errors_to])
           record.errors[attribute].each do |error|
             record.errors.add base_attribute, error
           end
+
+          record.errors.delete(attribute) if options[:add_validation_errors_to] == :base
         end
       end
 

--- a/lib/paperclip/validators/attachment_file_name_validator.rb
+++ b/lib/paperclip/validators/attachment_file_name_validator.rb
@@ -3,6 +3,9 @@ module Paperclip
     class AttachmentFileNameValidator < ActiveModel::EachValidator
       def initialize(options)
         options[:allow_nil] = true unless options.has_key?(:allow_nil)
+        unless options.has_key?(:add_validation_errors_to)
+          options[:add_validation_errors_to] = Paperclip.options[:add_validation_errors_to]
+        end
         super
       end
 
@@ -20,10 +23,13 @@ module Paperclip
         validate_whitelist(record, attribute, value)
         validate_blacklist(record, attribute, value)
 
-        if record.errors.include? attribute
+        if record.errors.include?(attribute) &&
+        [:both, :base].include?(options[:add_validation_errors_to])
           record.errors[attribute].each do |error|
             record.errors.add base_attribute, error
           end
+
+          record.errors.delete(attribute) if options[:add_validation_errors_to] == :base
         end
       end
 

--- a/lib/paperclip/validators/attachment_size_validator.rb
+++ b/lib/paperclip/validators/attachment_size_validator.rb
@@ -17,6 +17,18 @@ module Paperclip
       def validate_each(record, attr_name, value)
         base_attr_name = attr_name
         attr_name = "#{attr_name}_file_size".to_sym
+
+        error_attrs = []
+        case options[:add_validation_errors_to]
+        when :base
+          error_attrs << base_attr_name
+        when :attribute
+          error_attrs << attr_name
+        else
+          error_attrs << base_attr_name
+          error_attrs << attr_name
+        end
+
         value = record.send(:read_attribute_for_validation, attr_name)
 
         unless value.blank?
@@ -26,7 +38,7 @@ module Paperclip
 
             unless value.send(CHECKS[option], option_value)
               error_message_key = options[:in] ? :in_between : option
-              [ attr_name, base_attr_name ].each do |error_attr_name|
+              error_attrs.each do |error_attr_name|
                 record.errors.add(error_attr_name, error_message_key, filtered_options(value).merge(
                   :min => min_value_in_human_size(record),
                   :max => max_value_in_human_size(record),
@@ -55,6 +67,10 @@ module Paperclip
             options[:less_than_or_equal_to] = range
             options[:greater_than_or_equal_to] = range
           end
+        end
+
+        unless options.has_key?(:add_validation_errors_to)
+          options[:add_validation_errors_to] = Paperclip.options[:add_validation_errors_to]
         end
       end
 

--- a/spec/paperclip/validators/attachment_content_type_validator_spec.rb
+++ b/spec/paperclip/validators/attachment_content_type_validator_spec.rb
@@ -67,6 +67,94 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
     end
   end
 
+  context "with add_validation_errors_to not set (implicitly :both)" do
+    it "adds error to both attribute and base" do
+      build_validator content_type: "image/png", allow_nil: false
+      @dummy.stubs(avatar_content_type: nil)
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar_content_type].present?,
+        "Error not added to attribute"
+
+      assert @dummy.errors[:avatar].present?,
+        "Error not added to base attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :attribute globally" do
+    before do
+      Paperclip.options[:add_validation_errors_to] = :attribute
+    end
+
+    after do
+      Paperclip.options[:add_validation_errors_to] = :both
+    end
+
+    it "only adds error to attribute not base" do
+      build_validator content_type: "image/png", allow_nil: false
+      @dummy.stubs(avatar_content_type: nil)
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar_content_type].present?,
+        "Error not added to attribute"
+
+      assert @dummy.errors[:avatar].blank?,
+        "Error added to base attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :base globally" do
+    before do
+      Paperclip.options[:add_validation_errors_to] = :base
+    end
+
+    after do
+      Paperclip.options[:add_validation_errors_to] = :both
+    end
+
+    it "only adds error to base not attribute" do
+      build_validator content_type: "image/png", allow_nil: false
+      @dummy.stubs(avatar_content_type: nil)
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar].present?,
+        "Error not added to base attribute"
+
+      assert @dummy.errors[:avatar_content_type].blank?,
+        "Error added to attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :attribute" do
+    it "only adds error to attribute not base" do
+      build_validator content_type: "image/png", allow_nil: false,
+        add_validation_errors_to: :attribute
+      @dummy.stubs(avatar_content_type: nil)
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar_content_type].present?,
+        "Error not added to attribute"
+
+      assert @dummy.errors[:avatar].blank?,
+        "Error added to base attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :base" do
+    it "only adds error to base not attribute" do
+      build_validator content_type: "image/png", allow_nil: false,
+        add_validation_errors_to: :base
+      @dummy.stubs(avatar_content_type: nil)
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar].present?,
+        "Error not added to base attribute"
+
+      assert @dummy.errors[:avatar_content_type].blank?,
+        "Error added to attribute"
+    end
+  end
+
   context "with a successful validation" do
     before do
       build_validator content_type: "image/png", allow_nil: false

--- a/spec/paperclip/validators/attachment_file_name_validator_spec.rb
+++ b/spec/paperclip/validators/attachment_file_name_validator_spec.rb
@@ -29,6 +29,94 @@ describe Paperclip::Validators::AttachmentFileNameValidator do
     end
   end
 
+  context "with add_validation_errors_to not set (implicitly :both)" do
+    it "adds error to both attribute and base" do
+      build_validator matches: /.*\.png$/, allow_nil: false
+      @dummy.stubs(avatar_file_name: "data.txt")
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar_file_name].present?,
+        "Error not added to attribute"
+
+      assert @dummy.errors[:avatar].present?,
+        "Error not added to base attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :attribute globally" do
+    before do
+      Paperclip.options[:add_validation_errors_to] = :attribute
+    end
+
+    after do
+      Paperclip.options[:add_validation_errors_to] = :both
+    end
+
+    it "only adds error to attribute not base" do
+      build_validator matches: /.*\.png$/, allow_nil: false
+      @dummy.stubs(avatar_file_name: "data.txt")
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar_file_name].present?,
+        "Error not added to attribute"
+
+      assert @dummy.errors[:avatar].blank?,
+        "Error added to base attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :base globally" do
+    before do
+      Paperclip.options[:add_validation_errors_to] = :base
+    end
+
+    after do
+      Paperclip.options[:add_validation_errors_to] = :both
+    end
+
+    it "only adds error to base not attribute" do
+      build_validator matches: /.*\.png$/, allow_nil: false
+      @dummy.stubs(avatar_file_name: "data.txt")
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar].present?,
+        "Error not added to base attribute"
+
+      assert @dummy.errors[:avatar_file_name].blank?,
+        "Error added to attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :attribute" do
+    it "only adds error to attribute not base" do
+      build_validator matches: /.*\.png$/, allow_nil: false,
+        add_validation_errors_to: :attribute
+      @dummy.stubs(avatar_file_name: "data.txt")
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar_file_name].present?,
+        "Error not added to attribute"
+
+      assert @dummy.errors[:avatar].blank?,
+        "Error added to base attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :base" do
+    it "only adds error to base not attribute" do
+      build_validator matches: /.*\.png$/, allow_nil: false,
+        add_validation_errors_to: :base
+      @dummy.stubs(avatar_file_name: "data.txt")
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar].present?,
+        "Error not added to base attribute"
+
+      assert @dummy.errors[:avatar_file_name].blank?,
+        "Error added to attribute"
+    end
+  end
+
   it "does not add error to the base object with a successful validation" do
     build_validator matches: /.*\.png$/, allow_nil: false
     @dummy.stubs(avatar_file_name: "image.png")

--- a/spec/paperclip/validators/attachment_size_validator_spec.rb
+++ b/spec/paperclip/validators/attachment_size_validator_spec.rb
@@ -205,6 +205,94 @@ describe Paperclip::Validators::AttachmentSizeValidator do
     end
   end
 
+  context "with add_validation_errors_to not set (implicitly :both)" do
+    it "adds error to both attribute and base" do
+      build_validator in: (5.kilobytes..10.kilobytes)
+      @dummy.stubs(:avatar_file_size).returns(11.kilobytes)
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar_file_size].present?,
+        "Error not added to attribute"
+
+      assert @dummy.errors[:avatar].present?,
+        "Error not added to base attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :attribute globally" do
+    before do
+      Paperclip.options[:add_validation_errors_to] = :attribute
+    end
+
+    after do
+      Paperclip.options[:add_validation_errors_to] = :both
+    end
+
+    it "only adds error to attribute not base" do
+      build_validator in: (5.kilobytes..10.kilobytes)
+      @dummy.stubs(:avatar_file_size).returns(11.kilobytes)
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar_file_size].present?,
+        "Error not added to attribute"
+
+      assert @dummy.errors[:avatar].blank?,
+        "Error added to base attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :base globally" do
+    before do
+      Paperclip.options[:add_validation_errors_to] = :base
+    end
+
+    after do
+      Paperclip.options[:add_validation_errors_to] = :both
+    end
+
+    it "only adds error to base not attribute" do
+      build_validator in: (5.kilobytes..10.kilobytes)
+      @dummy.stubs(:avatar_file_size).returns(11.kilobytes)
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar].present?,
+        "Error not added to base attribute"
+
+      assert @dummy.errors[:avatar_file_size].blank?,
+        "Error added to attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :attribute" do
+    it "only adds error to attribute not base" do
+      build_validator in: (5.kilobytes..10.kilobytes),
+        add_validation_errors_to: :attribute
+      @dummy.stubs(:avatar_file_size).returns(11.kilobytes)
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar_file_size].present?,
+        "Error not added to attribute"
+
+      assert @dummy.errors[:avatar].blank?,
+        "Error added to base attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :base" do
+    it "only adds error to base not attribute" do
+      build_validator in: (5.kilobytes..10.kilobytes),
+        add_validation_errors_to: :base
+      @dummy.stubs(:avatar_file_size).returns(11.kilobytes)
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar].present?,
+        "Error not added to base attribute"
+
+      assert @dummy.errors[:avatar_file_size].blank?,
+        "Error added to attribute"
+    end
+  end
+
   context "using the helper" do
     before do
       Dummy.validates_attachment_size :avatar, in: (5.kilobytes..10.kilobytes)


### PR DESCRIPTION
Valid values for `add_validation_errors_to` are `:attribute`, `:base`,
or `:both`.

The option is globally set to `:both` that retains the existing
behaviour of adding validation errors to both the attribute and the
model base.

Closes: #1367
References: #2090, #2040