### PR TITLE
Fix JRuby binary operator warning

### DIFF
--- a/lib/paperclip/storage/filesystem.rb
+++ b/lib/paperclip/storage/filesystem.rb
@@ -46,7 +46,7 @@ module Paperclip
             end
           end
           unless @options[:override_file_permissions] == false
-            resolved_chmod = (@options[:override_file_permissions] &~ 0111) || (0666 &~ File.umask)
+            resolved_chmod = (@options[:override_file_permissions] & ~0111) || (0666 & ~File.umask)
             FileUtils.chmod( resolved_chmod, path(style_name) )
           end
           file.rewind


### PR DESCRIPTION
Fixes the following warning shown by JRuby 9.1.6.0:

gems/paperclip-5.1.0/lib/paperclip/storage/filesystem.rb:49: warning: `&' after local variable or literal is interpreted as binary operator even though it seems like argument prefix