### PR TITLE
Fix access denied / file exists error on Windows

### DIFF
--- a/lib/paperclip/io_adapters/abstract_adapter.rb
+++ b/lib/paperclip/io_adapters/abstract_adapter.rb
@@ -57,13 +57,15 @@ module Paperclip
     end
 
     def link_or_copy_file(src, dest)
-      Paperclip.log("Trying to link #{src} to #{dest}")
-      FileUtils.ln(src, dest, force: true) # overwrite existing
       @destination.close
+      begin
+        Paperclip.log("Trying to link #{src} to #{dest}")
+        FileUtils.ln(src, dest, force: true) # overwrite existing
+      rescue Errno::EXDEV, Errno::EPERM, Errno::ENOENT => e
+        Paperclip.log("Link failed with #{e.message}; copying link #{src} to #{dest}")
+        FileUtils.cp(src, dest)
+      end
       @destination.open.binmode
-    rescue Errno::EXDEV, Errno::EPERM, Errno::ENOENT => e
-      Paperclip.log("Link failed with #{e.message}; copying link #{src} to #{dest}")
-      FileUtils.cp(src, dest)
     end
   end
 end


### PR DESCRIPTION
After the changes introduced by #2290, uploads were broken for me on my Windows dev machine. The problem turned out to be the 'destination' file, which was opened and created before the 'link_or_copy_file' method is called. 'FileUtils.ln', when called with the 'force' parameter, tries to first delete the file and ignores the inevitable access denied error, then fails to create the link, since the destination path already exists. I have reordered the code to first close the destination file and only reopen it at the end, when file operations have completed.