### PR TITLE
Add mandatory attachment content type to Quick Start model in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,8 @@ Quick Start
 ```ruby
 class User < ActiveRecord::Base
   has_attached_file :avatar, styles: { medium: "300x300>", thumb: "100x100>" }, default_url: "/images/:style/missing.png"
-  validates_attachment_content_type :avatar, content_type: /\Aimage\/.*\z/
+  validates_attachment_presence :avatar
+  validates_attachment_content_type :avatar, :content_type => ["image/jpg", "image/jpeg", "image/png", "image/gif", "application/pdf"]
 end
 ```
 


### PR DESCRIPTION
Paperclip version 4.0 and onward requires attachment content type. Users following the quick start instructions will fail unless validates_attachment_content_type is declared in the model.

I got it to work by reviewing Naveen Thonpunoori's stack overflow response to [this question](http://stackoverflow.com/questions/33151061/papercliperrorsmissingrequiredvalidatorerror).