### PR TITLE
Correct the version limitations on aws-sdk

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -119,6 +119,8 @@ module Paperclip
     #   Other storage classes, such as <tt>:STANDARD_IA</tt>, are also available—see the
     #   documentation for the <tt>aws-sdk</tt> gem for the full list.
 
+    MIN_SUPPORTED_AWS_SDK_VERSION = "2.0.34".freeze
+
     module S3
       def self.extended base
         begin
@@ -127,9 +129,8 @@ module Paperclip
           e.message << " (You may need to install the aws-sdk gem)"
           raise e
         end
-        if Gem::Version.new(Aws::VERSION) >= Gem::Version.new(2) &&
-           Gem::Version.new(Aws::VERSION) <= Gem::Version.new("2.0.33")
-          raise LoadError, "paperclip does not support aws-sdk versions 2.0.0 - 2.0.33.  Please upgrade aws-sdk to a newer version."
+        if Gem::Version.new(Aws::VERSION) < Gem::Version.new(MIN_SUPPORTED_AWS_SDK_VERSION)
+          raise LoadError, "paperclip requires aws-sdk >= #{MIN_SUPPORTED_AWS_SDK_VERSION}.  Please upgrade aws-sdk to a newer version."
         end
 
         base.instance_eval do


### PR DESCRIPTION
Note that when this code was originally added (commit
3dcc08c2e374b5d21ce7b7939535dd299df6e4ba), aws-sdk 1.x was supported,
but as of commit 25be0b25d67923e28419c6146e8f8307741a974b, it is not,
so it's sufficient to say that versions < 2.0.34 are not supported.