### PR TITLE
fix missing dependency when running  require paperclip in irb

### DIFF
--- a/lib/paperclip/url_generator.rb
+++ b/lib/paperclip/url_generator.rb
@@ -1,4 +1,5 @@
 require 'uri'
+require 'active_support/core_ext/module/delegation'
 
 module Paperclip
   class UrlGenerator


### PR DESCRIPTION
fix missing dependency on delegator in Rails. Not sure how to test it, because all active support core extensions are loaded in spec_helper

```
2.3.1 :003 > require 'paperclip'
NoMethodError: undefined method `delegate' for Paperclip::UrlGenerator:Class
Did you mean?  DelegateClass
  from /Users/lordvacuumcleaner/paperclip/lib/paperclip/url_generator.rb:21:in `<class:UrlGenerator>'
  from /Users/lordvacuumcleaner/paperclip/lib/paperclip/url_generator.rb:4:in `<module:Paperclip>'
  from /Users/lordvacuumcleaner/paperclip/lib/paperclip/url_generator.rb:3:in `<top (required)>'
  from /Users/lordvacuumcleaner/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  from /Users/lordvacuumcleaner/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  from /Users/lordvacuumcleaner/paperclip/lib/paperclip/attachment.rb:3:in `<top (required)>'
  from /Users/lordvacuumcleaner/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  from /Users/lordvacuumcleaner/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  from /Users/lordvacuumcleaner/paperclip/lib/paperclip.rb:44:in `<top (required)>'
  from /Users/lordvacuumcleaner/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  from /Users/lordvacuumcleaner/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  from (irb):3
  from /Users/lordvacuumcleaner/.rvm/rubies/ruby-2.3.1/bin/irb:11:in `<main>'
```