### PR TITLE
Added config to bypass media type spoofing check

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,16 @@
 master:
 
+* Improvement: Added `:do_not_do_media_type_spoofing_detection` option to Paperclip
+  to disable media type spoofing. Internally, this just returns `false` when calling 
+  `#spoofed?` on `MediaTypeSpoofDetector` when the configuration is set.
+
+  This is a reduction in security (hence the long and explicit config key) but this
+  would allow developers to make a decision on enabling/disabling Media Type Spoof
+  Detection on their environments.
+
+  A better implementation for this would be implementing this on a per-class basis
+  instead of a global configuration.
+
 * Improvement: Added `:use_accelerate_endpoint` option when using S3 to enable
   [Amazon S3 Transfer Acceleration](http://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html)
 * Improvement: make the fingerprint digest configurable per attachment. The

--- a/lib/paperclip/media_type_spoof_detector.rb
+++ b/lib/paperclip/media_type_spoof_detector.rb
@@ -11,6 +11,8 @@ module Paperclip
     end
 
     def spoofed?
+      return false if bypass?
+
       if has_name? && has_extension? && media_type_mismatch? && mapping_override_mismatch?
         Paperclip.log("Content Type Spoof: Filename #{File.basename(@name)} (#{supplied_content_type} from Headers, #{content_types_from_name.map(&:to_s)} from Extension), content type discovered from file command: #{calculated_content_type}. See documentation to allow this combination.")
         true
@@ -20,6 +22,9 @@ module Paperclip
     end
 
     private
+    def bypass?
+      Paperclip.options[:do_not_do_media_type_spoofing_detection]
+    end
 
     def has_name?
       @name.present?

--- a/spec/paperclip/media_type_spoof_detector_spec.rb
+++ b/spec/paperclip/media_type_spoof_detector_spec.rb
@@ -77,12 +77,15 @@ describe Paperclip::MediaTypeSpoofDetector do
     end
   end
 
-  it 'bypasses media type spoofing detection if disabled in config' do
+  it "bypasses media type spoofing detection if disabled in config" do
     begin
       Paperclip.options[:do_not_do_media_type_spoofing_detection] = true
       # See 'rejects a file that is named .html and identifies as PNG'
       file = File.open(fixture_file("5k.png"))
-      assert ! Paperclip::MediaTypeSpoofDetector.using(file, "5k.html", "image/png").spoofed?
+      spoofed = Paperclip::MediaTypeSpoofDetector
+                .using(file, "5k.html", "image/png").spoofed?
+
+      assert !spoofed
     ensure
       Paperclip.options.delete(:do_not_do_media_type_spoofing_detection)
     end

--- a/spec/paperclip/media_type_spoof_detector_spec.rb
+++ b/spec/paperclip/media_type_spoof_detector_spec.rb
@@ -76,4 +76,15 @@ describe Paperclip::MediaTypeSpoofDetector do
       Paperclip.options[:content_type_mappings] = {}
     end
   end
+
+  it 'bypasses media type spoofing detection if disabled in config' do
+    begin
+      Paperclip.options[:do_not_do_media_type_spoofing_detection] = true
+      # Example from earlier failing test
+      file = File.open(fixture_file("5k.png"))
+      assert ! Paperclip::MediaTypeSpoofDetector.using(file, "5k.html", "image/png").spoofed?
+    ensure
+      Paperclip.options.delete(:do_not_do_media_type_spoofing_detection)
+    end
+  end
 end

--- a/spec/paperclip/media_type_spoof_detector_spec.rb
+++ b/spec/paperclip/media_type_spoof_detector_spec.rb
@@ -80,7 +80,7 @@ describe Paperclip::MediaTypeSpoofDetector do
   it 'bypasses media type spoofing detection if disabled in config' do
     begin
       Paperclip.options[:do_not_do_media_type_spoofing_detection] = true
-      # Example from earlier failing test
+      # See 'rejects a file that is named .html and identifies as PNG'
       file = File.open(fixture_file("5k.png"))
       assert ! Paperclip::MediaTypeSpoofDetector.using(file, "5k.html", "image/png").spoofed?
     ensure


### PR DESCRIPTION
https://github.com/thoughtbot/paperclip/issues/1924

Though a better implementation for this would be doing this on a per
model basis.