### PR TITLE
Add connection caching for Fog storage

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,7 @@ master:
   `CLASS=User rake paperclip:refresh:fingerprints`
   You can optionally limit the attachment that will be processed, e.g:
   `CLASS=User ATTACHMENT=avatar rake paperclip:refresh:fingerprints`
+* Improvement: Add connection caching for Fog storage
 
 5.1.0 (2016-08-19):
 

--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -224,7 +224,8 @@ module Paperclip
       end
 
       def connection
-        @connection ||= ::Fog::Storage.new(fog_credentials)
+        instances = (Thread.current[:paperclip_fog_instances] ||= {})
+        instances[fog_credentials] ||= ::Fog::Storage.new(fog_credentials)
       end
 
       def directory


### PR DESCRIPTION
This is already done with the S3 storage. Authentication with Fog / OpenStack Swift takes some time so this is heavily required.
As this is my first contributions here please write everything I missed in the comments below. Specs should pass.