### PR TITLE
Better handling of the content-disposition header

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 master:
 
+* Improvement: Better handling of the content-disposition header. Now supports file name that is either
+  enclosed or not in double quotes and is case insensitive as per RC6266 grammar
 * Improvement: Added `:use_accelerate_endpoint` option when using S3 to enable
   [Amazon S3 Transfer Acceleration](http://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html)
 * Improvement: make the fingerprint digest configurable per attachment. The

--- a/lib/paperclip/io_adapters/uri_adapter.rb
+++ b/lib/paperclip/io_adapters/uri_adapter.rb
@@ -28,10 +28,13 @@ module Paperclip
     end
 
     def filename_from_content_disposition
-      if @content.meta.has_key?("content-disposition")
-        matches = @content.meta["content-disposition"].
-          match(/filename="([^"]*)"/)
-        matches[1] if matches
+      if @content.meta.has_key?("content-disposition") && @content.meta["content-disposition"].match(/filename/i)
+        # can include both filename and filename* values according to RCF6266. filename should come first
+        _, filename = @content.meta["content-disposition"].split(/filename\*?\s*=\s*/i)
+
+        # filename can be enclosed in quotes or not
+        matches = filename.match(/"(.*)"/)
+        matches ? matches[1] : filename.split(';')[0]
       end
     end
 


### PR DESCRIPTION
Encountered an issue where the URI was returning header with content-disposition where the filename value wasn't enclosed in the double quotes. Turns out that this is a valid grammar according to RFC6266. Also made the logic more robust to account for spaces and uppercase letters.