### PR TITLE
2253 handle url encoded

### DIFF
--- a/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
+++ b/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
@@ -4,9 +4,9 @@ module Paperclip
     REGEXP = /\Ahttps?:\/\//
 
     def initialize(target, options = {})
-      super(URI(URI.escape(target)), options)
+      escaped = URI.escape(target)
+      super(URI(target == URI.unescape(target) ? escaped : target), options)
     end
-
   end
 end
 

--- a/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
@@ -102,15 +102,32 @@ describe Paperclip::HttpUrlProxyAdapter do
   end
 
   context "a url with special characters in the filename" do
-    it "returns a encoded filename" do
+    before do
       Paperclip::HttpUrlProxyAdapter.any_instance.stubs(:download_content).
         returns(@open_return)
-      url = "https://github.com/thoughtbot/paperclip-öäü字´½♥Ø²È.png"
-      subject = Paperclip.io_adapters.for(url)
-      filename = "paperclip-%C3%B6%C3%A4%C3%BC%E5%AD%97%C2%B4%C2%BD%E2%99%A5"\
-        "%C3%98%C2%B2%C3%88.png"
+    end
 
+    let(:filename) do
+      "paperclip-%C3%B6%C3%A4%C3%BC%E5%AD%97%C2%B4%C2%BD%E2%99%A5"\
+        "%C3%98%C2%B2%C3%88.png"
+    end
+    let(:url) { "https://github.com/thoughtbot/paperclip-öäü字´½♥Ø²È.png" }
+
+    subject { Paperclip.io_adapters.for(url) }
+
+    it "returns a encoded filename" do
       assert_equal filename, subject.original_filename
+    end
+
+    context "when already URI encoded" do
+      let(:url) do
+        "https://github.com/thoughtbot/paperclip-%C3%B6%C3%A4%C3%BC%E5%AD%97"\
+        "%C2%B4%C2%BD%E2%99%A5%C3%98%C2%B2%C3%88.png"
+      end
+
+      it "returns a encoded filename" do
+        assert_equal filename, subject.original_filename
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #2253.

Allow `HttpUrlProxyAdapter` to handle already-escaped targets by calling `URI.escape` only when necessary (since the latter *isn't* idempotent).