### PR TITLE
Ruby 2.4.0 compatibility (doen't use Fixnum anymore)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 rvm:
   - 2.1
   - 2.2.2
+  - 2.4.0
 
 script: "bundle exec rake clean spec cucumber"
 

--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,7 @@ master:
   `CLASS=User rake paperclip:refresh:fingerprints`
   You can optionally limit the attachment that will be processed, e.g:
   `CLASS=User ATTACHMENT=avatar rake paperclip:refresh:fingerprints`
+* Ruby 2.4.0 compatibility (doen't use Fixnum anymore)
 
 5.1.0 (2016-08-19):
 

--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -184,7 +184,7 @@ module Paperclip
       private
 
       def convert_time(time)
-        if time.is_a?(Fixnum)
+        if time.is_a?(0.class)
           time = Time.now + time
         end
         time


### PR DESCRIPTION
On Ruby 2.4.0, this PR avoids warnings like this:

```
/usr/local/rvm/gems/ruby-2.4.0/gems/paperclip-5.1.0/lib/paperclip/storage/fog.rb:184: warning: constant ::Fixnum is deprecated 
```
