### PR TITLE
Adds optional style and file argument to s3_headers block

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -458,7 +458,7 @@ module Paperclip
         # keep backwards compatible with previous version that only took one argument
         http_headers = http_headers.call(instance) if http_headers.respond_to?(:call) && http_headers.arity == 1
         http_headers = http_headers.call(instance, style, file) if http_headers.respond_to?(:call) && http_headers.arity == 3
-        s3_headers.inject({}) do |headers,(name,value)|
+        http_headers.inject({}) do |headers,(name,value)|
           case name.to_s
           when /\Ax-amz-meta-(.*)/i
             s3_metadata[$1.downcase] = value

--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -458,7 +458,7 @@ module Paperclip
         # keep backwards compatible with previous version that only took one argument
         http_headers = http_headers.call(instance) if http_headers.respond_to?(:call) && http_headers.arity == 1
         http_headers = http_headers.call(instance, style, file) if http_headers.respond_to?(:call) && http_headers.arity == 3
-        http_headers.inject({}) do |headers,(name,value)|
+        s3_headers.inject({}) do |headers,(name,value)|
           case name.to_s
           when /\Ax-amz-meta-(.*)/i
             s3_metadata[$1.downcase] = value

--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -1609,7 +1609,7 @@ describe Paperclip::Storage::S3 do
     end
   end
 
-  context "An attachment with S3 storage and metadata set using a proc as headers" do
+  context "An attachment with S3 storage and metadata set using a proc that takes a single argument as headers" do
     before do
       rebuild_model(
         (aws2_add_region).merge storage: :s3,
@@ -1650,6 +1650,63 @@ describe Paperclip::Storage::S3 do
                     acl: :"public-read",
                     content_disposition: 'attachment; filename="Custom Avatar Name.png"')
           end
+          @dummy.save
+        end
+
+        it "succeeds" do
+          assert true
+        end
+      end
+    end
+  end
+
+  context "An attachment with S3 storage and metadata set using a proc that takes 3 argument as headers" do
+    before do
+      rebuild_model(
+        (aws2_add_region).merge storage: :s3,
+        bucket: "testing",
+        path: ":attachment/:style/:basename:dotextension",
+        styles: {
+          thumb: "80x80>"
+        },
+        s3_credentials: {
+          'access_key_id' => "12345",
+          'secret_access_key' => "54321"
+        },
+        s3_headers: lambda {|attachment, style, file|
+          style === :original ? {'Content-Disposition' => "attachment; filename=\"#{file.original_filename}\""} : {}
+        }
+      )
+    end
+
+    context "when assigned" do
+      before do
+        @file = File.new(fixture_file('5k.png'), 'rb')
+        @dummy = Dummy.new
+        @dummy.avatar = @file
+      end
+
+      after { @file.close }
+
+      context "and saved" do
+        before do
+          object = stub
+          @dummy.avatar.stubs(:s3_object).with(:original).returns(object)
+
+          object.expects(:upload_file)
+            .with(anything,
+                  content_type: "image/png",
+                  acl: :"public-read",
+                  content_disposition: 'attachment; filename="5k.png"')
+
+          object = stub
+          @dummy.avatar.stubs(:s3_object).with(:thumb).returns(object)
+
+          object.expects(:upload_file)
+            .with(anything,
+                  content_type: "image/png",
+                  acl: :"public-read")
+
           @dummy.save
         end
 


### PR DESCRIPTION
Fixes https://github.com/thoughtbot/paperclip/issues/2412

There are now two additional parameters that get passed to the s3_headers block:

```rb
s3_headers: lambda {|attachment, style, file|
  {'Content-Disposition' => "attachment; filename=\"#{file.original_filename}\""}
}
```