### PR TITLE
Ignore empty filename from content-disposition

### DIFF
--- a/lib/paperclip/io_adapters/uri_adapter.rb
+++ b/lib/paperclip/io_adapters/uri_adapter.rb
@@ -31,7 +31,7 @@ module Paperclip
       if @content.meta.has_key?("content-disposition")
         matches = @content.meta["content-disposition"].
           match(/filename="([^"]*)"/)
-        matches[1] if matches
+        matches[1].presence if matches
       end
     end
 


### PR DESCRIPTION
e.g., the way google stores its user profile photos (from their oauth2 API)
https://lh3.googleusercontent.com/-aRHQV4YjnBM/AAAAAAAAAAI/AAAAAAAAAAo/ngSjy9-yR5c/photo.jpg