### PR TITLE
Fix S3 HTTP Proxy option passed to AWS SDK, which changed in version 2

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -251,7 +251,7 @@ module Paperclip
               userinfo += ":#{http_proxy_password}" if http_proxy_password
               proxy_opts[:userinfo] = userinfo
             end
-            config[:proxy_uri] = URI::HTTP.build(proxy_opts)
+            config[:http_proxy] = URI::HTTP.build(proxy_opts)
           end
 
           config[:use_accelerate_endpoint] = use_accelerate_endpoint?


### PR DESCRIPTION
In version 2, aws-sdk started using Seahorse as HTTP Client, and the
`http_proxy` configuration changed from `:proxy_uri` to `:http_proxy`.

The new option can be seen here:
https://github.com/aws/aws-sdk-ruby/blob/master/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb#L234