### PR TITLE
Cancel all processing if instance contains any errors

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -505,6 +505,7 @@ module Paperclip
 
     def post_process(*style_args) #:nodoc:
       return if @queued_for_write[:original].nil?
+      return if @options[:check_validity_before_processing] && instance.errors.any?
 
       instance.run_paperclip_callbacks(:post_process) do
         instance.run_paperclip_callbacks(:"#{name}_post_process") do

--- a/spec/paperclip/attachment_spec.rb
+++ b/spec/paperclip/attachment_spec.rb
@@ -844,6 +844,16 @@ describe Paperclip::Attachment do
       @dummy.avatar = @file
     end
 
+    it "cancels the processing if instance contains any errors" do
+      @dummy.expects(:errors).with().returns([true])
+      @dummy.expects(:do_before_avatar).never
+      @dummy.expects(:do_after_avatar).never
+      @dummy.expects(:do_before_all).never
+      @dummy.expects(:do_after_all).never
+      Paperclip::Thumbnail.expects(:make).never
+      @dummy.avatar = @file
+    end
+
     it "cancels the processing if a before_post_process returns false" do
       @dummy.expects(:do_before_avatar).never
       @dummy.expects(:do_after_avatar).never


### PR DESCRIPTION
Prior to this PR the check for validity happened inside the run_paperclip_callbacks block, so callbacks where always run.

From the README

> NOTE: Post-processing will not even start if the attachment is not
> valid according to the validations. Your callbacks and processors will
> only be called with valid attachments.

This PR brings the codebase inline with the documented behaviour.

Fixes #2462