### PR TITLE
Add migration_version variable to migration generator for rails 5 compatibility

### DIFF
--- a/lib/generators/paperclip/paperclip_generator.rb
+++ b/lib/generators/paperclip/paperclip_generator.rb
@@ -13,7 +13,7 @@ class PaperclipGenerator < ActiveRecord::Generators::Base
   end
 
   def generate_migration
-    migration_template "paperclip_migration.rb.erb", "db/migrate/#{migration_file_name}"
+    migration_template "paperclip_migration.rb.erb", "db/migrate/#{migration_file_name}", migration_version: migration_version
   end
 
   def migration_name
@@ -26,5 +26,11 @@ class PaperclipGenerator < ActiveRecord::Generators::Base
 
   def migration_class_name
     migration_name.camelize
+  end
+
+  def migration_version
+    if Rails.version.start_with? '5'
+      "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
+    end
   end
 end

--- a/lib/generators/paperclip/paperclip_generator.rb
+++ b/lib/generators/paperclip/paperclip_generator.rb
@@ -13,7 +13,9 @@ class PaperclipGenerator < ActiveRecord::Generators::Base
   end
 
   def generate_migration
-    migration_template "paperclip_migration.rb.erb", "db/migrate/#{migration_file_name}", migration_version: migration_version
+    migration_template("paperclip_migration.rb.erb",
+                       "db/migrate/#{migration_file_name}",
+                       migration_version: migration_version)
   end
 
   def migration_name
@@ -29,7 +31,7 @@ class PaperclipGenerator < ActiveRecord::Generators::Base
   end
 
   def migration_version
-    if Rails.version.start_with? '5'
+    if Rails.version.start_with? "5"
       "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
     end
   end

--- a/lib/generators/paperclip/templates/paperclip_migration.rb.erb
+++ b/lib/generators/paperclip/templates/paperclip_migration.rb.erb
@@ -1,4 +1,4 @@
-class <%= migration_class_name %> < ActiveRecord::Migration
+class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version %>
   def self.up
     change_table :<%= table_name %> do |t|
 <% attachment_names.each do |attachment| -%>


### PR DESCRIPTION
# Problem

[Relevant Issue](https://github.com/thoughtbot/paperclip/issues/2465) : Rails 5 does not allow classes to inherit directly from ActiveRecord::Migration without specifying a version. This prevents basic actions such as `db:migrate`.

# Solution

If the rails version is >= 5.x, pass a `migration_version` variable to the `migration_template` function to ensure that `[5.x]` is appended to the migration function declaration.

For similar code from a more trusted source, see [Devise's implementation](https://github.com/plataformatec/devise/blob/master/lib/generators/active_record/devise_generator.rb#L14).

## Concerns

Hey there's no test for this change! But there are no tests for any of the paperclip generator functions. It's late maybe I'll write em later.