### PR TITLE
Remove bad exception handling!

### DIFF
--- a/lib/tasks/paperclip.rake
+++ b/lib/tasks/paperclip.rake
@@ -46,7 +46,7 @@ namespace :paperclip do
           attachment = instance.send(name)
           begin
             attachment.reprocess!(*styles)
-          rescue Exception => e
+          rescue => e
             Paperclip::Task.log_error("exception while processing #{klass} ID #{instance.id}:")
             Paperclip::Task.log_error(" " + e.message + "\n")
           end

--- a/lib/tasks/paperclip.rake
+++ b/lib/tasks/paperclip.rake
@@ -46,7 +46,7 @@ namespace :paperclip do
           attachment = instance.send(name)
           begin
             attachment.reprocess!(*styles)
-          rescue => e
+          rescue StandardError => e
             Paperclip::Task.log_error("exception while processing #{klass} ID #{instance.id}:")
             Paperclip::Task.log_error(" " + e.message + "\n")
           end


### PR DESCRIPTION
Exception is the root of Ruby's exception hierarchy, so when you rescue Exception you rescue from everything, including subclasses such as SyntaxError, LoadError, and Interrupt etc which is a bad idea.

Fix: rescue from StandardError.