### PR TITLE
Backport Invalid Content-Disposition header fix to v4.3 

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+4.3.8 (8/23/2017):
+
+* Bug Fix: Backport "Ignore invalid content-disposition header (#2284)" to 4.3
+
 4.3.7 (7/1/2016):
 
 * Add deprecation warnings

--- a/lib/paperclip/io_adapters/uri_adapter.rb
+++ b/lib/paperclip/io_adapters/uri_adapter.rb
@@ -30,8 +30,9 @@ module Paperclip
 
     def filename_from_content_disposition
       if @content.meta.has_key?("content-disposition")
-        @content.meta["content-disposition"].
-          match(/filename="([^"]*)"/)[1]
+        matches = @content.meta["content-disposition"].
+          match(/filename="([^"]*)"/)
+        matches[1] if matches
       end
     end
 

--- a/lib/paperclip/version.rb
+++ b/lib/paperclip/version.rb
@@ -1,3 +1,3 @@
 module Paperclip
-  VERSION = "4.3.7".freeze unless defined? Paperclip::VERSION
+  VERSION = "4.3.8".freeze unless defined? Paperclip::VERSION
 end


### PR DESCRIPTION
This cherry picks 1f7886b onto the `v4.3` branch and tags a release for `v4.3.8`—backporting an important fix for the `UriAdapter` so that files can be attached with or without a valid `Content-Disposition` header. In the invalid or missing case, an error occurs as described in #2283.

#2284 Added this to the `master` branch and this adds that commit to the 4.3 history.

