### PR TITLE
Removed extra whitespace from UPGRADING

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -1,5 +1,5 @@
 ##################################################
-#  NOTE FOR UPGRADING FROM 4.3.0 OR EARLIER       #
+#  NOTE FOR UPGRADING FROM 4.3.0 OR EARLIER      #
 ##################################################
 
 Paperclip is now compatible with aws-sdk >= 2.0.0.


### PR DESCRIPTION
I noticed an extra whitespace character in the layout, it looked ugly in the CLI when installing the gem.