### PR TITLE
Change :default_url to default value to nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,11 @@ module YourApp
   class Application < Rails::Application
     # Other code...
 
-    config.paperclip_defaults = { storage: :fog, fog_credentials: { provider: "Local", local_root: "#{Rails.root}/public"}, fog_directory: "", fog_host: "localhost"}
+    config.paperclip_defaults = { storage: :fog,
+                                  fog_credentials: { provider: "Local", local_root: "#{Rails.root}/public"}, 
+                                  fog_directory: "", 
+                                  fog_host: "localhost",
+                                  default_url: "/:attachment/:style/missing.png" }
   end
 end
 ```
@@ -484,6 +488,7 @@ Paperclip::Attachment.default_options[:storage] = :fog
 Paperclip::Attachment.default_options[:fog_credentials] = { provider: "Local", local_root: "#{Rails.root}/public"}
 Paperclip::Attachment.default_options[:fog_directory] = ""
 Paperclip::Attachment.default_options[:fog_host] = "http://localhost:3000"
+Paperclip::Attachment.default_options[:default_url] = "/:attachment/:style/missing.png"
 ```
 ---
 

--- a/UPGRADING
+++ b/UPGRADING
@@ -1,4 +1,20 @@
 ##################################################
+#  DEPRECATION NOTICE                            #
+##################################################
+
+The 6.x version of Paperclip will change the behavior of the `:default_url`
+to be nil. In 5.x and earlier it is defaulted to 'missing.png'
+
+You can migrate to the new behavior now by adding to an initializer:
+
+Paperclip::Attachment.default_options[:default_url] = nil
+
+Alternatively, you can preserve existing behavior by adding:
+
+Paperclip::Attachment.default_options[:default_url] = '/:attachment/:style/missing.png'
+
+
+##################################################
 #  NOTE FOR UPGRADING FROM 4.3.0 OR EARLIER      #
 ##################################################
 

--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -131,11 +131,11 @@ module Paperclip
     #   Note: When using the +s3+ storage option, the +url+ option expects
     #   particular values. See the Paperclip::Storage::S3#url documentation for
     #   specifics.
-    # * +default_url+: The URL that will be returned if there is no attachment assigned.
-    #   This field is interpolated just as the url is. The default value is
-    #   "/:attachment/:style/missing.png"
-    #     has_attached_file :avatar, :default_url => "/images/default_:style_avatar.png"
-    #     User.new.avatar_url(:small) # => "/images/default_small_avatar.png"
+    # * +default_url+: The URL that will be returned if there is no attachment assigned,
+    #   useful for "missing" images. This field is interpolated just as the url is.
+    #   The default value is nil.
+    #     has_attached_file :avatar, :default_url => "/:attachment/missing_avatar_:style.png"
+    #     User.new.avatar_url(:small) # => "/images/missing_avatar_small.png"
     # * +styles+: A hash of thumbnail styles and their geometries. You can find more about
     #   geometry strings at the ImageMagick website
     #   (http://www.imagemagick.org/script/command-line-options.php#resize). Paperclip

--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -13,7 +13,7 @@ module Paperclip
       @default_options ||= {
         :convert_options       => {},
         :default_style         => :original,
-        :default_url           => "/:attachment/:style/missing.png",
+        :default_url           => nil,  # Paperclip::VERSION =~ /\A[1-5]\./ ? '/:attachment/:style/missing.png' : nil,
         :escape_url            => true,
         :restricted_characters => /[&$+,\/:;=?@<>\[\]\{\}\|\\\^~%# ]/,
         :filename_cleaner      => nil,
@@ -53,7 +53,7 @@ module Paperclip
     # +styles+ - a hash of options for processing the attachment. See +has_attached_file+ for the details
     # +only_process+ - style args to be run through the post-processor. This defaults to the empty list (which is
     #                  a special case that indicates all styles should be processed)
-    # +default_url+ - a URL for the missing image
+    # +default_url+ - an interpolatable URL for the missing image, e.g. "/:attachment/:style/missing.png". Defaults to nil
     # +default_style+ - the style to use when an argument is not specified e.g. #url, #path
     # +storage+ - the storage mechanism. Defaults to :filesystem
     # +use_timestamp+ - whether to append an anti-caching timestamp to image URLs. Defaults to true

--- a/lib/paperclip/interpolations.rb
+++ b/lib/paperclip/interpolations.rb
@@ -30,6 +30,7 @@ module Paperclip
     # an interpolation pattern for Paperclip to use.
     def self.interpolate pattern, *args
       pattern = args.first.instance.send(pattern) if pattern.kind_of? Symbol
+      return unless pattern
       result = pattern.dup
       interpolators_cache.each do |method, token|
         result.gsub!(token) { send(method, *args) } if result.include?(token)

--- a/lib/paperclip/url_generator.rb
+++ b/lib/paperclip/url_generator.rb
@@ -10,6 +10,7 @@ module Paperclip
       interpolated = attachment_options[:interpolator].interpolate(
         most_appropriate_url, @attachment, style_name
       )
+      return unless interpolated
 
       escaped = escape_url_as_needed(interpolated, options)
       timestamp_as_needed(escaped, options)


### PR DESCRIPTION
Change the default value of `:default_url` to `nil`. Discussion here #2345, there are several reasons:

1) Principle of Least Surprise: it is not obvious that a user should have a file called "missing.png" uploaded to a certain directory.

2) Single Responsibility Principle: Missing images are (in 90%+ of cases) the responsibility of the View layer, NOT the Model layer. This is doubly true for API apps (e.g. React, Ember); the frontend developer would want to control how missing images behave.

3) Paperclip can be used for non-image attachment types, e.g. audio, documents, etc. and .png type is used regardless.

I have amended the Readme, code comments, and upgrading message to make the change obvious to users and to inform how to get the legacy behavior.
