### PR TITLE
Also match filenames without quotes

### DIFF
--- a/lib/paperclip/io_adapters/uri_adapter.rb
+++ b/lib/paperclip/io_adapters/uri_adapter.rb
@@ -30,7 +30,7 @@ module Paperclip
     def filename_from_content_disposition
       if @content.meta.has_key?("content-disposition")
         matches = @content.meta["content-disposition"].
-          match(/filename="?([^";]*)"?/)
+          match(/filename="?([^"\;]*)"?/)
         matches[1] if matches
       end
     end

--- a/lib/paperclip/io_adapters/uri_adapter.rb
+++ b/lib/paperclip/io_adapters/uri_adapter.rb
@@ -30,7 +30,7 @@ module Paperclip
     def filename_from_content_disposition
       if @content.meta.has_key?("content-disposition")
         matches = @content.meta["content-disposition"].
-          match(/filename="([^"]*)"/)
+          match(/filename="?([^";]*)"?/)
         matches[1] if matches
       end
     end


### PR DESCRIPTION
If the filename in the header (for any reason) doesn't  have quotes, this line throws an error. This fix also matches filenames without quotes.

Real world example:
```
Content-Disposition: inline; filename=2125_plg_K1.1_type+C__01.pdf; filename*=UTF-8''2125_plg_K1.1_type+C__01.pdf
```

Throws an error:
```
NoMethodError: undefined method `[]' for nil:NilClass
/Users/bas/.rvm/gems/ruby-2.3.3/gems/paperclip-5.1.0/lib/paperclip/io_adapters/uri_adapter.rb:33:in `filename_from_content_disposition'
```