### PR TITLE
Remove magic comment

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'uri'
 require 'paperclip/url_generator'
 require 'active_support/deprecation'

--- a/lib/paperclip/filename_cleaner.rb
+++ b/lib/paperclip/filename_cleaner.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 module Paperclip
   class FilenameCleaner
     def initialize(invalid_character_regex)

--- a/lib/paperclip/style.rb
+++ b/lib/paperclip/style.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 module Paperclip
   # The Style class holds the definition of a thumbnail style,  applying
   # whatever processing is required to normalize the definition and delaying

--- a/spec/paperclip/attachment_processing_spec.rb
+++ b/spec/paperclip/attachment_processing_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'spec_helper'
 
 describe 'Attachment Processing' do

--- a/spec/paperclip/attachment_spec.rb
+++ b/spec/paperclip/attachment_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'spec_helper'
 
 describe Paperclip::Attachment do

--- a/spec/paperclip/filename_cleaner_spec.rb
+++ b/spec/paperclip/filename_cleaner_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'spec_helper'
 
 describe Paperclip::FilenameCleaner do

--- a/spec/paperclip/integration_spec.rb
+++ b/spec/paperclip/integration_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'spec_helper'
 require 'open-uri'
 

--- a/spec/paperclip/style_spec.rb
+++ b/spec/paperclip/style_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'spec_helper'
 
 describe Paperclip::Style do

--- a/spec/paperclip/url_generator_spec.rb
+++ b/spec/paperclip/url_generator_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'spec_helper'
 
 describe Paperclip::UrlGenerator do


### PR DESCRIPTION
Since the support version is Ruby 2.0 or later, magic comment is unnecessary.

`The UTF-8 default encoding, which make many magic comments omissible
`
https://www.ruby-lang.org/en/news/2013/02/24/ruby-2-0-0-p0-is-released/