### PR TITLE
Ignore "gem "bundler" cannot be uninstalled error message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ rvm:
 
 # FIXME: fails with modern bundler
 before_install:
-  - rvm @global do gem uninstall bundler -a -x
-  - rvm @global do gem install bundler -v 1.12.5
+  - rvm @global do gem uninstall bundler --all --executables || true
+  - rvm @global do gem install bundler --version 1.12.5
 
 script: "bundle exec rake clean spec cucumber"
 


### PR DESCRIPTION
Refer https://travis-ci.org/rails/rails/jobs/295600391#L1801

This workaround should be removed once https://github.com/bundler/bundler/issues/6072 is addressed.

This is a copy of  : https://github.com/rails/rails/pull/31029