### PR TITLE
Don't rely on AWS::S3::Client for s3_host_name option

### DIFF
--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -254,11 +254,6 @@ describe Paperclip::Storage::S3 do
     it "returns a url based on an :s3_host_name path" do
       assert_match %r{^//s3-ap-northeast-1.amazonaws.com/bucket/avatars/data[^\.]}, @dummy.avatar.url
     end
-
-    it "uses the S3 bucket with the correct host name" do
-      assert_equal "s3.ap-northeast-1.amazonaws.com",
-        @dummy.avatar.s3_bucket.client.config.endpoint.host
-    end
   end
 
   context "dynamic s3_host_name" do
@@ -814,17 +809,19 @@ describe Paperclip::Storage::S3 do
     it "gets the right s3_host_name in production" do
       rails_env("production") do
         assert_match %r{^s3-world-end.amazonaws.com}, @dummy.avatar.s3_host_name
-        assert_match %r{^s3.world-end.amazonaws.com},
-          @dummy.avatar.s3_bucket.client.config.endpoint.host
       end
     end
 
     it "gets the right s3_host_name in development" do
       rails_env("development") do
+<<<<<<< HEAD
         assert_match %r{^s3.ap-northeast-1.amazonaws.com},
           @dummy.avatar.s3_host_name
         assert_match %r{^s3.ap-northeast-1.amazonaws.com},
           @dummy.avatar.s3_bucket.client.config.endpoint.host
+=======
+        assert_match %r{^s3-ap-northeast-1.amazonaws.com}, @dummy.avatar.s3_host_name
+>>>>>>> AWS client config do not use s3_host_name option
       end
     end
 


### PR DESCRIPTION
Next to this : https://github.com/thoughtbot/paperclip/pull/2511

I dig into the two failing tests. [`AWS::S3::Client`](http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Client.html) only use a `region` param (`s3_region` in paperclip). `s3_host_name` is only used in in S3 paperclip class. We should not rely on `AWS::S3::Client` to get `s3_host_name`