### PR TITLE
Update README.md fix#2465

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ end
 (Or you can use the Rails migration generator: `rails generate paperclip user avatar`)
 
 Add your Rails version after `AddAvatarColumnsToUsers < ActiveRecord::Migration`
+
 e.g : `AddAttachmentAvatarToUsers < ActiveRecord::Migration[5.1]`
 
 ### Edit and New Views

--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ end
 
 (Or you can use the Rails migration generator: `rails generate paperclip user avatar`)
 
+Add your Rails version after `AddAvatarColumnsToUsers < ActiveRecord::Migration`
+e.g : `AddAttachmentAvatarToUsers < ActiveRecord::Migration[5.1]`
+
 ### Edit and New Views
 
 ```erb


### PR DESCRIPTION
I've meet this issue 
`StandardError: An error has occurred, this and all later migrations canceled:
Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:
  class AddAttachmentAvatarToUsers < ActiveRecord::Migration[4.2]`

So I've added [5.1] after ActiveRecord::Migration, then I saw in issues it's a known issue, so I've updated the Readme file to prevent for opening issue(s) in the future.