### PR TITLE
MIME type detection of Paperclip::MediaTypeSpoofDetector doesn't work with old versions of file.

### DIFF
--- a/lib/paperclip/media_type_spoof_detector.rb
+++ b/lib/paperclip/media_type_spoof_detector.rb
@@ -72,7 +72,8 @@ module Paperclip
 
     def type_from_file_command
       begin
-        Paperclip.run("file", "-b --mime :file", :file => @file.path).split(/[:;]\s+/).first
+        Paperclip.run("file", "-b --mime :file", file: @file.path).
+          split(/[:;\s]+/).first
       rescue Cocaine::CommandLineError
         ""
       end

--- a/spec/paperclip/file_command_content_type_detector_spec.rb
+++ b/spec/paperclip/file_command_content_type_detector_spec.rb
@@ -23,4 +23,18 @@ describe Paperclip::FileCommandContentTypeDetector do
     assert_equal "application/octet-stream",
       Paperclip::FileCommandContentTypeDetector.new("windows").detect
   end
+
+  context "#type_from_file_command" do
+    let(:detector) { Paperclip::FileCommandContentTypeDetector.new("html") }
+
+    it "does work with the output of old versions of file" do
+      Paperclip.stubs(:run).returns("text/html charset=us-ascii")
+      expect(detector.detect).to eq("text/html")
+    end
+
+    it "does work with the output of new versions of file" do
+      Paperclip.stubs(:run).returns("text/html; charset=us-ascii")
+      expect(detector.detect).to eq("text/html")
+    end
+  end
 end

--- a/spec/paperclip/media_type_spoof_detector_spec.rb
+++ b/spec/paperclip/media_type_spoof_detector_spec.rb
@@ -76,4 +76,19 @@ describe Paperclip::MediaTypeSpoofDetector do
       Paperclip.options[:content_type_mappings] = {}
     end
   end
+
+  context "#type_from_file_command" do
+    let(:file) { File.new(fixture_file("empty.html")) }
+    let(:detector) { Paperclip::MediaTypeSpoofDetector.new(file, "html", "") }
+
+    it "does work with the output of old versions of file" do
+      Paperclip.stubs(:run).returns("text/html charset=us-ascii")
+      expect(detector.send(:type_from_file_command)).to eq("text/html")
+    end
+
+    it "does work with the output of new versions of file" do
+      Paperclip.stubs(:run).returns("text/html; charset=us-ascii")
+      expect(detector.send(:type_from_file_command)).to eq("text/html")
+    end
+  end
 end


### PR DESCRIPTION
Please see #2527 for details.