### PR TITLE
Add Errno::EEXIST as possible exception that happens on linking

### DIFF
--- a/lib/paperclip/io_adapters/abstract_adapter.rb
+++ b/lib/paperclip/io_adapters/abstract_adapter.rb
@@ -61,7 +61,7 @@ module Paperclip
       FileUtils.ln(src, dest, force: true) # overwrite existing
       @destination.close
       @destination.open.binmode
-    rescue Errno::EXDEV, Errno::EPERM, Errno::ENOENT => e
+    rescue Errno::EXDEV, Errno::EPERM, Errno::ENOENT, Errno::EEXIST => e
       Paperclip.log("Link failed with #{e.message}; copying link #{src} to #{dest}")
       FileUtils.cp(src, dest)
     end


### PR DESCRIPTION
When I try to attach a file on Windows Paperclip fails on trying to make a link with Errno::EEXIST exception.
This exception should be caught as others inside `Paperclip::AbstractAdapter#link_or_copy_file`