### PR TITLE
Increase attachment file size from int (4 bytes) to bigint (8 bytes).

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,8 @@
 master:
 
+* Change database column type of attachment file size from unsigned 4-byte
+  `integer` to unsigned 8-byte `bigint`. The former type limits attachment
+  size to just over 2GB, which can easily be exceeded by a large video file.
 * Improvement: Added `:use_accelerate_endpoint` option when using S3 to enable
   [Amazon S3 Transfer Acceleration](http://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html)
 * Improvement: make the fingerprint digest configurable per attachment. The

--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -88,7 +88,7 @@ Then /^I should have attachment columns for "([^"]*)"$/ do |attachment_name|
     expect_columns = [
       ["#{attachment_name}_file_name", :string],
       ["#{attachment_name}_content_type", :string],
-      ["#{attachment_name}_file_size", :integer],
+      ["#{attachment_name}_file_size", :bigint],
       ["#{attachment_name}_updated_at", :datetime]
     ]
     expect(columns).to include(*expect_columns)
@@ -101,7 +101,7 @@ Then /^I should not have attachment columns for "([^"]*)"$/ do |attachment_name|
     expect_columns = [
       ["#{attachment_name}_file_name", :string],
       ["#{attachment_name}_content_type", :string],
-      ["#{attachment_name}_file_size", :integer],
+      ["#{attachment_name}_file_size", :bigint],
       ["#{attachment_name}_updated_at", :datetime]
     ]
 

--- a/lib/paperclip/schema.rb
+++ b/lib/paperclip/schema.rb
@@ -5,7 +5,7 @@ module Paperclip
   module Schema
     COLUMNS = {:file_name    => :string,
                :content_type => :string,
-               :file_size    => :integer,
+               :file_size    => :bigint,
                :updated_at   => :datetime}
 
     def self.included(base)

--- a/spec/paperclip/attachment_spec.rb
+++ b/spec/paperclip/attachment_spec.rb
@@ -1401,7 +1401,7 @@ describe Paperclip::Attachment do
 
     context "and avatar_file_size column" do
       before do
-        ActiveRecord::Base.connection.add_column :dummies, :avatar_file_size, :integer
+        ActiveRecord::Base.connection.add_column :dummies, :avatar_file_size, :bigint
         rebuild_class
         @dummy = Dummy.new
       end

--- a/spec/paperclip/matchers/validate_attachment_size_matcher_spec.rb
+++ b/spec/paperclip/matchers/validate_attachment_size_matcher_spec.rb
@@ -7,7 +7,7 @@ describe Paperclip::Shoulda::Matchers::ValidateAttachmentSizeMatcher do
   before do
     reset_table("dummies") do |d|
       d.string :avatar_file_name
-      d.integer :avatar_file_size
+      d.bigint :avatar_file_size
     end
     reset_class "Dummy"
     Dummy.do_not_validate_attachment_file_type :avatar

--- a/spec/paperclip/schema_spec.rb
+++ b/spec/paperclip/schema_spec.rb
@@ -29,7 +29,7 @@ describe Paperclip::Schema do
 
         expect(columns).to include(['avatar_file_name', :string])
         expect(columns).to include(['avatar_content_type', :string])
-        expect(columns).to include(['avatar_file_size', :integer])
+        expect(columns).to include(['avatar_file_size', :bigint])
         expect(columns).to include(['avatar_updated_at', :datetime])
       end
 

--- a/spec/support/model_reconstruction.rb
+++ b/spec/support/model_reconstruction.rb
@@ -37,7 +37,7 @@ module ModelReconstruction
       table.column :other, :string
       table.column :avatar_file_name, :string
       table.column :avatar_content_type, :string
-      table.column :avatar_file_size, :integer
+      table.column :avatar_file_size, :bigint
       table.column :avatar_updated_at, :datetime
       table.column :avatar_fingerprint, :string
     end


### PR DESCRIPTION
I think the 4 byte limit is unnecessary. Here's a stackoverflow thread that also mentions this problem:
https://stackoverflow.com/questions/34477248/rails-paperclip-rangeerror/47999887#47999887