### PR TITLE
Update the README Installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Paperclip is distributed as a gem, which is how it should be used in your app.
 Include the gem in your Gemfile:
 
 ```ruby
-gem "paperclip", "~> 5.0.0"
+gem "paperclip", "~> 5.2.1"
 ```
 
 Or, if you want to get the latest, you can get master from the main paperclip repository:


### PR DESCRIPTION
The command from the README is often copied into projects directly. The version used here before had a known vulnerability (CVE-2017-0889), so it might be wise to mention something more secure instead.