### PR TITLE
fix fallback when symlink in AbstractAdapter#link_or_copy_file fails

### DIFF
--- a/lib/paperclip/io_adapters/abstract_adapter.rb
+++ b/lib/paperclip/io_adapters/abstract_adapter.rb
@@ -58,12 +58,18 @@ module Paperclip
 
     def link_or_copy_file(src, dest)
       Paperclip.log("Trying to link #{src} to #{dest}")
-      FileUtils.ln(src, dest, force: true) # overwrite existing
+
+      begin
+        FileUtils.ln(src, dest, force: true) # overwrite existing
+      rescue Errno::EXDEV, Errno::EPERM, Errno::ENOENT, Errno::EEXIST => e
+        Paperclip.log(
+          "Link failed with #{e.message}; copying link #{src} to #{dest}",
+        )
+        FileUtils.cp(src, dest)
+      end
+
       @destination.close
       @destination.open.binmode
-    rescue Errno::EXDEV, Errno::EPERM, Errno::ENOENT, Errno::EEXIST => e
-      Paperclip.log("Link failed with #{e.message}; copying link #{src} to #{dest}")
-      FileUtils.cp(src, dest)
     end
   end
 end


### PR DESCRIPTION
Paperclip::AbstractAdapter provides the link_or_copy_file method which first tries to do a symlink. When the symlinking raises an exception it is rescued and it tries again with copy. The problem is that the failed symlink leaves the tempfile instance in a bad state and you cannot read from it without reopening it.

Current behavior with a file which cannot be linked (for example because it is on another filesystem):

```
File.open("file_which_cannot_be_linked", "w") { |f| f.print("body") }

Paperclip.io_adapters.for(File.open("file_which_cannot_be_linked")).read
[paperclip] Trying to link file_which_cannot_be_linked to /tmp/d783e2fb96492f5a9f5e9632d2987a1120180131-3949-1vavjso                                                                                                
[paperclip] Link failed with Invalid cross-device link @ rb_file_s_link - (file_which_cannot_be_linked, /tmp/d783e2fb96492f5a9f5e9632d2987a1120180131-3949-1vavjso); copying link file_which_cannot_be_linked to /tm
p/d783e2fb96492f5a9f5e9632d2987a1120180131-3949-1vavjso    
Command :: file -b --mime 'file_which_cannot_be_linked'                              
=> ""
```
Behavior after fix:

```
Paperclip.io_adapters.for(File.open("file_which_cannot_be_linked")).read                                                                                                                  
[paperclip] Trying to link file_which_cannot_be_linked to /tmp/d783e2fb96492f5a9f5e9632d2987a1120180131-3939-1cp0zud                                                                                              
[paperclip] Link failed with Invalid cross-device link; copying link file_which_cannot_be_linked to /tmp/d783e2fb96492f5a9f5e9632d2987a1120180131-3939-1cp0zud                                         
Command :: file -b --mime 'file_which_cannot_be_linked'                                                                                                                                                             
=> "body"                                                                                                                                                                                        
```