### PR TITLE
Reopen file even when copying instead of linking

### DIFF
--- a/lib/paperclip/io_adapters/abstract_adapter.rb
+++ b/lib/paperclip/io_adapters/abstract_adapter.rb
@@ -57,13 +57,16 @@ module Paperclip
     end
 
     def link_or_copy_file(src, dest)
-      Paperclip.log("Trying to link #{src} to #{dest}")
-      FileUtils.ln(src, dest, force: true) # overwrite existing
+      begin
+        Paperclip.log("Trying to link #{src} to #{dest}")
+        FileUtils.ln(src, dest, force: true) # overwrite existing
+      rescue Errno::EXDEV, Errno::EPERM, Errno::ENOENT, Errno::EEXIST => e
+        Paperclip.log("Link failed with #{e.message}; copying link #{src} to #{dest}")
+        FileUtils.cp(src, dest)
+      end
+
       @destination.close
       @destination.open.binmode
-    rescue Errno::EXDEV, Errno::EPERM, Errno::ENOENT, Errno::EEXIST => e
-      Paperclip.log("Link failed with #{e.message}; copying link #{src} to #{dest}")
-      FileUtils.cp(src, dest)
     end
   end
 end


### PR DESCRIPTION
This is necessary for:
```
$ uname -a
Linux aki-X220t 4.15.1-2-ARCH #1 SMP Sun Feb 4 22:27:45 UTC 2018 x86_64 GNU/Linux
$ mount -l | grep /tmp
tmpfs on /tmp type tmpfs (rw,relatime)
```