### PR TITLE
Log failing flush delete actions with logger

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,5 @@
+* Improvement: Make the flush_deletes log exceptions instead of ignoring it
+
 5.2.1 (2018-01-25):
 
 * Bugfix: Fix copying files on Windows. (#2532)

--- a/lib/paperclip/storage/filesystem.rb
+++ b/lib/paperclip/storage/filesystem.rb
@@ -19,7 +19,7 @@ module Paperclip
     #   saved by paperclip. If you set this to an explicit octal value (0755, 0644, etc) then
     #   that value will be used to set the permissions for an uploaded file. The default is 0666.
     #   If you set :override_file_permissions to false, the chmod will be skipped. This allows
-    #   you to use paperclip on filesystems that don't understand unix file permissions, and has the 
+    #   you to use paperclip on filesystems that don't understand unix file permissions, and has the
     #   added benefit of using the storage directories default umask on those that do.
     module Filesystem
       def self.extended base
@@ -64,6 +64,7 @@ module Paperclip
             FileUtils.rm(path) if File.exist?(path)
           rescue Errno::ENOENT => e
             # ignore file-not-found, let everything else pass
+            warn("#{e} - cannot delete #{path} from local directory")
           end
           begin
             while(true)

--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -413,7 +413,7 @@ module Paperclip
             log("deleting #{path}")
             s3_bucket.object(path.sub(%r{\A/}, "")).delete
           rescue Aws::Errors::ServiceError => e
-            # Ignore this.
+            warn("#{e} - cannot delete #{path} from remote storage")
           end
         end
         @queued_for_delete = []


### PR DESCRIPTION
**As is:**
When deleting attachments (local or remote) and deletion fails all the errors are silently rescued.

**I want:**
When deleting attachments and some fail with an exception I want to see the exception being logged so I can inspect it later when looking at the logs.