### PR TITLE
Replace cocaine to terrapin

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -67,7 +67,7 @@ end
 require 'mimemagic'
 require 'mimemagic/overlay'
 require 'logger'
-require 'cocaine'
+require 'terrapin'
 
 require 'paperclip/railtie' if defined?(Rails::Railtie)
 

--- a/lib/paperclip/file_command_content_type_detector.rb
+++ b/lib/paperclip/file_command_content_type_detector.rb
@@ -16,7 +16,7 @@ module Paperclip
       # On BSDs, `file` doesn't give a result code of 1 if the file doesn't exist.
       type = begin
                Paperclip.run("file", "-b --mime :file", file: @filename)
-             rescue Cocaine::CommandLineError => e
+             rescue Terrapin::CommandLineError => e
                Paperclip.log("Error while determining content type: #{e}")
                SENSIBLE_DEFAULT
              end

--- a/lib/paperclip/geometry_detector_factory.rb
+++ b/lib/paperclip/geometry_detector_factory.rb
@@ -24,9 +24,9 @@ module Paperclip
             :swallow_stderr => true
           }
         )
-      rescue Cocaine::ExitStatusError
+      rescue Terrapin::ExitStatusError
         ""
-      rescue Cocaine::CommandNotFoundError => e
+      rescue Terrapin::CommandNotFoundError => e
         raise_because_imagemagick_missing
       end
     end

--- a/lib/paperclip/helpers.rb
+++ b/lib/paperclip/helpers.rb
@@ -27,12 +27,12 @@ module Paperclip
     #
     def run(cmd, arguments = "", interpolation_values = {}, local_options = {})
       command_path = options[:command_path]
-      cocaine_path_array = Cocaine::CommandLine.path.try(:split, Cocaine::OS.path_separator)
-      Cocaine::CommandLine.path = [cocaine_path_array, command_path].flatten.compact.uniq
+      terrapin_path_array = Terrapin::CommandLine.path.try(:split, Terrapin::OS.path_separator)
+      Terrapin::CommandLine.path = [terrapin_path_array, command_path].flatten.compact.uniq
       if logging? && (options[:log_command] || local_options[:log_command])
         local_options = local_options.merge(:logger => logger)
       end
-      Cocaine::CommandLine.new(cmd, arguments, local_options).run(interpolation_values)
+      Terrapin::CommandLine.new(cmd, arguments, local_options).run(interpolation_values)
     end
 
     # Find all instances of the given Active Record model +klass+ with attachment +name+.

--- a/lib/paperclip/media_type_spoof_detector.rb
+++ b/lib/paperclip/media_type_spoof_detector.rb
@@ -74,7 +74,7 @@ module Paperclip
       begin
         Paperclip.run("file", "-b --mime :file", file: @file.path).
           split(/[:;\s]+/).first
-      rescue Cocaine::CommandLineError
+      rescue Terrapin::CommandLineError
         ""
       end
     end

--- a/lib/paperclip/thumbnail.rb
+++ b/lib/paperclip/thumbnail.rb
@@ -84,9 +84,9 @@ module Paperclip
           source: "#{File.expand_path(src.path)}#{frame}",
           dest: File.expand_path(dst.path),
         )
-      rescue Cocaine::ExitStatusError => e
+      rescue Terrapin::ExitStatusError => e
         raise Paperclip::Error, "There was an error processing the thumbnail for #{@basename}" if @whiny
-      rescue Cocaine::CommandNotFoundError => e
+      rescue Terrapin::CommandNotFoundError => e
         raise Paperclip::Errors::CommandNotFoundError.new("Could not run the `convert` command. Please install ImageMagick.")
       end
 
@@ -122,9 +122,9 @@ module Paperclip
         @identified_as_animated = ANIMATED_FORMATS.include? identify("-format %m :file", :file => "#{@file.path}[0]").to_s.downcase.strip
       end
       @identified_as_animated
-    rescue Cocaine::ExitStatusError => e
+    rescue Terrapin::ExitStatusError => e
       raise Paperclip::Error, "There was an error running `identify` for #{@basename}" if @whiny
-    rescue Cocaine::CommandNotFoundError => e
+    rescue Terrapin::CommandNotFoundError => e
       raise Paperclip::Errors::CommandNotFoundError.new("Could not run the `identify` command. Please install ImageMagick.")
     end
   end

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('activemodel', '>= 4.2.0')
   s.add_dependency('activesupport', '>= 4.2.0')
-  s.add_dependency('cocaine', '~> 0.5.5')
+  s.add_dependency('terrapin', '~> 0.6.0')
   s.add_dependency('mime-types')
   s.add_dependency('mimemagic', '~> 0.3.0')
 

--- a/spec/paperclip/content_type_detector_spec.rb
+++ b/spec/paperclip/content_type_detector_spec.rb
@@ -41,7 +41,7 @@ describe Paperclip::ContentTypeDetector do
   end
 
   it 'returns a sensible default when the file command is missing' do
-    Paperclip.stubs(:run).raises(Cocaine::CommandLineError.new)
+    Paperclip.stubs(:run).raises(Terrapin::CommandLineError.new)
     @filename = "/path/to/something"
     assert_equal "application/octet-stream", Paperclip::ContentTypeDetector.new(@filename).detect
   end

--- a/spec/paperclip/file_command_content_type_detector_spec.rb
+++ b/spec/paperclip/file_command_content_type_detector_spec.rb
@@ -12,7 +12,7 @@ describe Paperclip::FileCommandContentTypeDetector do
   end
 
   it 'returns a sensible default when the file command is missing' do
-    Paperclip.stubs(:run).raises(Cocaine::CommandLineError.new)
+    Paperclip.stubs(:run).raises(Terrapin::CommandLineError.new)
     @filename = "/path/to/something"
     assert_equal "application/octet-stream",
       Paperclip::FileCommandContentTypeDetector.new(@filename).detect

--- a/spec/paperclip/paperclip_spec.rb
+++ b/spec/paperclip/paperclip_spec.rb
@@ -4,40 +4,40 @@ describe Paperclip do
   context ".run" do
     before do
       Paperclip.options[:log_command] = false
-      Cocaine::CommandLine.expects(:new).with("convert", "stuff", {}).returns(stub(:run))
-      @original_command_line_path = Cocaine::CommandLine.path
+      Terrapin::CommandLine.expects(:new).with("convert", "stuff", {}).returns(stub(:run))
+      @original_command_line_path = Terrapin::CommandLine.path
     end
 
     after do
       Paperclip.options[:log_command] = true
-      Cocaine::CommandLine.path = @original_command_line_path
+      Terrapin::CommandLine.path = @original_command_line_path
     end
 
-    it "runs the command with Cocaine" do
+    it "runs the command with Terrapin" do
       Paperclip.run("convert", "stuff")
     end
 
-    it "saves Cocaine::CommandLine.path that set before" do
-      Cocaine::CommandLine.path = "/opt/my_app/bin"
+    it "saves Terrapin::CommandLine.path that set before" do
+      Terrapin::CommandLine.path = "/opt/my_app/bin"
       Paperclip.run("convert", "stuff")
-      expect(Cocaine::CommandLine.path).to match("/opt/my_app/bin")
+      expect(Terrapin::CommandLine.path).to match("/opt/my_app/bin")
     end
 
-    it "does not duplicate Cocaine::CommandLine.path on multiple runs" do
-      Cocaine::CommandLine.expects(:new).with("convert", "more_stuff", {}).returns(stub(:run))
-      Cocaine::CommandLine.path = nil
+    it "does not duplicate Terrapin::CommandLine.path on multiple runs" do
+      Terrapin::CommandLine.expects(:new).with("convert", "more_stuff", {}).returns(stub(:run))
+      Terrapin::CommandLine.path = nil
       Paperclip.options[:command_path] = "/opt/my_app/bin"
       Paperclip.run("convert", "stuff")
       Paperclip.run("convert", "more_stuff")
 
       cmd_path = Paperclip.options[:command_path]
-      assert_equal 1, Cocaine::CommandLine.path.scan(cmd_path).count
+      assert_equal 1, Terrapin::CommandLine.path.scan(cmd_path).count
     end
   end
 
   it 'does not raise errors when doing a lot of running' do
     Paperclip.options[:command_path] = ["/usr/local/bin"] * 1024
-    Cocaine::CommandLine.path = "/something/else"
+    Terrapin::CommandLine.path = "/something/else"
     100.times do |x|
       Paperclip.run("echo", x.to_s)
     end
@@ -63,7 +63,7 @@ describe Paperclip do
   context "Calling Paperclip.run with a logger" do
     it "passes the defined logger if :log_command is set" do
       Paperclip.options[:log_command] = true
-      Cocaine::CommandLine.expects(:new).with("convert", "stuff", logger: Paperclip.logger).returns(stub(:run))
+      Terrapin::CommandLine.expects(:new).with("convert", "stuff", logger: Paperclip.logger).returns(stub(:run))
       Paperclip.run("convert", "stuff")
     end
   end

--- a/spec/paperclip/processor_spec.rb
+++ b/spec/paperclip/processor_spec.rb
@@ -9,17 +9,17 @@ describe Paperclip::Processor do
   end
 
   context "Calling #convert" do
-    it "runs the convert command with Cocaine" do
+    it "runs the convert command with Terrapin" do
       Paperclip.options[:log_command] = false
-      Cocaine::CommandLine.expects(:new).with("convert", "stuff", {}).returns(stub(:run))
+      Terrapin::CommandLine.expects(:new).with("convert", "stuff", {}).returns(stub(:run))
       Paperclip::Processor.new('filename').convert("stuff")
     end
   end
 
   context "Calling #identify" do
-    it "runs the identify command with Cocaine" do
+    it "runs the identify command with Terrapin" do
       Paperclip.options[:log_command] = false
-      Cocaine::CommandLine.expects(:new).with("identify", "stuff", {}).returns(stub(:run))
+      Terrapin::CommandLine.expects(:new).with("identify", "stuff", {}).returns(stub(:run))
       Paperclip::Processor.new('filename').identify("stuff")
     end
   end

--- a/spec/paperclip/thumbnail_spec.rb
+++ b/spec/paperclip/thumbnail_spec.rb
@@ -48,7 +48,7 @@ describe Paperclip::Thumbnail do
       it "lets us know when a command isn't found versus a processing error" do
         old_path = ENV['PATH']
         begin
-          Cocaine::CommandLine.path = ''
+          Terrapin::CommandLine.path = ''
           Paperclip.options[:command_path] = ''
           ENV['PATH'] = ''
           assert_raises(Paperclip::Errors::CommandNotFoundError) do
@@ -102,7 +102,7 @@ describe Paperclip::Thumbnail do
 
       output_file = thumb.make
 
-      command = Cocaine::CommandLine.new("identify", "-format %wx%h :file")
+      command = Terrapin::CommandLine.new("identify", "-format %wx%h :file")
       assert_equal "50x50", command.run(file: output_file.path).strip
     end
 
@@ -189,7 +189,7 @@ describe Paperclip::Thumbnail do
         it "lets us know when a command isn't found versus a processing error" do
           old_path = ENV['PATH']
           begin
-            Cocaine::CommandLine.path = ''
+            Terrapin::CommandLine.path = ''
             Paperclip.options[:command_path] = ''
             ENV['PATH'] = ''
             assert_raises(Paperclip::Errors::CommandNotFoundError) do


### PR DESCRIPTION
Cocaine has been renamed to Terrapin (ref https://github.com/thoughtbot/cocaine/issues/99).

This Pull Request replaces `Cocaine::` with `Terrapin::`.
