### PR TITLE
Depends on aws-sdk-s3 gem instead of aws-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ Storage
 Paperclip ships with 3 storage adapters:
 
 * File Storage
-* S3 Storage (via `aws-sdk`)
+* S3 Storage (via `aws-sdk-s3`)
 * Fog Storage
 
 If you would like to use Paperclip with another storage, you can install these
@@ -593,10 +593,10 @@ _**NOTE**: This is a change from previous versions of Paperclip, but is overall 
 safer choice for the default file store._
 
 You may also choose to store your files using Amazon's S3 service. To do so, include
-the `aws-sdk` gem in your Gemfile:
+the `aws-sdk-s3` gem in your Gemfile:
 
 ```ruby
-gem 'aws-sdk', '~> 2.3.0'
+gem 'aws-sdk-s3'
 ```
 
 And then you can specify using S3 from `has_attached_file`.
@@ -663,7 +663,7 @@ has more information on the accepted style formats.
 For more fine-grained control of the conversion process, `source_file_options` and `convert_options` can be used to pass flags and settings directly to ImageMagick's powerful Convert tool, [documented here](https://www.imagemagick.org/script/convert.php). For example:
 
 ```ruby
-has_attached_file :image, styles: { regular: ['800x800>', :png]}, 
+has_attached_file :image, styles: { regular: ['800x800>', :png]},
     source_file_options: { regular: "-density 96 -depth 8 -quality 85" },
     convert_options: { regular: "-posterize 3"}
 ```

--- a/features/step_definitions/rails_steps.rb
+++ b/features/step_definitions/rails_steps.rb
@@ -17,7 +17,7 @@ Given /^I generate a new rails application$/ do
       gem "jruby-openssl", :platform => :jruby
       gem "capybara"
       gem "gherkin"
-      gem "aws-sdk", "~> 2.0.0"
+      gem "aws-sdk-s3"
       gem "racc", :platform => :rbx
       gem "rubysl", :platform => :rbx
       """

--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -3,8 +3,8 @@ module Paperclip
     # Amazon's S3 file hosting service is a scalable, easy place to store files for
     # distribution. You can find out more about it at http://aws.amazon.com/s3
     #
-    # To use Paperclip with S3, include the +aws-sdk+ gem in your Gemfile:
-    #   gem 'aws-sdk'
+    # To use Paperclip with S3, include the +aws-sdk-s3+ gem in your Gemfile:
+    #   gem 'aws-sdk-s3'
     # There are a few S3-specific options for has_attached_file:
     # * +s3_credentials+: Takes a path, a File, a Hash or a Proc. The path (or File) must point
     #   to a YAML file containing the +access_key_id+ and +secret_access_key+ that Amazon
@@ -96,7 +96,7 @@ module Paperclip
     #   separate parts of your file name.
     # * +s3_host_name+: If you are using your bucket in Tokyo region
     #   etc, write host_name (e.g., 's3-ap-northeast-1.amazonaws.com').
-    # * +s3_region+: For aws-sdk v2, s3_region is required.
+    # * +s3_region+: For aws-sdk-s3 s3_region is required.
     # * +s3_metadata+: These key/value pairs will be stored with the
     #   object.  This option works by prefixing each key with
     #   "x-amz-meta-" before sending it as a header on the object
@@ -118,19 +118,15 @@ module Paperclip
     #     :s3_storage_class => :REDUCED_REDUNDANCY
     #
     #   Other storage classes, such as <tt>:STANDARD_IA</tt>, are also available—see the
-    #   documentation for the <tt>aws-sdk</tt> gem for the full list.
+    #   documentation for the <tt>aws-sdk-s3</tt> gem for the full list.
 
     module S3
       def self.extended base
         begin
-          require 'aws-sdk'
+          require 'aws-sdk-s3'
         rescue LoadError => e
-          e.message << " (You may need to install the aws-sdk gem)"
+          e.message << " (You may need to install the aws-sdk-s3 gem)"
           raise e
-        end
-        if Gem::Version.new(Aws::VERSION) >= Gem::Version.new(2) &&
-           Gem::Version.new(Aws::VERSION) <= Gem::Version.new("2.0.33")
-          raise LoadError, "paperclip does not support aws-sdk versions 2.0.0 - 2.0.33.  Please upgrade aws-sdk to a newer version."
         end
 
         base.instance_eval do
@@ -158,11 +154,6 @@ module Paperclip
           @options[:url] = @options[:url].inspect if @options[:url].is_a?(Symbol)
 
           @http_proxy = @options[:http_proxy] || nil
-
-          if @options.has_key?(:use_accelerate_endpoint) &&
-              Gem::Version.new(Aws::VERSION) < Gem::Version.new("2.3.0")
-            raise LoadError, ":use_accelerate_endpoint is only available from aws-sdk version 2.3.0. Please upgrade aws-sdk to a newer version."
-          end
 
           @use_accelerate_endpoint = @options[:use_accelerate_endpoint]
         end

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('appraisal')
   s.add_development_dependency('mocha')
-  s.add_development_dependency('aws-sdk', '>= 2.3.0', '< 3.0')
+  s.add_development_dependency('aws-sdk-s3', '>= 1.0', '< 2.0')
   s.add_development_dependency('bourne')
   s.add_development_dependency('cucumber-rails')
   s.add_development_dependency('cucumber-expressions', '4.0.3') # TODO: investigate failures on 4.0.4

--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'aws-sdk'
+require 'aws-sdk-s3'
 
 describe Paperclip::Storage::S3 do
   before do


### PR DESCRIPTION
Gem aws-sdk use about 30 gems as a dependents, but paperclip needs only aws-sdk-s3