### PR TITLE
update to use new aws-sdk version 3 structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ Storage
 Paperclip ships with 3 storage adapters:
 
 * File Storage
-* S3 Storage (via `aws-sdk`)
+* S3 Storage (via `aws-sdk-s3`)
 * Fog Storage
 
 If you would like to use Paperclip with another storage, you can install these
@@ -593,10 +593,10 @@ _**NOTE**: This is a change from previous versions of Paperclip, but is overall 
 safer choice for the default file store._
 
 You may also choose to store your files using Amazon's S3 service. To do so, include
-the `aws-sdk` gem in your Gemfile:
+the `aws-sdk-s3` gem in your Gemfile:
 
 ```ruby
-gem 'aws-sdk', '~> 2.3.0'
+gem 'aws-sdk-s3', '~> 1.8.0'
 ```
 
 And then you can specify using S3 from `has_attached_file`.

--- a/UPGRADING
+++ b/UPGRADING
@@ -2,16 +2,14 @@
 #  NOTE FOR UPGRADING FROM 4.3.0 OR EARLIER      #
 ##################################################
 
-Paperclip is now compatible with aws-sdk >= 2.0.0.
+Paperclip now uses aws-sdk-s3 >= 1.0.0.
 
-If you are using S3 storage, aws-sdk >= 2.0.0 requires you to make a few small
-changes:
+If you are using S3 storage, this version requires you to make a few small changes:
 
+* Update your Gemfile to use the new gem `gem 'aws-sdk-s3', '~> 1.0'`
 * You must set the `s3_region`
 * If you are explicitly setting permissions anywhere, such as in an initializer,
   note that the format of the permissions changed from using an underscore to
   using a hyphen. For example, `:public_read` needs to be changed to
   `public-read`.
 
-For a walkthrough of upgrading from 4 to 5 and aws-sdk >= 2.0 you can watch
-http://rubythursday.com/episodes/ruby-snack-27-upgrade-paperclip-and-aws-sdk-in-prep-for-rails-5

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "sqlite3", "~> 1.3.8", :platforms => :ruby
+gem "sqlite3", "~> 1.3.8", platforms: :ruby
 gem "pry"
 gem "rails", "~> 4.2.0"
 
@@ -10,8 +10,8 @@ group :development, :test do
   gem "activerecord-import"
   gem "mime-types"
   gem "builder"
-  gem "rubocop", :require => false
+  gem "rubocop", require: false
   gem "rspec"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "sqlite3", "~> 1.3.8", :platforms => :ruby
+gem "sqlite3", "~> 1.3.8", platforms: :ruby
 gem "pry"
 gem "rails", "~> 5.0.0"
 
@@ -10,8 +10,8 @@ group :development, :test do
   gem "activerecord-import"
   gem "mime-types"
   gem "builder"
-  gem "rubocop", :require => false
+  gem "rubocop", require: false
   gem "rspec"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -123,14 +123,10 @@ module Paperclip
     module S3
       def self.extended base
         begin
-          require 'aws-sdk'
+          require 'aws-sdk-s3'
         rescue LoadError => e
-          e.message << " (You may need to install the aws-sdk gem)"
+          e.message << " (You may need to install the aws-sdk-s3 gem)"
           raise e
-        end
-        if Gem::Version.new(Aws::VERSION) >= Gem::Version.new(2) &&
-           Gem::Version.new(Aws::VERSION) <= Gem::Version.new("2.0.33")
-          raise LoadError, "paperclip does not support aws-sdk versions 2.0.0 - 2.0.33.  Please upgrade aws-sdk to a newer version."
         end
 
         base.instance_eval do
@@ -158,11 +154,6 @@ module Paperclip
           @options[:url] = @options[:url].inspect if @options[:url].is_a?(Symbol)
 
           @http_proxy = @options[:http_proxy] || nil
-
-          if @options.has_key?(:use_accelerate_endpoint) &&
-              Gem::Version.new(Aws::VERSION) < Gem::Version.new("2.3.0")
-            raise LoadError, ":use_accelerate_endpoint is only available from aws-sdk version 2.3.0. Please upgrade aws-sdk to a newer version."
-          end
 
           @use_accelerate_endpoint = @options[:use_accelerate_endpoint]
         end

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('appraisal')
   s.add_development_dependency('mocha')
-  s.add_development_dependency('aws-sdk', '>= 2.3.0', '< 3.0')
+  s.add_development_dependency('aws-sdk-s3', '>= 1.8.0')
   s.add_development_dependency('bourne')
   s.add_development_dependency('cucumber-rails')
   s.add_development_dependency('cucumber-expressions', '4.0.3') # TODO: investigate failures on 4.0.4

--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'aws-sdk'
+require 'aws-sdk-s3'
 
 describe Paperclip::Storage::S3 do
   before do
@@ -282,7 +282,7 @@ describe Paperclip::Storage::S3 do
     end
   end
 
-  context "use_accelerate_endpoint", if: aws_accelerate_available? do
+  context "use_accelerate_endpoint" do
     context "defaults to false" do
       before do
         rebuild_model(
@@ -308,7 +308,7 @@ describe Paperclip::Storage::S3 do
       end
     end
 
-    context "set to true", if: aws_accelerate_available? do
+    context "set to true" do
       before do
         rebuild_model(
           storage: :s3,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,7 +39,6 @@ RSpec.configure do |config|
   config.include TestData
   config.include Reporting
   config.extend VersionHelper
-  config.extend ConditionalFilterHelper
   config.mock_framework = :mocha
   config.before(:all) do
     rebuild_model

--- a/spec/support/conditional_filter_helper.rb
+++ b/spec/support/conditional_filter_helper.rb
@@ -1,5 +1,0 @@
-module ConditionalFilterHelper
-  def aws_accelerate_available?
-    (Gem::Version.new(Aws::VERSION) >= Gem::Version.new("2.3.0"))
-  end
-end


### PR DESCRIPTION
The AWS SDK now has separate gems for each resource this changes paperclip to only use what it needs.

This change only requires the use of the `aws-sdk-s3` gem. I've updated the readme also.