### PR TITLE
Add ID_PARTITION_LIMIT with id above 999_999_999

### DIFF
--- a/lib/paperclip/interpolations.rb
+++ b/lib/paperclip/interpolations.rb
@@ -5,6 +5,7 @@ module Paperclip
   # Paperclip.interpolates method.
   module Interpolations
     extend self
+    ID_PARTITION_LIMIT = 1_000_000_000
 
     # Hash assignment of interpolations. Included only for compatibility,
     # and is not intended for normal use.
@@ -175,7 +176,11 @@ module Paperclip
     def id_partition attachment, style_name
       case id = attachment.instance.id
       when Integer
-        ("%09d".freeze % id).scan(/\d{3}/).join("/".freeze)
+        if id < ID_PARTITION_LIMIT
+          ("%09d".freeze % id).scan(/\d{3}/).join("/".freeze)
+        else
+          ("%012d".freeze % id).scan(/\d{3}/).join("/".freeze)
+        end
       when String
         id.scan(/.{3}/).first(3).join("/".freeze)
       else

--- a/spec/paperclip/interpolations_spec.rb
+++ b/spec/paperclip/interpolations_spec.rb
@@ -139,11 +139,13 @@ describe Paperclip::Interpolations do
     assert_equal "000/000/023", Paperclip::Interpolations.id_partition(attachment, :style)
   end
 
-  it "returns the partitioned id of the attachment when the id is an integer and above 999_999_999" do
+  it "returns the partitioned id when the id is above 999_999_999" do
     attachment = mock
-    attachment.expects(:id).returns(Paperclip::Interpolations::ID_PARTITION_LIMIT)
+    attachment.expects(:id).
+      returns(Paperclip::Interpolations::ID_PARTITION_LIMIT)
     attachment.expects(:instance).returns(attachment)
-    assert_equal "001/000/000/000", Paperclip::Interpolations.id_partition(attachment, :style)
+    assert_equal "001/000/000/000",
+      Paperclip::Interpolations.id_partition(attachment, :style)
   end
 
   it "returns the partitioned id of the attachment when the id is a string" do

--- a/spec/paperclip/interpolations_spec.rb
+++ b/spec/paperclip/interpolations_spec.rb
@@ -139,6 +139,13 @@ describe Paperclip::Interpolations do
     assert_equal "000/000/023", Paperclip::Interpolations.id_partition(attachment, :style)
   end
 
+  it "returns the partitioned id of the attachment when the id is an integer and above 999_999_999" do
+    attachment = mock
+    attachment.expects(:id).returns(Paperclip::Interpolations::ID_PARTITION_LIMIT)
+    attachment.expects(:instance).returns(attachment)
+    assert_equal "001/000/000/000", Paperclip::Interpolations.id_partition(attachment, :style)
+  end
+
   it "returns the partitioned id of the attachment when the id is a string" do
     attachment = mock
     attachment.expects(:id).returns("32fnj23oio2f")


### PR DESCRIPTION
Did not find any issue on the the project, spec are green locally
This cause to erease previous image when the id change to above 999_999_999, for example:

```
2.3.6 :010 >   id
 => 1000602578
2.3.6 :011 > ("%09d".freeze % id).scan(/\d{3}/).join("/".freeze)
 => "100/060/257"
```