### PR TITLE
Fix url double escape [#2253]

### DIFF
--- a/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
+++ b/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
@@ -9,7 +9,8 @@ module Paperclip
     REGEXP = /\Ahttps?:\/\//
 
     def initialize(target, options = {})
-      super(URI(URI.escape(target)), options)
+      escaped_target = URI.escape(CGI.unescape(target))
+      super(URI(escaped_target), options)
     end
   end
 end

--- a/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
+++ b/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
@@ -9,7 +9,12 @@ module Paperclip
     REGEXP = /\Ahttps?:\/\//
 
     def initialize(target, options = {})
-      escaped_target = URI.escape(CGI.unescape(target))
+      already_escaped = CGI.unescape(target) != target
+      escaped_target = if already_escaped
+                         target
+                       else
+                         URI.escape(CGI.unescape(target))
+                       end
       super(URI(escaped_target), options)
     end
   end

--- a/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
@@ -118,7 +118,7 @@ describe Paperclip::HttpUrlProxyAdapter do
       assert_equal filename, subject.original_filename
     end
   end
-  
+ 
   context "a url with special characters already escaped in the filename" do
     it "returns a encoded filename" do
       Paperclip::HttpUrlProxyAdapter.any_instance.stubs(:download_content).

--- a/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
@@ -118,4 +118,18 @@ describe Paperclip::HttpUrlProxyAdapter do
       assert_equal filename, subject.original_filename
     end
   end
+  
+  context "a url with special characters already escaped in the filename" do
+    it "returns a encoded filename" do
+      Paperclip::HttpUrlProxyAdapter.any_instance.stubs(:download_content).
+        returns(@open_return)
+      url = "https://github.com/thoughtbot/paperclip-%C3%B6%C3%A4%C3%BC%E5%A"\
+        "D%97%C2%B4%C2%BD%E2%99%A5%C3%98%C2%B2%C3%88.png"
+      subject = Paperclip.io_adapters.for(url)
+      filename = "paperclip-%C3%B6%C3%A4%C3%BC%E5%AD%97%C2%B4%C2%BD%E2%99%A5"\
+        "%C3%98%C2%B2%C3%88.png"
+
+      assert_equal filename, subject.original_filename
+    end
+  end
 end


### PR DESCRIPTION
Issue: #2253 

# What

Fixes URI's being double-escaped as described in the issue.

It might be useful to use `CGI.escape` instead of `URI.escape` to address #2459 but those URI's are actually not valid so not adding it for now.