### PR TITLE
Rewind file in Storage::Fog if bucket does not exist

### DIFF
--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -117,6 +117,7 @@ module Paperclip
             raise if retried
             retried = true
             directory.save
+            file.rewind
             retry
           ensure
             file.rewind

--- a/spec/paperclip/storage/fog_spec.rb
+++ b/spec/paperclip/storage/fog_spec.rb
@@ -206,6 +206,11 @@ describe Paperclip::Storage::Fog do
           assert @dummy.save
           assert @connection.directories.get(@fog_directory)
         end
+
+        it "sucessfully rewinds the file during bucket creation" do
+          assert @dummy.save
+          expect(Paperclip.io_adapters.for(@dummy.avatar).read.length).to be > 0
+        end
       end
 
       context "with a bucket" do


### PR DESCRIPTION
There was a bug in the code where if you created a bucket the file would
get read but not rewind on the first pass through (when the bucket
didn't exist). So when we went into the retry logic the file would
already be read and zero bytes would get copied over from the file. This
fixes that by rewinding the file during the retry so it gets correctly
copied over the second time around.