### PR TITLE
Fix markdown typo

### DIFF
--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -19,7 +19,7 @@ module Paperclip
     #   store your files.  Remember that the bucket must be unique across
     #   all of Amazon S3. If the bucket does not exist, Paperclip will
     #   attempt to create it.
-    # * +fog_file*: This can be hash or lambda returning hash. The
+    # * +fog_file+: This can be hash or lambda returning hash. The
     #   value is used as base properties for new uploaded file.
     # * +path+: This is the key under the bucket in which the file will
     #   be stored. The URL will be constructed from the bucket and the


### PR DESCRIPTION
So that the `file_system` option renders correctly on the docs