### PR TITLE
Avoid creating unused objects

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -202,7 +202,7 @@ module Paperclip
         styles = @options[:styles]
         styles = styles.call(self) if styles.respond_to?(:call)
 
-        @normalized_styles = styles.dup
+        @normalized_styles = {}
         styles.each_pair do |name, options|
           @normalized_styles[name.to_sym] = Paperclip::Style.new(name.to_sym, options.dup, self)
         end


### PR DESCRIPTION
https://github.com/thoughtbot/paperclip/commit/d01d58c2ffc417541b5c35e40021bf1f71af9e84 removed the need for duplication