### PR TITLE
Support db transaction rollbacks with option to keep files until commit

### DIFF
--- a/lib/paperclip/has_attached_file.rb
+++ b/lib/paperclip/has_attached_file.rb
@@ -92,7 +92,9 @@ module Paperclip
       @klass.send(:after_save) { send(name).send(:save) }
       @klass.send(:before_destroy) { send(name).send(:queue_all_for_delete) }
       if @klass.respond_to?(:after_commit)
-        @klass.send(:after_commit, on: :destroy) do
+        flush_after = [:destroy]
+        flush_after << :update if @options[:keep_old_files_until_commit]
+        @klass.send(:after_commit, on: flush_after) do
           send(name).send(:flush_deletes)
         end
       else


### PR DESCRIPTION
This PR:
  1) adds a `:keep_files_until_commit` option to support database transaction rollbacks, and
  2) fixes an issue with where a new file with the same filename is deleted on commit if using this option (the issue actually already exists if using the `:keep_files` option).

Further details in the issue here:  https://github.com/thoughtbot/paperclip/issues/2588.

I'll add tests and specs, but would appreciate feedback on the approach first, thanks!