### PR TITLE
Fix content type in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ Lastly, you can also define multiple validations on a single attachment using `v
 
 ```ruby
 validates_attachment :avatar, presence: true,
-  content_type: { content_type: "image/jpeg" },
+  content_type: "image/jpeg",
   size: { in: 0..10.kilobytes }
 ```
 
@@ -368,7 +368,7 @@ afterwards, then assign manually:
 ```ruby
 class Book < ActiveRecord::Base
   has_attached_file :document, styles: { thumbnail: "60x60#" }
-  validates_attachment :document, content_type: { content_type: "application/pdf" }
+  validates_attachment :document, content_type: "application/pdf"
   validates_something_else # Other validations that conflict with Paperclip's
 end
 
@@ -400,7 +400,7 @@ image-y ones:
 
 ```ruby
 validates_attachment :avatar,
-  content_type: { content_type: ["image/jpeg", "image/gif", "image/png"] }
+  content_type: ["image/jpeg", "image/gif", "image/png"]
 ```
 
 `Paperclip::ContentTypeDetector` will attempt to match a file's extension to an


### PR DESCRIPTION
Remove content type object in AttachmentContentTypeValidator.