### PR TITLE
Fix bug in migration instructions on MariaDB

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -107,8 +107,7 @@ class ConvertToActiveStorage < ActiveRecord::Migration[5.2]
 
     active_storage_blob_statement = ActiveRecord::Base.connection.raw_connection.prepare(<<-SQL)
       INSERT INTO active_storage_blobs (
-        key, filename, content_type, metadata, byte_size,
-        checksum, created_at
+        `key`, filename, content_type, metadata, byte_size, checksum, created_at
       ) VALUES (?, ?, ?, '{}', ?, ?, ?)
     SQL
 


### PR DESCRIPTION
"key" is a reserved keyword in MariaDB, so the SQL statement fails. Surrounding the keyword in backticks fixes the error.