### PR TITLE
Avoid dynamic extend

### DIFF
--- a/lib/paperclip/has_attached_file.rb
+++ b/lib/paperclip/has_attached_file.rb
@@ -44,7 +44,7 @@ module Paperclip
         attachment = instance_variable_get(ivar)
 
         if attachment.nil?
-          attachment = Attachment.new(name, self, options)
+          attachment = Attachment.build(name, self, options)
           instance_variable_set(ivar, attachment)
         end
 

--- a/lib/paperclip/storage/filesystem.rb
+++ b/lib/paperclip/storage/filesystem.rb
@@ -19,12 +19,9 @@ module Paperclip
     #   saved by paperclip. If you set this to an explicit octal value (0755, 0644, etc) then
     #   that value will be used to set the permissions for an uploaded file. The default is 0666.
     #   If you set :override_file_permissions to false, the chmod will be skipped. This allows
-    #   you to use paperclip on filesystems that don't understand unix file permissions, and has the 
+    #   you to use paperclip on filesystems that don't understand unix file permissions, and has the
     #   added benefit of using the storage directories default umask on those that do.
     module Filesystem
-      def self.extended base
-      end
-
       def exists?(style_name = default_style)
         if original_filename
           File.exist?(path(style_name))

--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -39,7 +39,7 @@ module Paperclip
     #     { :multipart_chunk_size => 104857600 }
 
     module Fog
-      def self.extended base
+      def self.included(*)
         begin
           require 'fog'
         rescue LoadError => e
@@ -47,14 +47,17 @@ module Paperclip
           raise e
         end unless defined?(Fog)
 
-        base.instance_eval do
-          unless @options[:url].to_s.match(/\A:fog.*url\z/)
-            @options[:path]  = @options[:path].gsub(/:url/, @options[:url]).gsub(/\A:rails_root\/public\/system\//, '')
-            @options[:url]   = ':fog_public_url'
-          end
-          Paperclip.interpolates(:fog_public_url) do |attachment, style|
-            attachment.public_url(style)
-          end unless Paperclip::Interpolations.respond_to? :fog_public_url
+        Paperclip.interpolates(:fog_public_url) do |attachment, style|
+          attachment.public_url(style)
+        end unless Paperclip::Interpolations.respond_to? :fog_public_url
+      end
+
+      def initialize(*)
+        super
+
+        unless @options[:url].to_s.match(/\A:fog.*url\z/)
+          @options[:path]  = @options[:path].gsub(/:url/, @options[:url]).gsub(/\A:rails_root\/public\/system\//, '')
+          @options[:url]   = ':fog_public_url'
         end
       end
 

--- a/spec/paperclip/attachment_spec.rb
+++ b/spec/paperclip/attachment_spec.rb
@@ -82,7 +82,7 @@ describe Paperclip::Attachment do
 
     it "deep merges when it is overridden" do
       new_options = { convert_options: { thumb: "-thumbnailize" } }
-      attachment = Paperclip::Attachment.new(:name, :instance, new_options)
+      attachment = Paperclip::Attachment.build(:name, :instance, new_options)
 
       expect(Paperclip::Attachment.default_options.deep_merge(new_options)).to eq attachment.instance_variable_get("@options")
     end
@@ -90,7 +90,7 @@ describe Paperclip::Attachment do
 
   it "handles a boolean second argument to #url" do
     mock_url_generator_builder = MockUrlGeneratorBuilder.new
-    attachment = Paperclip::Attachment.new(
+    attachment = Paperclip::Attachment.build(
       :name,
       FakeModel.new,
       url_generator: mock_url_generator_builder
@@ -105,7 +105,7 @@ describe Paperclip::Attachment do
 
   it "passes the style and options through to the URL generator on #url" do
     mock_url_generator_builder = MockUrlGeneratorBuilder.new
-    attachment = Paperclip::Attachment.new(
+    attachment = Paperclip::Attachment.build(
       :name,
       FakeModel.new,
       url_generator: mock_url_generator_builder
@@ -117,7 +117,7 @@ describe Paperclip::Attachment do
 
   it "passes default options through when #url is given one argument" do
     mock_url_generator_builder = MockUrlGeneratorBuilder.new
-    attachment = Paperclip::Attachment.new(:name,
+    attachment = Paperclip::Attachment.build(:name,
                                            FakeModel.new,
                                            url_generator: mock_url_generator_builder,
                                            use_timestamp: true)
@@ -128,7 +128,7 @@ describe Paperclip::Attachment do
 
   it "passes default style and options through when #url is given no arguments" do
     mock_url_generator_builder = MockUrlGeneratorBuilder.new
-    attachment = Paperclip::Attachment.new(:name,
+    attachment = Paperclip::Attachment.build(:name,
                                            FakeModel.new,
                                            default_style: 'default style',
                                            url_generator: mock_url_generator_builder,
@@ -141,7 +141,7 @@ describe Paperclip::Attachment do
 
   it "passes the option timestamp: true if :use_timestamp is true and :timestamp is not passed" do
     mock_url_generator_builder = MockUrlGeneratorBuilder.new
-    attachment = Paperclip::Attachment.new(:name,
+    attachment = Paperclip::Attachment.build(:name,
                                            FakeModel.new,
                                            url_generator: mock_url_generator_builder,
                                            use_timestamp: true)
@@ -152,7 +152,7 @@ describe Paperclip::Attachment do
 
   it "passes the option timestamp: false if :use_timestamp is false and :timestamp is not passed" do
     mock_url_generator_builder = MockUrlGeneratorBuilder.new
-    attachment = Paperclip::Attachment.new(:name,
+    attachment = Paperclip::Attachment.build(:name,
                                            FakeModel.new,
                                            url_generator: mock_url_generator_builder,
                                            use_timestamp: false)
@@ -163,7 +163,7 @@ describe Paperclip::Attachment do
 
   it "does not change the :timestamp if :timestamp is passed" do
     mock_url_generator_builder = MockUrlGeneratorBuilder.new
-    attachment = Paperclip::Attachment.new(:name,
+    attachment = Paperclip::Attachment.build(:name,
                                            FakeModel.new,
                                            url_generator: mock_url_generator_builder,
                                            use_timestamp: false)
@@ -174,7 +174,7 @@ describe Paperclip::Attachment do
 
   it "renders JSON as default style" do
     mock_url_generator_builder = MockUrlGeneratorBuilder.new
-    attachment = Paperclip::Attachment.new(:name,
+    attachment = Paperclip::Attachment.build(:name,
                                            FakeModel.new,
                                            default_style: 'default style',
                                            url_generator: mock_url_generator_builder)
@@ -185,7 +185,7 @@ describe Paperclip::Attachment do
 
   it "passes the option escape: true if :escape_url is true and :escape is not passed" do
     mock_url_generator_builder = MockUrlGeneratorBuilder.new
-    attachment = Paperclip::Attachment.new(:name,
+    attachment = Paperclip::Attachment.build(:name,
                                            FakeModel.new,
                                            url_generator: mock_url_generator_builder,
                                            escape_url: true)
@@ -196,7 +196,7 @@ describe Paperclip::Attachment do
 
   it "passes the option escape: false if :escape_url is false and :escape is not passed" do
     mock_url_generator_builder = MockUrlGeneratorBuilder.new
-    attachment = Paperclip::Attachment.new(:name,
+    attachment = Paperclip::Attachment.build(:name,
                                            FakeModel.new,
                                            url_generator: mock_url_generator_builder,
                                            escape_url: false)
@@ -1098,7 +1098,7 @@ describe Paperclip::Attachment do
       rebuild_model
       @instance = Dummy.new
       @instance.stubs(:id).returns 123
-      # @attachment = Paperclip::Attachment.new(:avatar, @instance)
+      # @attachment = Paperclip::Attachment.build(:avatar, @instance)
       @attachment = @instance.avatar
       @file = File.new(fixture_file("5k.png"), 'rb')
     end
@@ -1109,7 +1109,7 @@ describe Paperclip::Attachment do
     end
 
     it "raises if there are not the correct columns when you try to assign" do
-      @other_attachment = Paperclip::Attachment.new(:not_here, @instance)
+      @other_attachment = Paperclip::Attachment.build(:not_here, @instance)
       assert_raises(Paperclip::Error) do
         @other_attachment.assign(@file)
       end


### PR DESCRIPTION
Hi!

I see this gem is deprecated. However maybe this changes will be suitable for the last release.

It removes calls to `Object#extend`  every time attachment is created. This makes:
- storage initialization code run only once, when first attachment with this storage is instantiated,
- use ruby's `super` instead of custom `initialize_storage` hooks,
- avoid bumping class_serial, which flushes ruby's method cache.