### PR TITLE
Migration Documentation: RSpec custom matcher, use `match` not `matches`

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -328,7 +328,7 @@ Here's one that is similar in spirit to the Paperclip-supplied matcher:
 
 ```ruby
 RSpec::Matchers.define :have_attached_file do |name|
-  matches do |record|
+  match do |record|
     file = record.send(name)
     file.respond_to?(:variant) && file.respond_to?(:attach)
   end


### PR DESCRIPTION
The official [RSpec documentation](https://relishapp.com/rspec/rspec-expectations/v/2-4/docs/custom-matchers/define-matcher#define-a-matcher-with-default-messages) outlines that the main block when defining custom matchers should be called `match`. 

The documentation currently uses `matches` when giving an example of the custom `:have_attached_file` matcher, which leads to the error 

    NoMethodError:
      undefined method `matches' for #<Class:#<RSpec::Matchers::DSL::Matcher:0x00007fc898c846d8>>

Updating to `match`