### PR TITLE
Add missing "not" in Migration Guide Validations section

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -451,8 +451,8 @@ Any resizing is done in the view as a variant.
 ### Validations
 
 Unlike Paperclip, [which shipped with built-in attachment
-validations][paperclip-validations], ActiveStorage does have built-in support for
-validating an attachment's content type or file size (which can be useful for
+validations][paperclip-validations], ActiveStorage does not have built-in support
+for validating an attachment's content type or file size (which can be useful for
 [preventing content type spoofing][security-validations]).
 
 There are alternatives that support some of Paperclip's file validations.


### PR DESCRIPTION
I believe this is meant to be "does not", not "does".