### PR TITLE
Add fog_options as an extra param to expiring_url

### DIFF
--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -149,11 +149,11 @@ module Paperclip
         end
       end
 
-      def expiring_url(time = (Time.now + 3600), style_name = default_style)
+      def expiring_url(time = (Time.now + 3600), style_name = default_style, fog_options = {})
         time = convert_time(time)
         http_url_method = "get_#{scheme}_url"
         if path(style_name) && directory.files.respond_to?(http_url_method)
-          expiring_url = directory.files.public_send(http_url_method, path(style_name), time)
+          expiring_url = directory.files.public_send(http_url_method, path(style_name), time, fog_options)
 
           if @options[:fog_host]
             expiring_url.gsub!(/#{host_name_for_directory}/, dynamic_fog_host_for_style(style_name))


### PR DESCRIPTION
Fog's [get_https_url](https://www.rubydoc.info/github/fog/fog-aws/Fog%2FStorage%2FAWS%2FFiles:get_https_url) accepts an optional `options` hash parameter, that is used to provide extra keys to the url, such as for example requesting some particular header values in the response. 

This PR allows for Paperclip's `expiring_url` to accept the same optional `fog_options` attribute, that will be directly passed to `get_https_url`. 

This also makes the `Fog` and `S3` `Storage` modules more homogenous, since S3 was already accepting `s3_url_options` for the same purpose on its own `expiring_url`. 