### PR TITLE
Adding an option to use s3_options and s3_server_side_encryption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ capybara*.html
 *SPIKE*
 *emfile.lock
 tags
+.idea

--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -219,7 +219,9 @@ module Paperclip
       def s3_server_side_encryption
         return false if @options[:s3_server_side_encryption].blank?
         s3_server_side_encryption = @options[:s3_server_side_encryption]
-        s3_server_side_encryption = s3_server_side_encryption.call(instance) if s3_server_side_encryption.respond_to?(:call)
+        if s3_server_side_encryption.respond_to?(:call)
+          s3_server_side_encryption = s3_server_side_encryption.call(instance)
+        end
         s3_server_side_encryption
       end
 


### PR DESCRIPTION
the main idea was to support s3 and minio dynamically and the only way to defer minio and aws is by changing endpoint url (s3_options)
another struggle that I had is that one of my company`s minio server was unencrypted so I had to pass this parameter as a dynamic one too.