### PR TITLE
Critical Bug Fix: Use AWS::S3::Object built in download_file method to avoid truncating during #reprocess!

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -412,11 +412,7 @@ module Paperclip
 
       def copy_to_local_file(style, local_dest_path)
         log("copying #{path(style)} to local file #{local_dest_path}")
-        ::File.open(local_dest_path, 'wb') do |local_file|
-          s3_object(style).get do |chunk|
-            local_file.write(chunk)
-          end
-        end
+        s3_object(style).download_file(local_dest_path)
       rescue Aws::Errors::ServiceError => e
         warn("#{e} - cannot copy #{path(style)} to local file #{local_dest_path}")
         false


### PR DESCRIPTION
Yesterday, I ran `#reprocess!` and it truncated all original images on S3. [The logs](https://gist.github.com/daniel-nelson/c865bc5e3bcdd547ee2841e0dd660b23) show that there was an error processing the image, and then the downloaded image was uploaded again.

I inspected the temporary file created from the download, and it was empty, so that explains why the exceptions were thrown and why the original was truncated (Paperclip uploaded the empty image back to S3).

Switching to the AWS::S3::Object built in `download_file` method fixes this.



