### PR TITLE
Fixes annoying warnings in filesystem.rb

### DIFF
--- a/lib/paperclip/storage/filesystem.rb
+++ b/lib/paperclip/storage/filesystem.rb
@@ -46,7 +46,7 @@ module Paperclip
             end
           end
           unless @options[:override_file_permissions] == false
-            resolved_chmod = (@options[:override_file_permissions] & ~0111) || (0666 & ~File.umask)
+            resolved_chmod = (@options[:override_file_permissions] &~ 0111) || (0666 &~ File.umask)
             FileUtils.chmod( resolved_chmod, path(style_name) )
           end
           file.rewind


### PR DESCRIPTION
# paperclip-4.3.7/lib/paperclip/storage/filesystem.rb:49: warning: `&' after local variable or literal is interpreted as binary operator
# paperclip-4.3.7/lib/paperclip/storage/filesystem.rb:49: warning: even though it seems like argument prefix