### PR TITLE
updating migration for specificities around mysql and postgres

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -132,9 +132,17 @@ class ConvertToActiveStorage < ActiveRecord::Migration[5.2]
     # sqlite
     # get_blob_id = 'LAST_INSERT_ROWID()'
 
+    # mysql
+    # active_storage_blob_statement = ActiveRecord::Base.connection.raw_connection.prepare('active_storage_blob_statement', <<-SQL)
+    #   INSERT INTO active_storage_blobs (
+    #     `key`, filename, content_type, metadata, byte_size, checksum, created_at
+    #   ) VALUES ($1, $2, $3, '{}', $4, $5, $6)
+    # SQL
+
+    # postgres
     active_storage_blob_statement = ActiveRecord::Base.connection.raw_connection.prepare('active_storage_blob_statement', <<-SQL)
       INSERT INTO active_storage_blobs (
-        `key`, filename, content_type, metadata, byte_size, checksum, created_at
+        "key", filename, content_type, metadata, byte_size, checksum, created_at
       ) VALUES ($1, $2, $3, '{}', $4, $5, $6)
     SQL
 


### PR DESCRIPTION
The backticks in the definition of `active_storage_blob_statement` in the data migration don't work with Postgres. Updated accordingly.