### PR TITLE
Link to kt-paperclip

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@ For existing projects, please consult and contribute to the migration guide,
 available [in English], [en español], and as [a video] recorded at RailsConf
 2019.
 
+Alternatively, for existing projects, [Kreeti] (insecure link) is maintaining
+[kt-paperclip], an ongoing [fork of Paperclip].
 
 We will leave the Issues open as a discussion forum _only_. We do _not_
-guarantee a response from us in the Issues.
+guarantee a response from us in the Issues. All bug reports should go to
+kt-paperclip.
 
 We are no longer accepting pull requests _except_ pull requests against the
 migration guide. All other pull requests will be closed without merging.
@@ -23,6 +26,9 @@ migration guide. All other pull requests will be closed without merging.
 [in English]: https://github.com/thoughtbot/paperclip/blob/master/MIGRATING.md
 [en español]: https://github.com/thoughtbot/paperclip/blob/master/MIGRATING-ES.md
 [a video]: https://www.youtube.com/watch?v=tZ_WNUytO9o
+[Kreeti]: http://www.kreeti.com/
+[kt-paperclip]: https://rubygems.org/gems/kt-paperclip
+[fork of Paperclip]: https://github.com/kreeti/kt-paperclip
 
 # Existing documentation
 


### PR DESCRIPTION
We were contacted in early December by Surendra of Kreeti, who explained
that they had forked Paperclip and were maintaining it. We let the
December US holidays go by and then checked in; they're still
maintaining it.

We do not know any of the Kreeti devs and cannot vouch for them as a
team. We did not know of a way to hand over the Rubygem ownership while
expressing that people should remember to audit when upgrading.
Therefore, we felt it best that they have a full fork: new Rubygem gem,
separate repo.

Therefore it makes sense for us to link to Kreeti's fork as an option
for those who cannot move off of Paperclip.