### PR TITLE
Fix Syntax Error

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -137,7 +137,7 @@ class ConvertToActiveStorage < ActiveRecord::Migration[5.2]
 
     active_storage_blob_statement = ActiveRecord::Base.connection.raw_connection.prepare('active_storage_blob_statement', <<-SQL)
       INSERT INTO active_storage_blobs (
-        `key`, filename, content_type, metadata, byte_size, checksum, created_at
+        key, filename, content_type, metadata, byte_size, checksum, created_at
       ) VALUES ($1, $2, $3, '{}', $4, $5, $6)
     SQL
 


### PR DESCRIPTION
When running the migration as typed a minor syntax error causes the migration to fail. The [linked video](https://youtu.be/tZ_WNUytO9o?t=617) shows the correct syntax.