### PR TITLE
Rails >6 add_column and column receive keyword arguments now

### DIFF
--- a/lib/paperclip/schema.rb
+++ b/lib/paperclip/schema.rb
@@ -51,7 +51,7 @@ module Paperclip
         attachment_names.each do |attachment_name|
           COLUMNS.each_pair do |column_name, column_type|
             column_options = options.merge(options[column_name.to_sym] || {})
-            column("#{attachment_name}_#{column_name}", column_type, column_options)
+            column("#{attachment_name}_#{column_name}", column_type, *column_options)
           end
         end
       end

--- a/lib/paperclip/schema.rb
+++ b/lib/paperclip/schema.rb
@@ -24,7 +24,7 @@ module Paperclip
         attachment_names.each do |attachment_name|
           COLUMNS.each_pair do |column_name, column_type|
             column_options = options.merge(options[column_name.to_sym] || {})
-            add_column(table_name, "#{attachment_name}_#{column_name}", column_type, column_options)
+            add_column(table_name, "#{attachment_name}_#{column_name}", column_type, *column_options)
           end
         end
       end


### PR DESCRIPTION
Please see:
https://apidock.com/rails/v6.0.0/ActiveRecord/ConnectionAdapters/SchemaStatements/add_column

```
# Before:
add_column(table_name, column_name, type, options = {}) public

# Currently (after Rails 6.0.0)
add_column(table_name, column_name, type, **options) public
``` 


