### PR TITLE
fix calling open-uri

### DIFF
--- a/lib/paperclip/io_adapters/uri_adapter.rb
+++ b/lib/paperclip/io_adapters/uri_adapter.rb
@@ -53,7 +53,7 @@ module Paperclip
     def download_content
       options = { read_timeout: Paperclip.options[:read_timeout] }.compact
 
-      open(@target, **options)
+      URI.open(@target, **options)
     end
 
     def copy_to_tempfile(src)


### PR DESCRIPTION
I upgraded from Rails 6.0 to 6.1, and now calling open-uri via `Kernel#open` doesn't seem to recognize `URI` objects anymore:

`TypeError: no implicit conversion of URI::HTTPS into String`

Calling it via `URI.open` fixes this.