### PR TITLE
Use CGI.escape and CGI.unescape instead of URI.escape and URI.unescape

### DIFF
--- a/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
+++ b/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
@@ -9,8 +9,8 @@ module Paperclip
     REGEXP = /\Ahttps?:\/\//
 
     def initialize(target, options = {})
-      escaped = URI.escape(target)
-      super(URI(target == URI.unescape(target) ? escaped : target), options)
+      escaped = CGI.escape(target)
+      super(URI(target == CGI.unescape(target) ? escaped : target), options)
     end
   end
 end

--- a/lib/paperclip/url_generator.rb
+++ b/lib/paperclip/url_generator.rb
@@ -65,7 +65,7 @@ module Paperclip
       if url.respond_to?(:escape)
         url.escape
       else
-        URI.escape(url).gsub(escape_regex){|m| "%#{m.ord.to_s(16).upcase}" }
+        CGI.escape(url).gsub(escape_regex){|m| "%#{m.ord.to_s(16).upcase}" }
       end
     end
 


### PR DESCRIPTION
Used `CGI.escape` and `CGI.unescape` as `URI.escape` and `URI.unescape` became obsolete and incompatible with ruby 3.0.0.