### PR TITLE
Update url_generator.rb

### DIFF
--- a/lib/paperclip/url_generator.rb
+++ b/lib/paperclip/url_generator.rb
@@ -65,7 +65,7 @@ module Paperclip
       if url.respond_to?(:escape)
         url.escape
       else
-        URI.escape(url).gsub(escape_regex){|m| "%#{m.ord.to_s(16).upcase}" }
+        URI.encode_www_form_component(url).gsub(escape_regex){|m| "%#{m.ord.to_s(16).upcase}" }
       end
     end
 

--- a/lib/paperclip/url_generator.rb
+++ b/lib/paperclip/url_generator.rb
@@ -65,7 +65,9 @@ module Paperclip
       if url.respond_to?(:escape)
         url.escape
       else
-        URI.encode_www_form_component(url).gsub(escape_regex){|m| "%#{m.ord.to_s(16).upcase}" }
+        URI.encode_www_form_component(url).gsub(escape_regex) { 
+          |m| "%#{m.ord.to_s(16).upcase}" 
+        }
       end
     end
 


### PR DESCRIPTION
undefined method `escape' for URI:Module with Ruby 3.0.0
This method is obsolete and should not be used. Instead, use
CGI.escape, URI.encode_www_form or URI.encode_www_form_component
depending on your specific use case.