### PR TITLE
Remove mimemagic as it now released under a GPL license, incompatible with Paperclip's MIT license

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -64,8 +64,6 @@ rescue LoadError
   require "mime/types"
 end
 
-require 'mimemagic'
-require 'mimemagic/overlay'
 require 'logger'
 require 'terrapin'
 

--- a/lib/paperclip/content_type_detector.rb
+++ b/lib/paperclip/content_type_detector.rb
@@ -60,16 +60,10 @@ module Paperclip
     end
 
     def type_from_file_contents
-      type_from_mime_magic || type_from_file_command
+      type_from_file_command
     rescue Errno::ENOENT => e
       Paperclip.log("Error while determining content type: #{e}")
       SENSIBLE_DEFAULT
-    end
-
-    def type_from_mime_magic
-      @type_from_mime_magic ||= File.open(@filepath) do |file|
-        MimeMagic.by_magic(file).try(:type)
-      end
     end
 
     def type_from_file_command

--- a/lib/paperclip/version.rb
+++ b/lib/paperclip/version.rb
@@ -1,5 +1,5 @@
 module Paperclip
   unless defined?(Paperclip::VERSION)
-    VERSION = "6.1.0".freeze
+    VERSION = "6.1.1".freeze
   end
 end

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
   s.add_dependency('activesupport', '>= 4.2.0')
   s.add_dependency('terrapin', '~> 0.6.0')
   s.add_dependency('mime-types')
-  s.add_dependency('mimemagic', '~> 0.3.0')
 
   s.add_development_dependency('activerecord', '>= 4.2.0')
   s.add_development_dependency('shoulda')


### PR DESCRIPTION
NOTE: this is still untested work in progress. 

Opened this PR in case anyone wants to help me.

See https://github.com/rails/rails/issues/41750 for more info.

Issue https://github.com/thoughtbot/paperclip/issues/2678

NOTE: Since paperclip has mandatory spoof detection, you will need to have the `file` command installed on your server in order for file uploads to keep working.