### PR TITLE
Update mimemagic dependency to 0.3.9 for MIT license

### DIFF
--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activesupport', '>= 3.2.0')
   s.add_dependency('cocaine', '~> 0.5.5')
   s.add_dependency('mime-types')
-  s.add_dependency('mimemagic', '0.3.0')
+  s.add_dependency('mimemagic', '0.3.9')
 
   s.add_development_dependency('activerecord', '>= 3.2.0')
   s.add_development_dependency('shoulda')


### PR DESCRIPTION
Per Issue #2678, mimemagic dependency 0.3.0 is now yanked due to licensing issue.  However, there is a later 0.3.9 that now has lowered nokogiri and rake dependencies on MIT license.