### PR TITLE
Readme doc not matching implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ If you're only interested in images, restrict your allowed content_types to
 image-y ones:
 
 ```ruby
-validates_attachment :avatar,
+validates_attachment_content_type :avatar,
   content_type: ["image/jpeg", "image/gif", "image/png"]
 ```
 


### PR DESCRIPTION
Using 6.1.0 and getting the error `undefined method `merge' for "image/jpeg":String (NoMethodError)` in /lib/paperclip/validators.rb:48

This is working for me: `validates_attachment_content_type :image, content_type: ["image/jpeg", "image/gif", "image/png"]`

I think this would also work: `validates_attachment :image, content_type: { content_type: ["image/jpeg", "image/gif", "image/png"] }`